### PR TITLE
Force Horizontal/VerticalOptions to default to Fill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ paket-files
 *.dll
 
 build_output/
+.idea/

--- a/Fabulous.Core/Xamarin.Forms.Core.fs
+++ b/Fabulous.Core/Xamarin.Forms.Core.fs
@@ -842,12 +842,12 @@ type View() =
         match prevHorizontalOptionsOpt, currHorizontalOptionsOpt with
         | ValueSome prevValue, ValueSome currValue when prevValue = currValue -> ()
         | _, ValueSome currValue -> target.HorizontalOptions <-  currValue
-        | ValueSome _, ValueNone -> target.HorizontalOptions <- Unchecked.defaultof<Xamarin.Forms.LayoutOptions>
+        | ValueSome _, ValueNone -> target.HorizontalOptions <- Xamarin.Forms.LayoutOptions.Fill
         | ValueNone, ValueNone -> ()
         match prevVerticalOptionsOpt, currVerticalOptionsOpt with
         | ValueSome prevValue, ValueSome currValue when prevValue = currValue -> ()
         | _, ValueSome currValue -> target.VerticalOptions <-  currValue
-        | ValueSome _, ValueNone -> target.VerticalOptions <- Unchecked.defaultof<Xamarin.Forms.LayoutOptions>
+        | ValueSome _, ValueNone -> target.VerticalOptions <- Xamarin.Forms.LayoutOptions.Fill
         | ValueNone, ValueNone -> ()
         match prevMarginOpt, currMarginOpt with
         | ValueSome prevValue, ValueSome currValue when prevValue = currValue -> ()

--- a/Generator/Program.fs
+++ b/Generator/Program.fs
@@ -1,6 +1,8 @@
 ﻿// Copyright 2018 Fabulous contributors. See LICENSE.md for license.
 
-// dotnet build -c Release Generator\Generator.fsproj && dotnet Generator\bin\Release\netcoreapp2.0\Generator.dll Generator\Xamarin.Forms.Core.json Fabulous\Xamarin.Forms.Core.fs 
+// Windows: dotnet build -c Release Generator\Generator.fsproj && dotnet Generator\bin\Release\netcoreapp2.0\Generator.dll Generator\Xamarin.Forms.Core.json Fabulous.Core\Xamarin.Forms.Core.fs
+
+// OSX: dotnet build -c Release Generator/Generator.fsproj && dotnet Generator/bin/Release/netcoreapp2.0/Generator.dll Generator/Xamarin.Forms.Core.json Fabulous.Core/Xamarin.Forms.Core.fs
 
 module Generator
 

--- a/Generator/Xamarin.Forms.Core.json
+++ b/Generator/Xamarin.Forms.Core.json
@@ -124,11 +124,11 @@
 			"members": [
 				{
 					"name": "HorizontalOptions",
-					"defaultValue": "Unchecked.defaultof<Xamarin.Forms.LayoutOptions>"
+					"defaultValue": "Xamarin.Forms.LayoutOptions.Fill"
 				},
 				{
 					"name": "VerticalOptions",
-					"defaultValue": "Unchecked.defaultof<Xamarin.Forms.LayoutOptions>"
+					"defaultValue": "Xamarin.Forms.LayoutOptions.Fill"
 				},
 				{
 					"name": "Margin",


### PR DESCRIPTION
According to the documentation for View.HorizontalOptions and View.VerticalOptions
>A LayoutOptions which defines how to lay out the element. Default value is Fill unless otherwise documented.

But in the binding json file, we were using `Unchecked.defaultOf<Xamarin.Forms.LayoutOptions>` which always return `LayoutOptions.Start`.
So changed it to apply `Fill` instead.

Fixes #136 (at least for the horizontal part)