### PR TITLE
Upgrade to Xamarin.Forms 3.1

### DIFF
--- a/Fabulous.Core/Fabulous.Core.fsproj
+++ b/Fabulous.Core/Fabulous.Core.fsproj
@@ -21,6 +21,6 @@
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.5.2" />
     <PackageReference Update="FSharp.Core" Version="4.5.2" /> <!-- workaround for VSMac bug https://github.com/mono/monodevelop/pull/5137 --> 
-    <PackageReference Include="Xamarin.Forms" Version="3.0.0.482510" />
+    <PackageReference Include="Xamarin.Forms" Version="3.1.0.697729" />
   </ItemGroup>
 </Project>

--- a/Fabulous.Core/Xamarin.Forms.Core.fs
+++ b/Fabulous.Core/Xamarin.Forms.Core.fs
@@ -93,6 +93,10 @@ type View() =
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
     static member val _ScrollOrientationAttribKey : AttributeKey<_> = AttributeKey<_>("ScrollOrientation")
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
+    static member val _HorizontalScrollBarVisibilityAttribKey : AttributeKey<_> = AttributeKey<_>("HorizontalScrollBarVisibility")
+    [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
+    static member val _VerticalScrollBarVisibilityAttribKey : AttributeKey<_> = AttributeKey<_>("VerticalScrollBarVisibility")
+    [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
     static member val _CancelButtonColorAttribKey : AttributeKey<_> = AttributeKey<_>("CancelButtonColor")
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
     static member val _FontFamilyAttribKey : AttributeKey<_> = AttributeKey<_>("FontFamily")
@@ -146,6 +150,8 @@ type View() =
     static member val _IsToggledAttribKey : AttributeKey<_> = AttributeKey<_>("IsToggled")
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
     static member val _ToggledAttribKey : AttributeKey<_> = AttributeKey<_>("Toggled")
+    [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
+    static member val _OnColorAttribKey : AttributeKey<_> = AttributeKey<_>("OnColor")
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
     static member val _HeightAttribKey : AttributeKey<_> = AttributeKey<_>("Height")
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
@@ -253,9 +259,17 @@ type View() =
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
     static member val _TextChangedAttribKey : AttributeKey<_> = AttributeKey<_>("TextChanged")
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
+    static member val _AutoSizeAttribKey : AttributeKey<_> = AttributeKey<_>("AutoSize")
+    [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
     static member val _IsPasswordAttribKey : AttributeKey<_> = AttributeKey<_>("IsPassword")
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
     static member val _EntryCompletedAttribKey : AttributeKey<_> = AttributeKey<_>("EntryCompleted")
+    [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
+    static member val _IsTextPredictionEnabledAttribKey : AttributeKey<_> = AttributeKey<_>("IsTextPredictionEnabled")
+    [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
+    static member val _ReturnTypeAttribKey : AttributeKey<_> = AttributeKey<_>("ReturnType")
+    [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
+    static member val _ReturnCommandAttribKey : AttributeKey<_> = AttributeKey<_>("ReturnCommand")
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
     static member val _LabelAttribKey : AttributeKey<_> = AttributeKey<_>("Label")
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
@@ -384,6 +398,8 @@ type View() =
     static member val _ListView_ItemTappedAttribKey : AttributeKey<_> = AttributeKey<_>("ListView_ItemTapped")
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
     static member val _ListView_RefreshingAttribKey : AttributeKey<_> = AttributeKey<_>("ListView_Refreshing")
+    [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
+    static member val _SelectionModeAttribKey : AttributeKey<_> = AttributeKey<_>("SelectionMode")
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
     static member val _ListViewGrouped_ItemsSourceAttribKey : AttributeKey<_> = AttributeKey<_>("ListViewGrouped_ItemsSource")
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
@@ -1414,14 +1430,18 @@ type View() =
 
     /// Builds the attributes for a ScrollView in the view
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
-    static member inline BuildScrollView(attribCount: int, ?content: ViewElement, ?orientation: Xamarin.Forms.ScrollOrientation, ?isClippedToBounds: bool, ?padding: obj, ?horizontalOptions: Xamarin.Forms.LayoutOptions, ?verticalOptions: Xamarin.Forms.LayoutOptions, ?margin: obj, ?gestureRecognizers: ViewElement list, ?anchorX: double, ?anchorY: double, ?backgroundColor: Xamarin.Forms.Color, ?heightRequest: double, ?inputTransparent: bool, ?isEnabled: bool, ?isVisible: bool, ?minimumHeightRequest: double, ?minimumWidthRequest: double, ?opacity: double, ?rotation: double, ?rotationX: double, ?rotationY: double, ?scale: double, ?style: Xamarin.Forms.Style, ?translationX: double, ?translationY: double, ?widthRequest: double, ?resources: (string * obj) list, ?styles: Xamarin.Forms.Style list, ?styleSheets: Xamarin.Forms.StyleSheets.StyleSheet list, ?classId: string, ?styleId: string, ?automationId: string) = 
+    static member inline BuildScrollView(attribCount: int, ?content: ViewElement, ?orientation: Xamarin.Forms.ScrollOrientation, ?horizontalScrollBarVisibility: Xamarin.Forms.ScrollBarVisibility, ?verticalScrollBarVisibility: Xamarin.Forms.ScrollBarVisibility, ?isClippedToBounds: bool, ?padding: obj, ?horizontalOptions: Xamarin.Forms.LayoutOptions, ?verticalOptions: Xamarin.Forms.LayoutOptions, ?margin: obj, ?gestureRecognizers: ViewElement list, ?anchorX: double, ?anchorY: double, ?backgroundColor: Xamarin.Forms.Color, ?heightRequest: double, ?inputTransparent: bool, ?isEnabled: bool, ?isVisible: bool, ?minimumHeightRequest: double, ?minimumWidthRequest: double, ?opacity: double, ?rotation: double, ?rotationX: double, ?rotationY: double, ?scale: double, ?style: Xamarin.Forms.Style, ?translationX: double, ?translationY: double, ?widthRequest: double, ?resources: (string * obj) list, ?styles: Xamarin.Forms.Style list, ?styleSheets: Xamarin.Forms.StyleSheets.StyleSheet list, ?classId: string, ?styleId: string, ?automationId: string) = 
 
         let attribCount = match content with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match orientation with Some _ -> attribCount + 1 | None -> attribCount
+        let attribCount = match horizontalScrollBarVisibility with Some _ -> attribCount + 1 | None -> attribCount
+        let attribCount = match verticalScrollBarVisibility with Some _ -> attribCount + 1 | None -> attribCount
 
         let attribBuilder = View.BuildLayout(attribCount, ?isClippedToBounds=isClippedToBounds, ?padding=padding, ?horizontalOptions=horizontalOptions, ?verticalOptions=verticalOptions, ?margin=margin, ?gestureRecognizers=gestureRecognizers, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?classId=classId, ?styleId=styleId, ?automationId=automationId)
         match content with None -> () | Some v -> attribBuilder.Add(View._ContentAttribKey, (v)) 
         match orientation with None -> () | Some v -> attribBuilder.Add(View._ScrollOrientationAttribKey, (v)) 
+        match horizontalScrollBarVisibility with None -> () | Some v -> attribBuilder.Add(View._HorizontalScrollBarVisibilityAttribKey, (v)) 
+        match verticalScrollBarVisibility with None -> () | Some v -> attribBuilder.Add(View._VerticalScrollBarVisibilityAttribKey, (v)) 
         attribBuilder
 
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
@@ -1443,11 +1463,19 @@ type View() =
         let mutable currContentOpt = ValueNone
         let mutable prevScrollOrientationOpt = ValueNone
         let mutable currScrollOrientationOpt = ValueNone
+        let mutable prevHorizontalScrollBarVisibilityOpt = ValueNone
+        let mutable currHorizontalScrollBarVisibilityOpt = ValueNone
+        let mutable prevVerticalScrollBarVisibilityOpt = ValueNone
+        let mutable currVerticalScrollBarVisibilityOpt = ValueNone
         for kvp in curr.AttributesKeyed do
             if kvp.Key = View._ContentAttribKey.KeyValue then 
                 currContentOpt <- ValueSome (kvp.Value :?> ViewElement)
             if kvp.Key = View._ScrollOrientationAttribKey.KeyValue then 
                 currScrollOrientationOpt <- ValueSome (kvp.Value :?> Xamarin.Forms.ScrollOrientation)
+            if kvp.Key = View._HorizontalScrollBarVisibilityAttribKey.KeyValue then 
+                currHorizontalScrollBarVisibilityOpt <- ValueSome (kvp.Value :?> Xamarin.Forms.ScrollBarVisibility)
+            if kvp.Key = View._VerticalScrollBarVisibilityAttribKey.KeyValue then 
+                currVerticalScrollBarVisibilityOpt <- ValueSome (kvp.Value :?> Xamarin.Forms.ScrollBarVisibility)
         match prevOpt with
         | ValueNone -> ()
         | ValueSome prev ->
@@ -1456,6 +1484,10 @@ type View() =
                     prevContentOpt <- ValueSome (kvp.Value :?> ViewElement)
                 if kvp.Key = View._ScrollOrientationAttribKey.KeyValue then 
                     prevScrollOrientationOpt <- ValueSome (kvp.Value :?> Xamarin.Forms.ScrollOrientation)
+                if kvp.Key = View._HorizontalScrollBarVisibilityAttribKey.KeyValue then 
+                    prevHorizontalScrollBarVisibilityOpt <- ValueSome (kvp.Value :?> Xamarin.Forms.ScrollBarVisibility)
+                if kvp.Key = View._VerticalScrollBarVisibilityAttribKey.KeyValue then 
+                    prevVerticalScrollBarVisibilityOpt <- ValueSome (kvp.Value :?> Xamarin.Forms.ScrollBarVisibility)
         match prevContentOpt, currContentOpt with
         // For structured objects, dependsOn on reference equality
         | ValueSome prevValue, ValueSome newValue when identical prevValue newValue -> ()
@@ -1471,11 +1503,21 @@ type View() =
         | _, ValueSome currValue -> target.Orientation <-  currValue
         | ValueSome _, ValueNone -> target.Orientation <- Unchecked.defaultof<Xamarin.Forms.ScrollOrientation>
         | ValueNone, ValueNone -> ()
+        match prevHorizontalScrollBarVisibilityOpt, currHorizontalScrollBarVisibilityOpt with
+        | ValueSome prevValue, ValueSome currValue when prevValue = currValue -> ()
+        | _, ValueSome currValue -> target.HorizontalScrollBarVisibility <-  currValue
+        | ValueSome _, ValueNone -> target.HorizontalScrollBarVisibility <- Xamarin.Forms.ScrollBarVisibility.Default
+        | ValueNone, ValueNone -> ()
+        match prevVerticalScrollBarVisibilityOpt, currVerticalScrollBarVisibilityOpt with
+        | ValueSome prevValue, ValueSome currValue when prevValue = currValue -> ()
+        | _, ValueSome currValue -> target.VerticalScrollBarVisibility <-  currValue
+        | ValueSome _, ValueNone -> target.VerticalScrollBarVisibility <- Xamarin.Forms.ScrollBarVisibility.Default
+        | ValueNone, ValueNone -> ()
 
     /// Describes a ScrollView in the view
-    static member inline ScrollView(?content: ViewElement, ?orientation: Xamarin.Forms.ScrollOrientation, ?isClippedToBounds: bool, ?padding: obj, ?horizontalOptions: Xamarin.Forms.LayoutOptions, ?verticalOptions: Xamarin.Forms.LayoutOptions, ?margin: obj, ?gestureRecognizers: ViewElement list, ?anchorX: double, ?anchorY: double, ?backgroundColor: Xamarin.Forms.Color, ?heightRequest: double, ?inputTransparent: bool, ?isEnabled: bool, ?isVisible: bool, ?minimumHeightRequest: double, ?minimumWidthRequest: double, ?opacity: double, ?rotation: double, ?rotationX: double, ?rotationY: double, ?scale: double, ?style: Xamarin.Forms.Style, ?translationX: double, ?translationY: double, ?widthRequest: double, ?resources: (string * obj) list, ?styles: Xamarin.Forms.Style list, ?styleSheets: Xamarin.Forms.StyleSheets.StyleSheet list, ?classId: string, ?styleId: string, ?automationId: string) = 
+    static member inline ScrollView(?content: ViewElement, ?orientation: Xamarin.Forms.ScrollOrientation, ?horizontalScrollBarVisibility: Xamarin.Forms.ScrollBarVisibility, ?verticalScrollBarVisibility: Xamarin.Forms.ScrollBarVisibility, ?isClippedToBounds: bool, ?padding: obj, ?horizontalOptions: Xamarin.Forms.LayoutOptions, ?verticalOptions: Xamarin.Forms.LayoutOptions, ?margin: obj, ?gestureRecognizers: ViewElement list, ?anchorX: double, ?anchorY: double, ?backgroundColor: Xamarin.Forms.Color, ?heightRequest: double, ?inputTransparent: bool, ?isEnabled: bool, ?isVisible: bool, ?minimumHeightRequest: double, ?minimumWidthRequest: double, ?opacity: double, ?rotation: double, ?rotationX: double, ?rotationY: double, ?scale: double, ?style: Xamarin.Forms.Style, ?translationX: double, ?translationY: double, ?widthRequest: double, ?resources: (string * obj) list, ?styles: Xamarin.Forms.Style list, ?styleSheets: Xamarin.Forms.StyleSheets.StyleSheet list, ?classId: string, ?styleId: string, ?automationId: string) = 
 
-        let attribBuilder = View.BuildScrollView(0, ?content=content, ?orientation=orientation, ?isClippedToBounds=isClippedToBounds, ?padding=padding, ?horizontalOptions=horizontalOptions, ?verticalOptions=verticalOptions, ?margin=margin, ?gestureRecognizers=gestureRecognizers, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?classId=classId, ?styleId=styleId, ?automationId=automationId)
+        let attribBuilder = View.BuildScrollView(0, ?content=content, ?orientation=orientation, ?horizontalScrollBarVisibility=horizontalScrollBarVisibility, ?verticalScrollBarVisibility=verticalScrollBarVisibility, ?isClippedToBounds=isClippedToBounds, ?padding=padding, ?horizontalOptions=horizontalOptions, ?verticalOptions=verticalOptions, ?margin=margin, ?gestureRecognizers=gestureRecognizers, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?classId=classId, ?styleId=styleId, ?automationId=automationId)
 
         ViewElement.Create<Xamarin.Forms.ScrollView>(View.CreateFuncScrollView, View.UpdateFuncScrollView, attribBuilder)
 
@@ -2069,14 +2111,16 @@ type View() =
 
     /// Builds the attributes for a Switch in the view
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
-    static member inline BuildSwitch(attribCount: int, ?isToggled: bool, ?toggled: Xamarin.Forms.ToggledEventArgs -> unit, ?horizontalOptions: Xamarin.Forms.LayoutOptions, ?verticalOptions: Xamarin.Forms.LayoutOptions, ?margin: obj, ?gestureRecognizers: ViewElement list, ?anchorX: double, ?anchorY: double, ?backgroundColor: Xamarin.Forms.Color, ?heightRequest: double, ?inputTransparent: bool, ?isEnabled: bool, ?isVisible: bool, ?minimumHeightRequest: double, ?minimumWidthRequest: double, ?opacity: double, ?rotation: double, ?rotationX: double, ?rotationY: double, ?scale: double, ?style: Xamarin.Forms.Style, ?translationX: double, ?translationY: double, ?widthRequest: double, ?resources: (string * obj) list, ?styles: Xamarin.Forms.Style list, ?styleSheets: Xamarin.Forms.StyleSheets.StyleSheet list, ?classId: string, ?styleId: string, ?automationId: string) = 
+    static member inline BuildSwitch(attribCount: int, ?isToggled: bool, ?toggled: Xamarin.Forms.ToggledEventArgs -> unit, ?onColor: Xamarin.Forms.Color, ?horizontalOptions: Xamarin.Forms.LayoutOptions, ?verticalOptions: Xamarin.Forms.LayoutOptions, ?margin: obj, ?gestureRecognizers: ViewElement list, ?anchorX: double, ?anchorY: double, ?backgroundColor: Xamarin.Forms.Color, ?heightRequest: double, ?inputTransparent: bool, ?isEnabled: bool, ?isVisible: bool, ?minimumHeightRequest: double, ?minimumWidthRequest: double, ?opacity: double, ?rotation: double, ?rotationX: double, ?rotationY: double, ?scale: double, ?style: Xamarin.Forms.Style, ?translationX: double, ?translationY: double, ?widthRequest: double, ?resources: (string * obj) list, ?styles: Xamarin.Forms.Style list, ?styleSheets: Xamarin.Forms.StyleSheets.StyleSheet list, ?classId: string, ?styleId: string, ?automationId: string) = 
 
         let attribCount = match isToggled with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match toggled with Some _ -> attribCount + 1 | None -> attribCount
+        let attribCount = match onColor with Some _ -> attribCount + 1 | None -> attribCount
 
         let attribBuilder = View.BuildView(attribCount, ?horizontalOptions=horizontalOptions, ?verticalOptions=verticalOptions, ?margin=margin, ?gestureRecognizers=gestureRecognizers, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?classId=classId, ?styleId=styleId, ?automationId=automationId)
         match isToggled with None -> () | Some v -> attribBuilder.Add(View._IsToggledAttribKey, (v)) 
         match toggled with None -> () | Some v -> attribBuilder.Add(View._ToggledAttribKey, (fun f -> System.EventHandler<Xamarin.Forms.ToggledEventArgs>(fun _sender args -> f args))(v)) 
+        match onColor with None -> () | Some v -> attribBuilder.Add(View._OnColorAttribKey, (v)) 
         attribBuilder
 
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
@@ -2098,11 +2142,15 @@ type View() =
         let mutable currIsToggledOpt = ValueNone
         let mutable prevToggledOpt = ValueNone
         let mutable currToggledOpt = ValueNone
+        let mutable prevOnColorOpt = ValueNone
+        let mutable currOnColorOpt = ValueNone
         for kvp in curr.AttributesKeyed do
             if kvp.Key = View._IsToggledAttribKey.KeyValue then 
                 currIsToggledOpt <- ValueSome (kvp.Value :?> bool)
             if kvp.Key = View._ToggledAttribKey.KeyValue then 
                 currToggledOpt <- ValueSome (kvp.Value :?> System.EventHandler<Xamarin.Forms.ToggledEventArgs>)
+            if kvp.Key = View._OnColorAttribKey.KeyValue then 
+                currOnColorOpt <- ValueSome (kvp.Value :?> Xamarin.Forms.Color)
         match prevOpt with
         | ValueNone -> ()
         | ValueSome prev ->
@@ -2111,6 +2159,8 @@ type View() =
                     prevIsToggledOpt <- ValueSome (kvp.Value :?> bool)
                 if kvp.Key = View._ToggledAttribKey.KeyValue then 
                     prevToggledOpt <- ValueSome (kvp.Value :?> System.EventHandler<Xamarin.Forms.ToggledEventArgs>)
+                if kvp.Key = View._OnColorAttribKey.KeyValue then 
+                    prevOnColorOpt <- ValueSome (kvp.Value :?> Xamarin.Forms.Color)
         match prevIsToggledOpt, currIsToggledOpt with
         | ValueSome prevValue, ValueSome currValue when prevValue = currValue -> ()
         | _, ValueSome currValue -> target.IsToggled <-  currValue
@@ -2122,11 +2172,16 @@ type View() =
         | ValueNone, ValueSome currValue -> target.Toggled.AddHandler(currValue)
         | ValueSome prevValue, ValueNone -> target.Toggled.RemoveHandler(prevValue)
         | ValueNone, ValueNone -> ()
+        match prevOnColorOpt, currOnColorOpt with
+        | ValueSome prevValue, ValueSome currValue when prevValue = currValue -> ()
+        | _, ValueSome currValue -> target.OnColor <-  currValue
+        | ValueSome _, ValueNone -> target.OnColor <- Xamarin.Forms.Color.Default
+        | ValueNone, ValueNone -> ()
 
     /// Describes a Switch in the view
-    static member inline Switch(?isToggled: bool, ?toggled: Xamarin.Forms.ToggledEventArgs -> unit, ?horizontalOptions: Xamarin.Forms.LayoutOptions, ?verticalOptions: Xamarin.Forms.LayoutOptions, ?margin: obj, ?gestureRecognizers: ViewElement list, ?anchorX: double, ?anchorY: double, ?backgroundColor: Xamarin.Forms.Color, ?heightRequest: double, ?inputTransparent: bool, ?isEnabled: bool, ?isVisible: bool, ?minimumHeightRequest: double, ?minimumWidthRequest: double, ?opacity: double, ?rotation: double, ?rotationX: double, ?rotationY: double, ?scale: double, ?style: Xamarin.Forms.Style, ?translationX: double, ?translationY: double, ?widthRequest: double, ?resources: (string * obj) list, ?styles: Xamarin.Forms.Style list, ?styleSheets: Xamarin.Forms.StyleSheets.StyleSheet list, ?classId: string, ?styleId: string, ?automationId: string) = 
+    static member inline Switch(?isToggled: bool, ?toggled: Xamarin.Forms.ToggledEventArgs -> unit, ?onColor: Xamarin.Forms.Color, ?horizontalOptions: Xamarin.Forms.LayoutOptions, ?verticalOptions: Xamarin.Forms.LayoutOptions, ?margin: obj, ?gestureRecognizers: ViewElement list, ?anchorX: double, ?anchorY: double, ?backgroundColor: Xamarin.Forms.Color, ?heightRequest: double, ?inputTransparent: bool, ?isEnabled: bool, ?isVisible: bool, ?minimumHeightRequest: double, ?minimumWidthRequest: double, ?opacity: double, ?rotation: double, ?rotationX: double, ?rotationY: double, ?scale: double, ?style: Xamarin.Forms.Style, ?translationX: double, ?translationY: double, ?widthRequest: double, ?resources: (string * obj) list, ?styles: Xamarin.Forms.Style list, ?styleSheets: Xamarin.Forms.StyleSheets.StyleSheet list, ?classId: string, ?styleId: string, ?automationId: string) = 
 
-        let attribBuilder = View.BuildSwitch(0, ?isToggled=isToggled, ?toggled=toggled, ?horizontalOptions=horizontalOptions, ?verticalOptions=verticalOptions, ?margin=margin, ?gestureRecognizers=gestureRecognizers, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?classId=classId, ?styleId=styleId, ?automationId=automationId)
+        let attribBuilder = View.BuildSwitch(0, ?isToggled=isToggled, ?toggled=toggled, ?onColor=onColor, ?horizontalOptions=horizontalOptions, ?verticalOptions=verticalOptions, ?margin=margin, ?gestureRecognizers=gestureRecognizers, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?classId=classId, ?styleId=styleId, ?automationId=automationId)
 
         ViewElement.Create<Xamarin.Forms.Switch>(View.CreateFuncSwitch, View.UpdateFuncSwitch, attribBuilder)
 
@@ -3444,7 +3499,7 @@ type View() =
 
     /// Builds the attributes for a Editor in the view
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
-    static member inline BuildEditor(attribCount: int, ?text: string, ?fontSize: obj, ?fontFamily: string, ?fontAttributes: Xamarin.Forms.FontAttributes, ?textColor: Xamarin.Forms.Color, ?completed: string -> unit, ?textChanged: Xamarin.Forms.TextChangedEventArgs -> unit, ?keyboard: Xamarin.Forms.Keyboard, ?horizontalOptions: Xamarin.Forms.LayoutOptions, ?verticalOptions: Xamarin.Forms.LayoutOptions, ?margin: obj, ?gestureRecognizers: ViewElement list, ?anchorX: double, ?anchorY: double, ?backgroundColor: Xamarin.Forms.Color, ?heightRequest: double, ?inputTransparent: bool, ?isEnabled: bool, ?isVisible: bool, ?minimumHeightRequest: double, ?minimumWidthRequest: double, ?opacity: double, ?rotation: double, ?rotationX: double, ?rotationY: double, ?scale: double, ?style: Xamarin.Forms.Style, ?translationX: double, ?translationY: double, ?widthRequest: double, ?resources: (string * obj) list, ?styles: Xamarin.Forms.Style list, ?styleSheets: Xamarin.Forms.StyleSheets.StyleSheet list, ?classId: string, ?styleId: string, ?automationId: string) = 
+    static member inline BuildEditor(attribCount: int, ?text: string, ?fontSize: obj, ?fontFamily: string, ?fontAttributes: Xamarin.Forms.FontAttributes, ?textColor: Xamarin.Forms.Color, ?completed: string -> unit, ?textChanged: Xamarin.Forms.TextChangedEventArgs -> unit, ?autoSize: Xamarin.Forms.EditorAutoSizeOption, ?keyboard: Xamarin.Forms.Keyboard, ?horizontalOptions: Xamarin.Forms.LayoutOptions, ?verticalOptions: Xamarin.Forms.LayoutOptions, ?margin: obj, ?gestureRecognizers: ViewElement list, ?anchorX: double, ?anchorY: double, ?backgroundColor: Xamarin.Forms.Color, ?heightRequest: double, ?inputTransparent: bool, ?isEnabled: bool, ?isVisible: bool, ?minimumHeightRequest: double, ?minimumWidthRequest: double, ?opacity: double, ?rotation: double, ?rotationX: double, ?rotationY: double, ?scale: double, ?style: Xamarin.Forms.Style, ?translationX: double, ?translationY: double, ?widthRequest: double, ?resources: (string * obj) list, ?styles: Xamarin.Forms.Style list, ?styleSheets: Xamarin.Forms.StyleSheets.StyleSheet list, ?classId: string, ?styleId: string, ?automationId: string) = 
 
         let attribCount = match text with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match fontSize with Some _ -> attribCount + 1 | None -> attribCount
@@ -3453,6 +3508,7 @@ type View() =
         let attribCount = match textColor with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match completed with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match textChanged with Some _ -> attribCount + 1 | None -> attribCount
+        let attribCount = match autoSize with Some _ -> attribCount + 1 | None -> attribCount
 
         let attribBuilder = View.BuildInputView(attribCount, ?keyboard=keyboard, ?horizontalOptions=horizontalOptions, ?verticalOptions=verticalOptions, ?margin=margin, ?gestureRecognizers=gestureRecognizers, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?classId=classId, ?styleId=styleId, ?automationId=automationId)
         match text with None -> () | Some v -> attribBuilder.Add(View._TextAttribKey, (v)) 
@@ -3462,6 +3518,7 @@ type View() =
         match textColor with None -> () | Some v -> attribBuilder.Add(View._TextColorAttribKey, (v)) 
         match completed with None -> () | Some v -> attribBuilder.Add(View._EditorCompletedAttribKey, (fun f -> System.EventHandler(fun sender args -> f (sender :?> Xamarin.Forms.Editor).Text))(v)) 
         match textChanged with None -> () | Some v -> attribBuilder.Add(View._TextChangedAttribKey, (fun f -> System.EventHandler<Xamarin.Forms.TextChangedEventArgs>(fun _sender args -> f args))(v)) 
+        match autoSize with None -> () | Some v -> attribBuilder.Add(View._AutoSizeAttribKey, (v)) 
         attribBuilder
 
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
@@ -3493,6 +3550,8 @@ type View() =
         let mutable currEditorCompletedOpt = ValueNone
         let mutable prevTextChangedOpt = ValueNone
         let mutable currTextChangedOpt = ValueNone
+        let mutable prevAutoSizeOpt = ValueNone
+        let mutable currAutoSizeOpt = ValueNone
         for kvp in curr.AttributesKeyed do
             if kvp.Key = View._TextAttribKey.KeyValue then 
                 currTextOpt <- ValueSome (kvp.Value :?> string)
@@ -3508,6 +3567,8 @@ type View() =
                 currEditorCompletedOpt <- ValueSome (kvp.Value :?> System.EventHandler)
             if kvp.Key = View._TextChangedAttribKey.KeyValue then 
                 currTextChangedOpt <- ValueSome (kvp.Value :?> System.EventHandler<Xamarin.Forms.TextChangedEventArgs>)
+            if kvp.Key = View._AutoSizeAttribKey.KeyValue then 
+                currAutoSizeOpt <- ValueSome (kvp.Value :?> Xamarin.Forms.EditorAutoSizeOption)
         match prevOpt with
         | ValueNone -> ()
         | ValueSome prev ->
@@ -3526,6 +3587,8 @@ type View() =
                     prevEditorCompletedOpt <- ValueSome (kvp.Value :?> System.EventHandler)
                 if kvp.Key = View._TextChangedAttribKey.KeyValue then 
                     prevTextChangedOpt <- ValueSome (kvp.Value :?> System.EventHandler<Xamarin.Forms.TextChangedEventArgs>)
+                if kvp.Key = View._AutoSizeAttribKey.KeyValue then 
+                    prevAutoSizeOpt <- ValueSome (kvp.Value :?> Xamarin.Forms.EditorAutoSizeOption)
         match prevTextOpt, currTextOpt with
         | ValueSome prevValue, ValueSome currValue when prevValue = currValue -> ()
         | _, ValueSome currValue -> target.Text <-  currValue
@@ -3563,11 +3626,16 @@ type View() =
         | ValueNone, ValueSome currValue -> target.TextChanged.AddHandler(currValue)
         | ValueSome prevValue, ValueNone -> target.TextChanged.RemoveHandler(prevValue)
         | ValueNone, ValueNone -> ()
+        match prevAutoSizeOpt, currAutoSizeOpt with
+        | ValueSome prevValue, ValueSome currValue when prevValue = currValue -> ()
+        | _, ValueSome currValue -> target.AutoSize <-  currValue
+        | ValueSome _, ValueNone -> target.AutoSize <- Xamarin.Forms.EditorAutoSizeOption.Disabled
+        | ValueNone, ValueNone -> ()
 
     /// Describes a Editor in the view
-    static member inline Editor(?text: string, ?fontSize: obj, ?fontFamily: string, ?fontAttributes: Xamarin.Forms.FontAttributes, ?textColor: Xamarin.Forms.Color, ?completed: string -> unit, ?textChanged: Xamarin.Forms.TextChangedEventArgs -> unit, ?keyboard: Xamarin.Forms.Keyboard, ?horizontalOptions: Xamarin.Forms.LayoutOptions, ?verticalOptions: Xamarin.Forms.LayoutOptions, ?margin: obj, ?gestureRecognizers: ViewElement list, ?anchorX: double, ?anchorY: double, ?backgroundColor: Xamarin.Forms.Color, ?heightRequest: double, ?inputTransparent: bool, ?isEnabled: bool, ?isVisible: bool, ?minimumHeightRequest: double, ?minimumWidthRequest: double, ?opacity: double, ?rotation: double, ?rotationX: double, ?rotationY: double, ?scale: double, ?style: Xamarin.Forms.Style, ?translationX: double, ?translationY: double, ?widthRequest: double, ?resources: (string * obj) list, ?styles: Xamarin.Forms.Style list, ?styleSheets: Xamarin.Forms.StyleSheets.StyleSheet list, ?classId: string, ?styleId: string, ?automationId: string) = 
+    static member inline Editor(?text: string, ?fontSize: obj, ?fontFamily: string, ?fontAttributes: Xamarin.Forms.FontAttributes, ?textColor: Xamarin.Forms.Color, ?completed: string -> unit, ?textChanged: Xamarin.Forms.TextChangedEventArgs -> unit, ?autoSize: Xamarin.Forms.EditorAutoSizeOption, ?keyboard: Xamarin.Forms.Keyboard, ?horizontalOptions: Xamarin.Forms.LayoutOptions, ?verticalOptions: Xamarin.Forms.LayoutOptions, ?margin: obj, ?gestureRecognizers: ViewElement list, ?anchorX: double, ?anchorY: double, ?backgroundColor: Xamarin.Forms.Color, ?heightRequest: double, ?inputTransparent: bool, ?isEnabled: bool, ?isVisible: bool, ?minimumHeightRequest: double, ?minimumWidthRequest: double, ?opacity: double, ?rotation: double, ?rotationX: double, ?rotationY: double, ?scale: double, ?style: Xamarin.Forms.Style, ?translationX: double, ?translationY: double, ?widthRequest: double, ?resources: (string * obj) list, ?styles: Xamarin.Forms.Style list, ?styleSheets: Xamarin.Forms.StyleSheets.StyleSheet list, ?classId: string, ?styleId: string, ?automationId: string) = 
 
-        let attribBuilder = View.BuildEditor(0, ?text=text, ?fontSize=fontSize, ?fontFamily=fontFamily, ?fontAttributes=fontAttributes, ?textColor=textColor, ?completed=completed, ?textChanged=textChanged, ?keyboard=keyboard, ?horizontalOptions=horizontalOptions, ?verticalOptions=verticalOptions, ?margin=margin, ?gestureRecognizers=gestureRecognizers, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?classId=classId, ?styleId=styleId, ?automationId=automationId)
+        let attribBuilder = View.BuildEditor(0, ?text=text, ?fontSize=fontSize, ?fontFamily=fontFamily, ?fontAttributes=fontAttributes, ?textColor=textColor, ?completed=completed, ?textChanged=textChanged, ?autoSize=autoSize, ?keyboard=keyboard, ?horizontalOptions=horizontalOptions, ?verticalOptions=verticalOptions, ?margin=margin, ?gestureRecognizers=gestureRecognizers, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?classId=classId, ?styleId=styleId, ?automationId=automationId)
 
         ViewElement.Create<Xamarin.Forms.Editor>(View.CreateFuncEditor, View.UpdateFuncEditor, attribBuilder)
 
@@ -3576,7 +3644,7 @@ type View() =
 
     /// Builds the attributes for a Entry in the view
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
-    static member inline BuildEntry(attribCount: int, ?text: string, ?placeholder: string, ?horizontalTextAlignment: Xamarin.Forms.TextAlignment, ?fontSize: obj, ?fontFamily: string, ?fontAttributes: Xamarin.Forms.FontAttributes, ?textColor: Xamarin.Forms.Color, ?placeholderColor: Xamarin.Forms.Color, ?isPassword: bool, ?completed: string -> unit, ?textChanged: Xamarin.Forms.TextChangedEventArgs -> unit, ?keyboard: Xamarin.Forms.Keyboard, ?horizontalOptions: Xamarin.Forms.LayoutOptions, ?verticalOptions: Xamarin.Forms.LayoutOptions, ?margin: obj, ?gestureRecognizers: ViewElement list, ?anchorX: double, ?anchorY: double, ?backgroundColor: Xamarin.Forms.Color, ?heightRequest: double, ?inputTransparent: bool, ?isEnabled: bool, ?isVisible: bool, ?minimumHeightRequest: double, ?minimumWidthRequest: double, ?opacity: double, ?rotation: double, ?rotationX: double, ?rotationY: double, ?scale: double, ?style: Xamarin.Forms.Style, ?translationX: double, ?translationY: double, ?widthRequest: double, ?resources: (string * obj) list, ?styles: Xamarin.Forms.Style list, ?styleSheets: Xamarin.Forms.StyleSheets.StyleSheet list, ?classId: string, ?styleId: string, ?automationId: string) = 
+    static member inline BuildEntry(attribCount: int, ?text: string, ?placeholder: string, ?horizontalTextAlignment: Xamarin.Forms.TextAlignment, ?fontSize: obj, ?fontFamily: string, ?fontAttributes: Xamarin.Forms.FontAttributes, ?textColor: Xamarin.Forms.Color, ?placeholderColor: Xamarin.Forms.Color, ?isPassword: bool, ?completed: string -> unit, ?textChanged: Xamarin.Forms.TextChangedEventArgs -> unit, ?isTextPredictionEnabled: bool, ?returnType: Xamarin.Forms.ReturnType, ?returnCommand: unit -> unit, ?keyboard: Xamarin.Forms.Keyboard, ?horizontalOptions: Xamarin.Forms.LayoutOptions, ?verticalOptions: Xamarin.Forms.LayoutOptions, ?margin: obj, ?gestureRecognizers: ViewElement list, ?anchorX: double, ?anchorY: double, ?backgroundColor: Xamarin.Forms.Color, ?heightRequest: double, ?inputTransparent: bool, ?isEnabled: bool, ?isVisible: bool, ?minimumHeightRequest: double, ?minimumWidthRequest: double, ?opacity: double, ?rotation: double, ?rotationX: double, ?rotationY: double, ?scale: double, ?style: Xamarin.Forms.Style, ?translationX: double, ?translationY: double, ?widthRequest: double, ?resources: (string * obj) list, ?styles: Xamarin.Forms.Style list, ?styleSheets: Xamarin.Forms.StyleSheets.StyleSheet list, ?classId: string, ?styleId: string, ?automationId: string) = 
 
         let attribCount = match text with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match placeholder with Some _ -> attribCount + 1 | None -> attribCount
@@ -3589,6 +3657,9 @@ type View() =
         let attribCount = match isPassword with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match completed with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match textChanged with Some _ -> attribCount + 1 | None -> attribCount
+        let attribCount = match isTextPredictionEnabled with Some _ -> attribCount + 1 | None -> attribCount
+        let attribCount = match returnType with Some _ -> attribCount + 1 | None -> attribCount
+        let attribCount = match returnCommand with Some _ -> attribCount + 1 | None -> attribCount
 
         let attribBuilder = View.BuildInputView(attribCount, ?keyboard=keyboard, ?horizontalOptions=horizontalOptions, ?verticalOptions=verticalOptions, ?margin=margin, ?gestureRecognizers=gestureRecognizers, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?classId=classId, ?styleId=styleId, ?automationId=automationId)
         match text with None -> () | Some v -> attribBuilder.Add(View._TextAttribKey, (v)) 
@@ -3602,6 +3673,9 @@ type View() =
         match isPassword with None -> () | Some v -> attribBuilder.Add(View._IsPasswordAttribKey, (v)) 
         match completed with None -> () | Some v -> attribBuilder.Add(View._EntryCompletedAttribKey, (fun f -> System.EventHandler(fun sender args -> f (sender :?> Xamarin.Forms.Entry).Text))(v)) 
         match textChanged with None -> () | Some v -> attribBuilder.Add(View._TextChangedAttribKey, (fun f -> System.EventHandler<Xamarin.Forms.TextChangedEventArgs>(fun _sender args -> f args))(v)) 
+        match isTextPredictionEnabled with None -> () | Some v -> attribBuilder.Add(View._IsTextPredictionEnabledAttribKey, (v)) 
+        match returnType with None -> () | Some v -> attribBuilder.Add(View._ReturnTypeAttribKey, (v)) 
+        match returnCommand with None -> () | Some v -> attribBuilder.Add(View._ReturnCommandAttribKey, makeCommand(v)) 
         attribBuilder
 
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
@@ -3641,6 +3715,12 @@ type View() =
         let mutable currEntryCompletedOpt = ValueNone
         let mutable prevTextChangedOpt = ValueNone
         let mutable currTextChangedOpt = ValueNone
+        let mutable prevIsTextPredictionEnabledOpt = ValueNone
+        let mutable currIsTextPredictionEnabledOpt = ValueNone
+        let mutable prevReturnTypeOpt = ValueNone
+        let mutable currReturnTypeOpt = ValueNone
+        let mutable prevReturnCommandOpt = ValueNone
+        let mutable currReturnCommandOpt = ValueNone
         for kvp in curr.AttributesKeyed do
             if kvp.Key = View._TextAttribKey.KeyValue then 
                 currTextOpt <- ValueSome (kvp.Value :?> string)
@@ -3664,6 +3744,12 @@ type View() =
                 currEntryCompletedOpt <- ValueSome (kvp.Value :?> System.EventHandler)
             if kvp.Key = View._TextChangedAttribKey.KeyValue then 
                 currTextChangedOpt <- ValueSome (kvp.Value :?> System.EventHandler<Xamarin.Forms.TextChangedEventArgs>)
+            if kvp.Key = View._IsTextPredictionEnabledAttribKey.KeyValue then 
+                currIsTextPredictionEnabledOpt <- ValueSome (kvp.Value :?> bool)
+            if kvp.Key = View._ReturnTypeAttribKey.KeyValue then 
+                currReturnTypeOpt <- ValueSome (kvp.Value :?> Xamarin.Forms.ReturnType)
+            if kvp.Key = View._ReturnCommandAttribKey.KeyValue then 
+                currReturnCommandOpt <- ValueSome (kvp.Value :?> System.Windows.Input.ICommand)
         match prevOpt with
         | ValueNone -> ()
         | ValueSome prev ->
@@ -3690,6 +3776,12 @@ type View() =
                     prevEntryCompletedOpt <- ValueSome (kvp.Value :?> System.EventHandler)
                 if kvp.Key = View._TextChangedAttribKey.KeyValue then 
                     prevTextChangedOpt <- ValueSome (kvp.Value :?> System.EventHandler<Xamarin.Forms.TextChangedEventArgs>)
+                if kvp.Key = View._IsTextPredictionEnabledAttribKey.KeyValue then 
+                    prevIsTextPredictionEnabledOpt <- ValueSome (kvp.Value :?> bool)
+                if kvp.Key = View._ReturnTypeAttribKey.KeyValue then 
+                    prevReturnTypeOpt <- ValueSome (kvp.Value :?> Xamarin.Forms.ReturnType)
+                if kvp.Key = View._ReturnCommandAttribKey.KeyValue then 
+                    prevReturnCommandOpt <- ValueSome (kvp.Value :?> System.Windows.Input.ICommand)
         match prevTextOpt, currTextOpt with
         | ValueSome prevValue, ValueSome currValue when prevValue = currValue -> ()
         | _, ValueSome currValue -> target.Text <-  currValue
@@ -3747,11 +3839,26 @@ type View() =
         | ValueNone, ValueSome currValue -> target.TextChanged.AddHandler(currValue)
         | ValueSome prevValue, ValueNone -> target.TextChanged.RemoveHandler(prevValue)
         | ValueNone, ValueNone -> ()
+        match prevIsTextPredictionEnabledOpt, currIsTextPredictionEnabledOpt with
+        | ValueSome prevValue, ValueSome currValue when prevValue = currValue -> ()
+        | _, ValueSome currValue -> target.IsTextPredictionEnabled <-  currValue
+        | ValueSome _, ValueNone -> target.IsTextPredictionEnabled <- true
+        | ValueNone, ValueNone -> ()
+        match prevReturnTypeOpt, currReturnTypeOpt with
+        | ValueSome prevValue, ValueSome currValue when prevValue = currValue -> ()
+        | _, ValueSome currValue -> target.ReturnType <-  currValue
+        | ValueSome _, ValueNone -> target.ReturnType <- Xamarin.Forms.ReturnType.Default
+        | ValueNone, ValueNone -> ()
+        match prevReturnCommandOpt, currReturnCommandOpt with
+        | ValueSome prevValue, ValueSome currValue when prevValue = currValue -> ()
+        | _, ValueSome currValue -> target.ReturnCommand <-  currValue
+        | ValueSome _, ValueNone -> target.ReturnCommand <- null
+        | ValueNone, ValueNone -> ()
 
     /// Describes a Entry in the view
-    static member inline Entry(?text: string, ?placeholder: string, ?horizontalTextAlignment: Xamarin.Forms.TextAlignment, ?fontSize: obj, ?fontFamily: string, ?fontAttributes: Xamarin.Forms.FontAttributes, ?textColor: Xamarin.Forms.Color, ?placeholderColor: Xamarin.Forms.Color, ?isPassword: bool, ?completed: string -> unit, ?textChanged: Xamarin.Forms.TextChangedEventArgs -> unit, ?keyboard: Xamarin.Forms.Keyboard, ?horizontalOptions: Xamarin.Forms.LayoutOptions, ?verticalOptions: Xamarin.Forms.LayoutOptions, ?margin: obj, ?gestureRecognizers: ViewElement list, ?anchorX: double, ?anchorY: double, ?backgroundColor: Xamarin.Forms.Color, ?heightRequest: double, ?inputTransparent: bool, ?isEnabled: bool, ?isVisible: bool, ?minimumHeightRequest: double, ?minimumWidthRequest: double, ?opacity: double, ?rotation: double, ?rotationX: double, ?rotationY: double, ?scale: double, ?style: Xamarin.Forms.Style, ?translationX: double, ?translationY: double, ?widthRequest: double, ?resources: (string * obj) list, ?styles: Xamarin.Forms.Style list, ?styleSheets: Xamarin.Forms.StyleSheets.StyleSheet list, ?classId: string, ?styleId: string, ?automationId: string) = 
+    static member inline Entry(?text: string, ?placeholder: string, ?horizontalTextAlignment: Xamarin.Forms.TextAlignment, ?fontSize: obj, ?fontFamily: string, ?fontAttributes: Xamarin.Forms.FontAttributes, ?textColor: Xamarin.Forms.Color, ?placeholderColor: Xamarin.Forms.Color, ?isPassword: bool, ?completed: string -> unit, ?textChanged: Xamarin.Forms.TextChangedEventArgs -> unit, ?isTextPredictionEnabled: bool, ?returnType: Xamarin.Forms.ReturnType, ?returnCommand: unit -> unit, ?keyboard: Xamarin.Forms.Keyboard, ?horizontalOptions: Xamarin.Forms.LayoutOptions, ?verticalOptions: Xamarin.Forms.LayoutOptions, ?margin: obj, ?gestureRecognizers: ViewElement list, ?anchorX: double, ?anchorY: double, ?backgroundColor: Xamarin.Forms.Color, ?heightRequest: double, ?inputTransparent: bool, ?isEnabled: bool, ?isVisible: bool, ?minimumHeightRequest: double, ?minimumWidthRequest: double, ?opacity: double, ?rotation: double, ?rotationX: double, ?rotationY: double, ?scale: double, ?style: Xamarin.Forms.Style, ?translationX: double, ?translationY: double, ?widthRequest: double, ?resources: (string * obj) list, ?styles: Xamarin.Forms.Style list, ?styleSheets: Xamarin.Forms.StyleSheets.StyleSheet list, ?classId: string, ?styleId: string, ?automationId: string) = 
 
-        let attribBuilder = View.BuildEntry(0, ?text=text, ?placeholder=placeholder, ?horizontalTextAlignment=horizontalTextAlignment, ?fontSize=fontSize, ?fontFamily=fontFamily, ?fontAttributes=fontAttributes, ?textColor=textColor, ?placeholderColor=placeholderColor, ?isPassword=isPassword, ?completed=completed, ?textChanged=textChanged, ?keyboard=keyboard, ?horizontalOptions=horizontalOptions, ?verticalOptions=verticalOptions, ?margin=margin, ?gestureRecognizers=gestureRecognizers, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?classId=classId, ?styleId=styleId, ?automationId=automationId)
+        let attribBuilder = View.BuildEntry(0, ?text=text, ?placeholder=placeholder, ?horizontalTextAlignment=horizontalTextAlignment, ?fontSize=fontSize, ?fontFamily=fontFamily, ?fontAttributes=fontAttributes, ?textColor=textColor, ?placeholderColor=placeholderColor, ?isPassword=isPassword, ?completed=completed, ?textChanged=textChanged, ?isTextPredictionEnabled=isTextPredictionEnabled, ?returnType=returnType, ?returnCommand=returnCommand, ?keyboard=keyboard, ?horizontalOptions=horizontalOptions, ?verticalOptions=verticalOptions, ?margin=margin, ?gestureRecognizers=gestureRecognizers, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?classId=classId, ?styleId=styleId, ?automationId=automationId)
 
         ViewElement.Create<Xamarin.Forms.Entry>(View.CreateFuncEntry, View.UpdateFuncEntry, attribBuilder)
 
@@ -4117,7 +4224,7 @@ type View() =
 
     /// Builds the attributes for a Span in the view
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
-    static member inline BuildSpan(attribCount: int, ?fontFamily: string, ?fontAttributes: Xamarin.Forms.FontAttributes, ?fontSize: obj, ?backgroundColor: Xamarin.Forms.Color, ?foregroundColor: Xamarin.Forms.Color, ?text: string, ?propertyChanged: System.ComponentModel.PropertyChangedEventArgs -> unit) = 
+    static member inline BuildSpan(attribCount: int, ?fontFamily: string, ?fontAttributes: Xamarin.Forms.FontAttributes, ?fontSize: obj, ?backgroundColor: Xamarin.Forms.Color, ?foregroundColor: Xamarin.Forms.Color, ?text: string, ?propertyChanged: System.ComponentModel.PropertyChangedEventArgs -> unit, ?classId: string, ?styleId: string, ?automationId: string) = 
 
         let attribCount = match fontFamily with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match fontAttributes with Some _ -> attribCount + 1 | None -> attribCount
@@ -4126,7 +4233,8 @@ type View() =
         let attribCount = match foregroundColor with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match text with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match propertyChanged with Some _ -> attribCount + 1 | None -> attribCount
-        let attribBuilder = new AttributesBuilder(attribCount)
+
+        let attribBuilder = View.BuildElement(attribCount, ?classId=classId, ?styleId=styleId, ?automationId=automationId)
         match fontFamily with None -> () | Some v -> attribBuilder.Add(View._FontFamilyAttribKey, (v)) 
         match fontAttributes with None -> () | Some v -> attribBuilder.Add(View._FontAttributesAttribKey, (v)) 
         match fontSize with None -> () | Some v -> attribBuilder.Add(View._FontSizeAttribKey, makeFontSize(v)) 
@@ -4148,6 +4256,9 @@ type View() =
 
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
     static member UpdateSpan (prevOpt: ViewElement voption, curr: ViewElement, target: Xamarin.Forms.Span) = 
+        // update the inherited Element element
+        let baseElement = (if View.ProtoElement.IsNone then View.ProtoElement <- Some (View.Element())); View.ProtoElement.Value
+        baseElement.UpdateInherited (prevOpt, curr, target)
         let mutable prevFontFamilyOpt = ValueNone
         let mutable currFontFamilyOpt = ValueNone
         let mutable prevFontAttributesOpt = ValueNone
@@ -4233,9 +4344,9 @@ type View() =
         | ValueNone, ValueNone -> ()
 
     /// Describes a Span in the view
-    static member inline Span(?fontFamily: string, ?fontAttributes: Xamarin.Forms.FontAttributes, ?fontSize: obj, ?backgroundColor: Xamarin.Forms.Color, ?foregroundColor: Xamarin.Forms.Color, ?text: string, ?propertyChanged: System.ComponentModel.PropertyChangedEventArgs -> unit) = 
+    static member inline Span(?fontFamily: string, ?fontAttributes: Xamarin.Forms.FontAttributes, ?fontSize: obj, ?backgroundColor: Xamarin.Forms.Color, ?foregroundColor: Xamarin.Forms.Color, ?text: string, ?propertyChanged: System.ComponentModel.PropertyChangedEventArgs -> unit, ?classId: string, ?styleId: string, ?automationId: string) = 
 
-        let attribBuilder = View.BuildSpan(0, ?fontFamily=fontFamily, ?fontAttributes=fontAttributes, ?fontSize=fontSize, ?backgroundColor=backgroundColor, ?foregroundColor=foregroundColor, ?text=text, ?propertyChanged=propertyChanged)
+        let attribBuilder = View.BuildSpan(0, ?fontFamily=fontFamily, ?fontAttributes=fontAttributes, ?fontSize=fontSize, ?backgroundColor=backgroundColor, ?foregroundColor=foregroundColor, ?text=text, ?propertyChanged=propertyChanged, ?classId=classId, ?styleId=styleId, ?automationId=automationId)
 
         ViewElement.Create<Xamarin.Forms.Span>(View.CreateFuncSpan, View.UpdateFuncSpan, attribBuilder)
 
@@ -4244,10 +4355,11 @@ type View() =
 
     /// Builds the attributes for a FormattedString in the view
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
-    static member inline BuildFormattedString(attribCount: int, ?spans: ViewElement[]) = 
+    static member inline BuildFormattedString(attribCount: int, ?spans: ViewElement[], ?classId: string, ?styleId: string, ?automationId: string) = 
 
         let attribCount = match spans with Some _ -> attribCount + 1 | None -> attribCount
-        let attribBuilder = new AttributesBuilder(attribCount)
+
+        let attribBuilder = View.BuildElement(attribCount, ?classId=classId, ?styleId=styleId, ?automationId=automationId)
         match spans with None -> () | Some v -> attribBuilder.Add(View._SpansAttribKey, (v)) 
         attribBuilder
 
@@ -4263,6 +4375,9 @@ type View() =
 
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
     static member UpdateFormattedString (prevOpt: ViewElement voption, curr: ViewElement, target: Xamarin.Forms.FormattedString) = 
+        // update the inherited Element element
+        let baseElement = (if View.ProtoElement.IsNone then View.ProtoElement <- Some (View.Element())); View.ProtoElement.Value
+        baseElement.UpdateInherited (prevOpt, curr, target)
         let mutable prevSpansOpt = ValueNone
         let mutable currSpansOpt = ValueNone
         for kvp in curr.AttributesKeyed do
@@ -4281,9 +4396,9 @@ type View() =
             updateChild
 
     /// Describes a FormattedString in the view
-    static member inline FormattedString(?spans: ViewElement[]) = 
+    static member inline FormattedString(?spans: ViewElement[], ?classId: string, ?styleId: string, ?automationId: string) = 
 
-        let attribBuilder = View.BuildFormattedString(0, ?spans=spans)
+        let attribBuilder = View.BuildFormattedString(0, ?spans=spans, ?classId=classId, ?styleId=styleId, ?automationId=automationId)
 
         ViewElement.Create<Xamarin.Forms.FormattedString>(View.CreateFuncFormattedString, View.UpdateFuncFormattedString, attribBuilder)
 
@@ -5524,7 +5639,7 @@ type View() =
 
     /// Builds the attributes for a ListView in the view
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
-    static member inline BuildListView(attribCount: int, ?items: seq<ViewElement>, ?footer: System.Object, ?hasUnevenRows: bool, ?header: System.Object, ?headerTemplate: Xamarin.Forms.DataTemplate, ?isGroupingEnabled: bool, ?isPullToRefreshEnabled: bool, ?isRefreshing: bool, ?refreshCommand: unit -> unit, ?rowHeight: int, ?selectedItem: int option, ?separatorVisibility: Xamarin.Forms.SeparatorVisibility, ?separatorColor: Xamarin.Forms.Color, ?itemAppearing: int -> unit, ?itemDisappearing: int -> unit, ?itemSelected: int option -> unit, ?itemTapped: int -> unit, ?refreshing: unit -> unit, ?horizontalOptions: Xamarin.Forms.LayoutOptions, ?verticalOptions: Xamarin.Forms.LayoutOptions, ?margin: obj, ?gestureRecognizers: ViewElement list, ?anchorX: double, ?anchorY: double, ?backgroundColor: Xamarin.Forms.Color, ?heightRequest: double, ?inputTransparent: bool, ?isEnabled: bool, ?isVisible: bool, ?minimumHeightRequest: double, ?minimumWidthRequest: double, ?opacity: double, ?rotation: double, ?rotationX: double, ?rotationY: double, ?scale: double, ?style: Xamarin.Forms.Style, ?translationX: double, ?translationY: double, ?widthRequest: double, ?resources: (string * obj) list, ?styles: Xamarin.Forms.Style list, ?styleSheets: Xamarin.Forms.StyleSheets.StyleSheet list, ?classId: string, ?styleId: string, ?automationId: string) = 
+    static member inline BuildListView(attribCount: int, ?items: seq<ViewElement>, ?footer: System.Object, ?hasUnevenRows: bool, ?header: System.Object, ?headerTemplate: Xamarin.Forms.DataTemplate, ?isGroupingEnabled: bool, ?isPullToRefreshEnabled: bool, ?isRefreshing: bool, ?refreshCommand: unit -> unit, ?rowHeight: int, ?selectedItem: int option, ?separatorVisibility: Xamarin.Forms.SeparatorVisibility, ?separatorColor: Xamarin.Forms.Color, ?itemAppearing: int -> unit, ?itemDisappearing: int -> unit, ?itemSelected: int option -> unit, ?itemTapped: int -> unit, ?refreshing: unit -> unit, ?selectionMode: Xamarin.Forms.ListViewSelectionMode, ?horizontalOptions: Xamarin.Forms.LayoutOptions, ?verticalOptions: Xamarin.Forms.LayoutOptions, ?margin: obj, ?gestureRecognizers: ViewElement list, ?anchorX: double, ?anchorY: double, ?backgroundColor: Xamarin.Forms.Color, ?heightRequest: double, ?inputTransparent: bool, ?isEnabled: bool, ?isVisible: bool, ?minimumHeightRequest: double, ?minimumWidthRequest: double, ?opacity: double, ?rotation: double, ?rotationX: double, ?rotationY: double, ?scale: double, ?style: Xamarin.Forms.Style, ?translationX: double, ?translationY: double, ?widthRequest: double, ?resources: (string * obj) list, ?styles: Xamarin.Forms.Style list, ?styleSheets: Xamarin.Forms.StyleSheets.StyleSheet list, ?classId: string, ?styleId: string, ?automationId: string) = 
 
         let attribCount = match items with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match footer with Some _ -> attribCount + 1 | None -> attribCount
@@ -5544,6 +5659,7 @@ type View() =
         let attribCount = match itemSelected with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match itemTapped with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match refreshing with Some _ -> attribCount + 1 | None -> attribCount
+        let attribCount = match selectionMode with Some _ -> attribCount + 1 | None -> attribCount
 
         let attribBuilder = View.BuildView(attribCount, ?horizontalOptions=horizontalOptions, ?verticalOptions=verticalOptions, ?margin=margin, ?gestureRecognizers=gestureRecognizers, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?classId=classId, ?styleId=styleId, ?automationId=automationId)
         match items with None -> () | Some v -> attribBuilder.Add(View._ListViewItemsAttribKey, (v)) 
@@ -5564,6 +5680,7 @@ type View() =
         match itemSelected with None -> () | Some v -> attribBuilder.Add(View._ListView_ItemSelectedAttribKey, (fun f -> System.EventHandler<Xamarin.Forms.SelectedItemChangedEventArgs>(fun sender args -> f (tryFindListViewItem sender args.SelectedItem)))(v)) 
         match itemTapped with None -> () | Some v -> attribBuilder.Add(View._ListView_ItemTappedAttribKey, (fun f -> System.EventHandler<Xamarin.Forms.ItemTappedEventArgs>(fun sender args -> f (tryFindListViewItem sender args.Item).Value))(v)) 
         match refreshing with None -> () | Some v -> attribBuilder.Add(View._ListView_RefreshingAttribKey, (fun f -> System.EventHandler(fun sender args -> f ()))(v)) 
+        match selectionMode with None -> () | Some v -> attribBuilder.Add(View._SelectionModeAttribKey, (v)) 
         attribBuilder
 
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
@@ -5617,6 +5734,8 @@ type View() =
         let mutable currListView_ItemTappedOpt = ValueNone
         let mutable prevListView_RefreshingOpt = ValueNone
         let mutable currListView_RefreshingOpt = ValueNone
+        let mutable prevSelectionModeOpt = ValueNone
+        let mutable currSelectionModeOpt = ValueNone
         for kvp in curr.AttributesKeyed do
             if kvp.Key = View._ListViewItemsAttribKey.KeyValue then 
                 currListViewItemsOpt <- ValueSome (kvp.Value :?> seq<ViewElement>)
@@ -5654,6 +5773,8 @@ type View() =
                 currListView_ItemTappedOpt <- ValueSome (kvp.Value :?> System.EventHandler<Xamarin.Forms.ItemTappedEventArgs>)
             if kvp.Key = View._ListView_RefreshingAttribKey.KeyValue then 
                 currListView_RefreshingOpt <- ValueSome (kvp.Value :?> System.EventHandler)
+            if kvp.Key = View._SelectionModeAttribKey.KeyValue then 
+                currSelectionModeOpt <- ValueSome (kvp.Value :?> Xamarin.Forms.ListViewSelectionMode)
         match prevOpt with
         | ValueNone -> ()
         | ValueSome prev ->
@@ -5694,6 +5815,8 @@ type View() =
                     prevListView_ItemTappedOpt <- ValueSome (kvp.Value :?> System.EventHandler<Xamarin.Forms.ItemTappedEventArgs>)
                 if kvp.Key = View._ListView_RefreshingAttribKey.KeyValue then 
                     prevListView_RefreshingOpt <- ValueSome (kvp.Value :?> System.EventHandler)
+                if kvp.Key = View._SelectionModeAttribKey.KeyValue then 
+                    prevSelectionModeOpt <- ValueSome (kvp.Value :?> Xamarin.Forms.ListViewSelectionMode)
         updateListViewItems prevListViewItemsOpt currListViewItemsOpt target
         match prevFooterOpt, currFooterOpt with
         | ValueSome prevValue, ValueSome currValue when prevValue = currValue -> ()
@@ -5785,11 +5908,16 @@ type View() =
         | ValueNone, ValueSome currValue -> target.Refreshing.AddHandler(currValue)
         | ValueSome prevValue, ValueNone -> target.Refreshing.RemoveHandler(prevValue)
         | ValueNone, ValueNone -> ()
+        match prevSelectionModeOpt, currSelectionModeOpt with
+        | ValueSome prevValue, ValueSome currValue when prevValue = currValue -> ()
+        | _, ValueSome currValue -> target.SelectionMode <-  currValue
+        | ValueSome _, ValueNone -> target.SelectionMode <- Xamarin.Forms.ListViewSelectionMode.Single
+        | ValueNone, ValueNone -> ()
 
     /// Describes a ListView in the view
-    static member inline ListView(?items: seq<ViewElement>, ?footer: System.Object, ?hasUnevenRows: bool, ?header: System.Object, ?headerTemplate: Xamarin.Forms.DataTemplate, ?isGroupingEnabled: bool, ?isPullToRefreshEnabled: bool, ?isRefreshing: bool, ?refreshCommand: unit -> unit, ?rowHeight: int, ?selectedItem: int option, ?separatorVisibility: Xamarin.Forms.SeparatorVisibility, ?separatorColor: Xamarin.Forms.Color, ?itemAppearing: int -> unit, ?itemDisappearing: int -> unit, ?itemSelected: int option -> unit, ?itemTapped: int -> unit, ?refreshing: unit -> unit, ?horizontalOptions: Xamarin.Forms.LayoutOptions, ?verticalOptions: Xamarin.Forms.LayoutOptions, ?margin: obj, ?gestureRecognizers: ViewElement list, ?anchorX: double, ?anchorY: double, ?backgroundColor: Xamarin.Forms.Color, ?heightRequest: double, ?inputTransparent: bool, ?isEnabled: bool, ?isVisible: bool, ?minimumHeightRequest: double, ?minimumWidthRequest: double, ?opacity: double, ?rotation: double, ?rotationX: double, ?rotationY: double, ?scale: double, ?style: Xamarin.Forms.Style, ?translationX: double, ?translationY: double, ?widthRequest: double, ?resources: (string * obj) list, ?styles: Xamarin.Forms.Style list, ?styleSheets: Xamarin.Forms.StyleSheets.StyleSheet list, ?classId: string, ?styleId: string, ?automationId: string) = 
+    static member inline ListView(?items: seq<ViewElement>, ?footer: System.Object, ?hasUnevenRows: bool, ?header: System.Object, ?headerTemplate: Xamarin.Forms.DataTemplate, ?isGroupingEnabled: bool, ?isPullToRefreshEnabled: bool, ?isRefreshing: bool, ?refreshCommand: unit -> unit, ?rowHeight: int, ?selectedItem: int option, ?separatorVisibility: Xamarin.Forms.SeparatorVisibility, ?separatorColor: Xamarin.Forms.Color, ?itemAppearing: int -> unit, ?itemDisappearing: int -> unit, ?itemSelected: int option -> unit, ?itemTapped: int -> unit, ?refreshing: unit -> unit, ?selectionMode: Xamarin.Forms.ListViewSelectionMode, ?horizontalOptions: Xamarin.Forms.LayoutOptions, ?verticalOptions: Xamarin.Forms.LayoutOptions, ?margin: obj, ?gestureRecognizers: ViewElement list, ?anchorX: double, ?anchorY: double, ?backgroundColor: Xamarin.Forms.Color, ?heightRequest: double, ?inputTransparent: bool, ?isEnabled: bool, ?isVisible: bool, ?minimumHeightRequest: double, ?minimumWidthRequest: double, ?opacity: double, ?rotation: double, ?rotationX: double, ?rotationY: double, ?scale: double, ?style: Xamarin.Forms.Style, ?translationX: double, ?translationY: double, ?widthRequest: double, ?resources: (string * obj) list, ?styles: Xamarin.Forms.Style list, ?styleSheets: Xamarin.Forms.StyleSheets.StyleSheet list, ?classId: string, ?styleId: string, ?automationId: string) = 
 
-        let attribBuilder = View.BuildListView(0, ?items=items, ?footer=footer, ?hasUnevenRows=hasUnevenRows, ?header=header, ?headerTemplate=headerTemplate, ?isGroupingEnabled=isGroupingEnabled, ?isPullToRefreshEnabled=isPullToRefreshEnabled, ?isRefreshing=isRefreshing, ?refreshCommand=refreshCommand, ?rowHeight=rowHeight, ?selectedItem=selectedItem, ?separatorVisibility=separatorVisibility, ?separatorColor=separatorColor, ?itemAppearing=itemAppearing, ?itemDisappearing=itemDisappearing, ?itemSelected=itemSelected, ?itemTapped=itemTapped, ?refreshing=refreshing, ?horizontalOptions=horizontalOptions, ?verticalOptions=verticalOptions, ?margin=margin, ?gestureRecognizers=gestureRecognizers, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?classId=classId, ?styleId=styleId, ?automationId=automationId)
+        let attribBuilder = View.BuildListView(0, ?items=items, ?footer=footer, ?hasUnevenRows=hasUnevenRows, ?header=header, ?headerTemplate=headerTemplate, ?isGroupingEnabled=isGroupingEnabled, ?isPullToRefreshEnabled=isPullToRefreshEnabled, ?isRefreshing=isRefreshing, ?refreshCommand=refreshCommand, ?rowHeight=rowHeight, ?selectedItem=selectedItem, ?separatorVisibility=separatorVisibility, ?separatorColor=separatorColor, ?itemAppearing=itemAppearing, ?itemDisappearing=itemDisappearing, ?itemSelected=itemSelected, ?itemTapped=itemTapped, ?refreshing=refreshing, ?selectionMode=selectionMode, ?horizontalOptions=horizontalOptions, ?verticalOptions=verticalOptions, ?margin=margin, ?gestureRecognizers=gestureRecognizers, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?classId=classId, ?styleId=styleId, ?automationId=automationId)
 
         ViewElement.Create<Xamarin.Forms.ListView>(View.CreateFuncListView, View.UpdateFuncListView, attribBuilder)
 
@@ -6187,6 +6315,12 @@ module ViewElementExtensions =
         /// Adjusts the ScrollOrientation property in the visual element
         member x.ScrollOrientation(value: Xamarin.Forms.ScrollOrientation) = x.WithAttribute(View._ScrollOrientationAttribKey, (value))
 
+        /// Adjusts the HorizontalScrollBarVisibility property in the visual element
+        member x.HorizontalScrollBarVisibility(value: Xamarin.Forms.ScrollBarVisibility) = x.WithAttribute(View._HorizontalScrollBarVisibilityAttribKey, (value))
+
+        /// Adjusts the VerticalScrollBarVisibility property in the visual element
+        member x.VerticalScrollBarVisibility(value: Xamarin.Forms.ScrollBarVisibility) = x.WithAttribute(View._VerticalScrollBarVisibilityAttribKey, (value))
+
         /// Adjusts the CancelButtonColor property in the visual element
         member x.CancelButtonColor(value: Xamarin.Forms.Color) = x.WithAttribute(View._CancelButtonColorAttribKey, (value))
 
@@ -6267,6 +6401,9 @@ module ViewElementExtensions =
 
         /// Adjusts the Toggled property in the visual element
         member x.Toggled(value: Xamarin.Forms.ToggledEventArgs -> unit) = x.WithAttribute(View._ToggledAttribKey, (fun f -> System.EventHandler<Xamarin.Forms.ToggledEventArgs>(fun _sender args -> f args))(value))
+
+        /// Adjusts the OnColor property in the visual element
+        member x.OnColor(value: Xamarin.Forms.Color) = x.WithAttribute(View._OnColorAttribKey, (value))
 
         /// Adjusts the Height property in the visual element
         member x.Height(value: double) = x.WithAttribute(View._HeightAttribKey, (value))
@@ -6427,11 +6564,23 @@ module ViewElementExtensions =
         /// Adjusts the TextChanged property in the visual element
         member x.TextChanged(value: Xamarin.Forms.TextChangedEventArgs -> unit) = x.WithAttribute(View._TextChangedAttribKey, (fun f -> System.EventHandler<Xamarin.Forms.TextChangedEventArgs>(fun _sender args -> f args))(value))
 
+        /// Adjusts the AutoSize property in the visual element
+        member x.AutoSize(value: Xamarin.Forms.EditorAutoSizeOption) = x.WithAttribute(View._AutoSizeAttribKey, (value))
+
         /// Adjusts the IsPassword property in the visual element
         member x.IsPassword(value: bool) = x.WithAttribute(View._IsPasswordAttribKey, (value))
 
         /// Adjusts the EntryCompleted property in the visual element
         member x.EntryCompleted(value: string -> unit) = x.WithAttribute(View._EntryCompletedAttribKey, (fun f -> System.EventHandler(fun sender args -> f (sender :?> Xamarin.Forms.Entry).Text))(value))
+
+        /// Adjusts the IsTextPredictionEnabled property in the visual element
+        member x.IsTextPredictionEnabled(value: bool) = x.WithAttribute(View._IsTextPredictionEnabledAttribKey, (value))
+
+        /// Adjusts the ReturnType property in the visual element
+        member x.ReturnType(value: Xamarin.Forms.ReturnType) = x.WithAttribute(View._ReturnTypeAttribKey, (value))
+
+        /// Adjusts the ReturnCommand property in the visual element
+        member x.ReturnCommand(value: unit -> unit) = x.WithAttribute(View._ReturnCommandAttribKey, makeCommand(value))
 
         /// Adjusts the Label property in the visual element
         member x.Label(value: string) = x.WithAttribute(View._LabelAttribKey, (value))
@@ -6625,6 +6774,9 @@ module ViewElementExtensions =
         /// Adjusts the ListView_Refreshing property in the visual element
         member x.ListView_Refreshing(value: unit -> unit) = x.WithAttribute(View._ListView_RefreshingAttribKey, (fun f -> System.EventHandler(fun sender args -> f ()))(value))
 
+        /// Adjusts the SelectionMode property in the visual element
+        member x.SelectionMode(value: Xamarin.Forms.ListViewSelectionMode) = x.WithAttribute(View._SelectionModeAttribKey, (value))
+
         /// Adjusts the ListViewGrouped_ItemsSource property in the visual element
         member x.ListViewGrouped_ItemsSource(value: (string * ViewElement * ViewElement list) list) = x.WithAttribute(View._ListViewGrouped_ItemsSourceAttribKey, (fun es -> es |> Array.ofList |> Array.map (fun (g, e, l) -> (g, e, Array.ofList l)))(value))
 
@@ -6785,6 +6937,12 @@ module ViewElementExtensions =
     /// Adjusts the ScrollOrientation property in the visual element
     let scrollOrientation (value: Xamarin.Forms.ScrollOrientation) (x: ViewElement) = x.ScrollOrientation(value)
 
+    /// Adjusts the HorizontalScrollBarVisibility property in the visual element
+    let horizontalScrollBarVisibility (value: Xamarin.Forms.ScrollBarVisibility) (x: ViewElement) = x.HorizontalScrollBarVisibility(value)
+
+    /// Adjusts the VerticalScrollBarVisibility property in the visual element
+    let verticalScrollBarVisibility (value: Xamarin.Forms.ScrollBarVisibility) (x: ViewElement) = x.VerticalScrollBarVisibility(value)
+
     /// Adjusts the CancelButtonColor property in the visual element
     let cancelButtonColor (value: Xamarin.Forms.Color) (x: ViewElement) = x.CancelButtonColor(value)
 
@@ -6865,6 +7023,9 @@ module ViewElementExtensions =
 
     /// Adjusts the Toggled property in the visual element
     let toggled (value: Xamarin.Forms.ToggledEventArgs -> unit) (x: ViewElement) = x.Toggled(value)
+
+    /// Adjusts the OnColor property in the visual element
+    let onColor (value: Xamarin.Forms.Color) (x: ViewElement) = x.OnColor(value)
 
     /// Adjusts the Height property in the visual element
     let height (value: double) (x: ViewElement) = x.Height(value)
@@ -7025,11 +7186,23 @@ module ViewElementExtensions =
     /// Adjusts the TextChanged property in the visual element
     let textChanged (value: Xamarin.Forms.TextChangedEventArgs -> unit) (x: ViewElement) = x.TextChanged(value)
 
+    /// Adjusts the AutoSize property in the visual element
+    let autoSize (value: Xamarin.Forms.EditorAutoSizeOption) (x: ViewElement) = x.AutoSize(value)
+
     /// Adjusts the IsPassword property in the visual element
     let isPassword (value: bool) (x: ViewElement) = x.IsPassword(value)
 
     /// Adjusts the EntryCompleted property in the visual element
     let entryCompleted (value: string -> unit) (x: ViewElement) = x.EntryCompleted(value)
+
+    /// Adjusts the IsTextPredictionEnabled property in the visual element
+    let isTextPredictionEnabled (value: bool) (x: ViewElement) = x.IsTextPredictionEnabled(value)
+
+    /// Adjusts the ReturnType property in the visual element
+    let returnType (value: Xamarin.Forms.ReturnType) (x: ViewElement) = x.ReturnType(value)
+
+    /// Adjusts the ReturnCommand property in the visual element
+    let returnCommand (value: unit -> unit) (x: ViewElement) = x.ReturnCommand(value)
 
     /// Adjusts the Label property in the visual element
     let label (value: string) (x: ViewElement) = x.Label(value)
@@ -7222,6 +7395,9 @@ module ViewElementExtensions =
 
     /// Adjusts the ListView_Refreshing property in the visual element
     let listView_Refreshing (value: unit -> unit) (x: ViewElement) = x.ListView_Refreshing(value)
+
+    /// Adjusts the SelectionMode property in the visual element
+    let selectionMode (value: Xamarin.Forms.ListViewSelectionMode) (x: ViewElement) = x.SelectionMode(value)
 
     /// Adjusts the ListViewGrouped_ItemsSource property in the visual element
     let listViewGrouped_ItemsSource (value: (string * ViewElement * ViewElement list) list) (x: ViewElement) = x.ListViewGrouped_ItemsSource(value)

--- a/Fabulous.LiveUpdate/Fabulous.LiveUpdate.fsproj
+++ b/Fabulous.LiveUpdate/Fabulous.LiveUpdate.fsproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.5.2" />
     <PackageReference Update="FSharp.Core" Version="4.5.2" /> <!-- workaround for VSMac bug https://github.com/mono/monodevelop/pull/5137 --> 
-    <PackageReference Include="Xamarin.Forms" Version="3.0.0.482510" />
+    <PackageReference Include="Xamarin.Forms" Version="3.1.0.697729" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <ProjectReference Include="..\Fabulous.Core\Fabulous.Core.fsproj" />
   </ItemGroup>

--- a/Generator/Xamarin.Forms.Core.json
+++ b/Generator/Xamarin.Forms.Core.json
@@ -273,6 +273,14 @@
 					"name": "Orientation",
 					"uniqueName": "ScrollOrientation",
 					"defaultValue": "Unchecked.defaultof<Xamarin.Forms.ScrollOrientation>"
+				},
+				{
+					"name": "HorizontalScrollBarVisibility",
+					"defaultValue": "Xamarin.Forms.ScrollBarVisibility.Default"
+				},
+				{
+					"name": "VerticalScrollBarVisibility",
+					"defaultValue": "Xamarin.Forms.ScrollBarVisibility.Default"
 				}
 			]
 		},
@@ -474,6 +482,10 @@
 					"defaultValue": "null",
 					"inputType": "Xamarin.Forms.ToggledEventArgs -> unit",
 					"convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.ToggledEventArgs>(fun _sender args -> f args))"
+				},
+				{
+					"name": "OnColor",
+					"defaultValue": "Xamarin.Forms.Color.Default"
 				}
 			]
 		},
@@ -942,6 +954,10 @@
 					"defaultValue": "null",
 					"inputType": "Xamarin.Forms.TextChangedEventArgs -> unit",
 					"convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.TextChangedEventArgs>(fun _sender args -> f args))"
+				},
+				{
+					"name": "AutoSize",
+					"defaultValue": "Xamarin.Forms.EditorAutoSizeOption.Disabled"
 				}
 			]
 		},
@@ -998,6 +1014,20 @@
 					"defaultValue": "null",
 					"inputType": "Xamarin.Forms.TextChangedEventArgs -> unit",
 					"convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.TextChangedEventArgs>(fun _sender args -> f args))"
+				},
+				{
+					"name": "IsTextPredictionEnabled",
+					"defaultValue": "true"
+				},
+				{
+					"name": "ReturnType",
+					"defaultValue": "Xamarin.Forms.ReturnType.Default"
+				},
+				{
+					"name": "ReturnCommand",
+					"defaultValue": "null",
+					"inputType": "unit -> unit",
+					"convToModel": "makeCommand"
 				}
 			]
 		},
@@ -1651,6 +1681,10 @@
 					"defaultValue": "null",
 					"inputType": "unit -> unit",
 					"convToModel": "(fun f -> System.EventHandler(fun sender args -> f ()))"
+				},
+				{
+					"name": "SelectionMode",
+					"defaultValue": "Xamarin.Forms.ListViewSelectionMode.Single"
 				}
 			]
 		},

--- a/Samples/AllControls/AllControls/AllControls.fsproj
+++ b/Samples/AllControls/AllControls/AllControls.fsproj
@@ -11,7 +11,7 @@
     <EmbeddedResource Include="Baboon_Serengeti.jpg" />
     <PackageReference Include="FSharp.Core" Version="4.5.2" />
     <PackageReference Update="FSharp.Core" Version="4.5.2" /> <!-- workaround for VSMac bug https://github.com/mono/monodevelop/pull/5137 --> 
-    <PackageReference Include="Xamarin.Forms" Version="3.0.0.482510" />
+    <PackageReference Include="Xamarin.Forms" Version="3.1.0.697729" />
     <ProjectReference Include="..\..\..\Fabulous.Core\Fabulous.Core.fsproj" />
   </ItemGroup>
 </Project>

--- a/Samples/CounterApp/CounterApp/CounterApp.fsproj
+++ b/Samples/CounterApp/CounterApp/CounterApp.fsproj
@@ -13,6 +13,6 @@
     <PackageReference Include="FSharp.Core" Version="4.5.2" />
     <PackageReference Update="FSharp.Core" Version="4.5.2" /> <!-- workaround for VSMac bug https://github.com/mono/monodevelop/pull/5137 --> 
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Xamarin.Forms" Version="3.0.0.482510" />
+    <PackageReference Include="Xamarin.Forms" Version="3.1.0.697729" />
   </ItemGroup>
 </Project>

--- a/Samples/StaticView/StaticViewCounterApp/StaticViewCounterApp/StaticViewCounterApp.fsproj
+++ b/Samples/StaticView/StaticViewCounterApp/StaticViewCounterApp/StaticViewCounterApp.fsproj
@@ -17,6 +17,6 @@
     <ProjectReference Include="..\..\..\..\Fabulous.Core\Fabulous.Core.fsproj" />
     <PackageReference Include="FSharp.Core" Version="4.5.2" />
     <PackageReference Update="FSharp.Core" Version="4.5.2" /> <!-- workaround for VSMac bug https://github.com/mono/monodevelop/pull/5137 --> 
-    <PackageReference Include="Xamarin.Forms" Version="3.0.0.482510" />
+    <PackageReference Include="Xamarin.Forms" Version="3.1.0.697729" />
   </ItemGroup>
 </Project>

--- a/Samples/TicTacToe/TicTacToe/TicTacToe.fsproj
+++ b/Samples/TicTacToe/TicTacToe/TicTacToe.fsproj
@@ -11,7 +11,7 @@
     <PackageReference Include="FSharp.Core" Version="4.5.2" />
     <PackageReference Update="FSharp.Core" Version="4.5.2" /> <!-- workaround for VSMac bug https://github.com/mono/monodevelop/pull/5137 --> 
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Xamarin.Forms" Version="3.0.0.482510" />
+    <PackageReference Include="Xamarin.Forms" Version="3.1.0.697729" />
     <ProjectReference Include="..\..\..\Fabulous.LiveUpdate\Fabulous.LiveUpdate.fsproj" />
     <ProjectReference Include="..\..\..\Fabulous.Core\Fabulous.Core.fsproj" />
   </ItemGroup>

--- a/extensions/Maps/Fabulous.Maps.fsproj
+++ b/extensions/Maps/Fabulous.Maps.fsproj
@@ -12,8 +12,8 @@
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.5.2" />
     <PackageReference Update="FSharp.Core" Version="4.5.2" /> <!-- workaround for VSMac bug https://github.com/mono/monodevelop/pull/5137 --> 
-    <PackageReference Include="Xamarin.Forms" Version="3.0.0.482510" />
-    <PackageReference Include="Xamarin.Forms.Maps" Version="3.0.0.482510" />
+    <PackageReference Include="Xamarin.Forms" Version="3.1.0.697729" />
+    <PackageReference Include="Xamarin.Forms.Maps" Version="3.1.0.697729" />
     <ProjectReference Include="..\..\Fabulous.Core\Fabulous.Core.fsproj" />
   </ItemGroup>
 </Project>

--- a/extensions/OxyPlot/Fabulous.OxyPlot.fsproj
+++ b/extensions/OxyPlot/Fabulous.OxyPlot.fsproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.5.2" />
     <PackageReference Update="FSharp.Core" Version="4.5.2" /> <!-- workaround for VSMac bug https://github.com/mono/monodevelop/pull/5137 --> 
-    <PackageReference Include="Xamarin.Forms" Version="3.0.0.482510" />
+    <PackageReference Include="Xamarin.Forms" Version="3.1.0.697729" />
     <PackageReference Include="OxyPlot.Core" Version="2.0.0-unstable0956" />
     <PackageReference Include="OxyPlot.Xamarin.Forms" Version="1.1.0-unstable0013" />
     <ProjectReference Include="..\..\Fabulous.Core\Fabulous.Core.fsproj" />

--- a/extensions/SkiaSharp/Fabulous.SkiaSharp.fsproj
+++ b/extensions/SkiaSharp/Fabulous.SkiaSharp.fsproj
@@ -12,9 +12,9 @@
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.5.2" />
     <PackageReference Update="FSharp.Core" Version="4.5.2" /> <!-- workaround for VSMac bug https://github.com/mono/monodevelop/pull/5137 --> 
-    <PackageReference Include="Xamarin.Forms" Version="3.0.0.482510" />
-    <PackageReference Include="SkiaSharp" Version="1.60.2" />
-    <PackageReference Include="SkiaSharp.Views.Forms" Version="1.60.2" />
+    <PackageReference Include="Xamarin.Forms" Version="3.1.0.697729" />
+    <PackageReference Include="SkiaSharp" Version="1.60.3" />
+    <PackageReference Include="SkiaSharp.Views.Forms" Version="1.60.3" />
     <ProjectReference Include="..\..\Fabulous.Core\Fabulous.Core.fsproj" />
   </ItemGroup>
 </Project>

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -8,8 +8,8 @@ group neutral
   source https://www.nuget.org/api/v2
   source https://www.myget.org/F/oxyplot
   nuget FSharp.Core 4.5.2
-  nuget Xamarin.Forms 3.0.0.482510
-  nuget Xamarin.Forms.Maps 3.0.0.482510
+  nuget Xamarin.Forms 3.1.0.697729
+  nuget Xamarin.Forms.Maps 3.1.0.697729
   nuget SkiaSharp
   nuget SkiaSharp.Views.Forms
   nuget OxyPlot.Core 2.0.0-unstable0956 # version matching last updated version of OxyPlot.Xamarin.Forms
@@ -22,8 +22,8 @@ group androidapp
   framework: monoandroid71
   source https://www.nuget.org/api/v2
   nuget FSharp.Core 4.5.2
-  nuget Xamarin.Forms 3.0.0.482510
-  nuget Xamarin.Android.FSharp.ResourceProvider 1.0.0.14
+  nuget Xamarin.Forms 3.1.0.697729
+  nuget Xamarin.Android.FSharp.ResourceProvider 1.0.0.25
   nuget Xamarin.Android.Arch.Core.Common 1.0.0.1
   nuget Xamarin.Android.Arch.Core.Runtime 1.0.0.1
   nuget Xamarin.Android.Arch.Lifecycle.Common 1.0.3.1
@@ -52,12 +52,12 @@ group iosapp
   framework: monotouch
   source https://www.nuget.org/api/v2
   nuget FSharp.Core 4.5.2
-  nuget Xamarin.Forms 3.0.0.482510
+  nuget Xamarin.Forms 3.1.0.697729
   nuget Newtonsoft.Json 11.0.2
 
 group macos
   framework: xamarinmac20
   source https://www.nuget.org/api/v2
   nuget FSharp.Core 4.5.2
-  nuget Xamarin.Forms 3.0.0.482510 
+  nuget Xamarin.Forms 3.1.0.697729
   nuget Newtonsoft.Json 11.0.2

--- a/paket.lock
+++ b/paket.lock
@@ -141,7 +141,7 @@ NUGET
     Xamarin.Android.Arch.Core.Runtime (1.0.0.1)
     Xamarin.Android.Arch.Lifecycle.Common (1.0.3.1)
     Xamarin.Android.Arch.Lifecycle.Runtime (1.0.3.1)
-    Xamarin.Android.FSharp.ResourceProvider (1.0.0.14)
+    Xamarin.Android.FSharp.ResourceProvider (1.0.0.25)
     Xamarin.Android.Support.Animated.Vector.Drawable (27.0.2.1)
     Xamarin.Android.Support.Annotations (27.0.2.1)
     Xamarin.Android.Support.Compat (27.0.2.1)
@@ -158,7 +158,7 @@ NUGET
     Xamarin.Android.Support.v7.Palette (27.0.2.1)
     Xamarin.Android.Support.v7.RecyclerView (27.0.2.1)
     Xamarin.Android.Support.Vector.Drawable (27.0.2.1)
-    Xamarin.Forms (3.0.0.482510)
+    Xamarin.Forms (3.1.0.697729)
       Xamarin.Android.Support.Design (>= 25.4.0.2)
       Xamarin.Android.Support.v4 (>= 25.4.0.2)
       Xamarin.Android.Support.v7.AppCompat (>= 25.4.0.2)
@@ -299,7 +299,7 @@ NUGET
     System.Xml.ReaderWriter (4.3.1)
     System.Xml.XDocument (4.3)
     System.Xml.XmlDocument (4.3)
-    Xamarin.Forms (3.0.0.482510)
+    Xamarin.Forms (3.1.0.697729)
 
 GROUP macos
 RESTRICTION: == xamarinmac
@@ -435,7 +435,7 @@ NUGET
     System.Xml.ReaderWriter (4.3.1)
     System.Xml.XDocument (4.3)
     System.Xml.XmlDocument (4.3)
-    Xamarin.Forms (3.0.0.482510)
+    Xamarin.Forms (3.1.0.697729)
 
 GROUP neutral
 RESTRICTION: == netstandard2.0
@@ -448,9 +448,9 @@ NUGET
     SkiaSharp.Views.Forms (1.60.2)
       SkiaSharp (>= 1.60.2)
       Xamarin.Forms (>= 2.5.0.280555)
-    Xamarin.Forms (3.0.0.482510)
-    Xamarin.Forms.Maps (3.0.0.482510)
-      Xamarin.Forms (>= 3.0.0.482510)
+    Xamarin.Forms (3.1.0.697729)
+    Xamarin.Forms.Maps (3.1.0.697729)
+      Xamarin.Forms (>= 3.1.0.697729)
   remote: https://www.myget.org/F/oxyplot
     OxyPlot.Xamarin.Forms (1.1.0-unstable0013)
       OxyPlot.Core (>= 2.0.0-unstable0956)

--- a/templates/content/blank/.template.config/template.json
+++ b/templates/content/blank/.template.config/template.json
@@ -131,7 +131,7 @@
             "type": "parameter",
             "dataType": "string",
             "replaces": "XamarinFormsSdk",
-            "defaultValue": "3.0.0.482510"
+            "defaultValue": "3.1.0.697729"
         },
         "FabulousPkgsVersion": {
             "type": "parameter",


### PR DESCRIPTION
Xamarin.Forms 3.1 has been stable for 3 months now, so I think we can update.

I've also updated the bindings with the new properties from https://developer.xamarin.com/releases/xamarin-forms/xamarin-forms-3.1/3.1.0/#whats-new-in-this-release

(PS: Paket does not seem to manage the packages of the .NET Standard projects, only the Android/iOS projects. Wouldn't it be better to make Paket handle everything?)

Closes #145 