### PR TITLE
Derive version from ReleaseNotes

### DIFF
--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -24,12 +24,7 @@ start Fabulous.sln
 
 ## Dev Notes - Releasing
 
-Before releasing a new version, the version number need to be updated in several places:
-
-* Add a new entry at the top of [RELEASE_NOTES.md](RELEASE_NOTES.md) (FAKE will use that version when building)
-* Replace the old version number in [tools.md](docs/tools.md)
-* Update the default value of `FabulousPkgsVersion` in [template.json](templates/content/blank/.template.config/template.json)
-* Replace the old version number in [LiveUpdate.fs](Fabulous.LiveUpdate/LiveUpdate.fs)
+Before releasing a new version, add a new entry at the top of [RELEASE_NOTES.md](RELEASE_NOTES.md) (FAKE will use that version when building).
 
 NB.: If you're releasing the same version, you might need to do the following first:
 * Run `git clean -xfd .`
@@ -47,7 +42,7 @@ On Windows:
 .\build NuGet
 ```
 
-FAKE will have updated all the `AssemblyInfo.fs` files. Commit all changes.
+FAKE will have updated all the `AssemblyInfo.fs` files and `template.json`. Commit all changes.
 
 Lastly, publish all the generated packages to NuGet by running these commands:
 

--- a/Fabulous.LiveUpdate/LiveUpdate.fs
+++ b/Fabulous.LiveUpdate/LiveUpdate.fs
@@ -154,7 +154,7 @@ type HttpServer(?port) =
         <pre>    cd MyApp\MyApp</pre>
         <pre>    %USERPROFILE%\.nuget\packages\Fabulous.LiveUpdate\FABULOUS_VERSION\tools\fscd.exe --watch --webhook:http://localhost:PORT/update</pre>
         <pre>    mono ~/.nuget/packages/Fabulous.LiveUpdate/FABULOUS_VERSION/tools/fscd.exe --watch --webhook:http://localhost:PORT/update</pre>
-        <p>in your project directoty</p>
+        <p>in your project directory</p>
     </body>
 </html>"""
                                         |> fun s -> s.Replace("FABULOUS_VERSION", AssemblyVersionInformation.AssemblyVersion)

--- a/Fabulous.LiveUpdate/LiveUpdate.fs
+++ b/Fabulous.LiveUpdate/LiveUpdate.fs
@@ -158,7 +158,7 @@ type HttpServer(?port) =
     </body>
 </html>"""
                                         |> fun s -> s.Replace("FABULOUS_VERSION", AssemblyVersionInformation.AssemblyVersion)
-                                        |> fun s -> s.Replace("PORT", string port)
+                                                     .Replace("PORT", string port)
                             }
 
                         printfn "LiveUpdate: setting response code to 200, response = %s" resString

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -42,17 +42,17 @@ Some manual set-up is required.  The following assumes your app is called `Squea
        Windows (Android):
 
            cd SqueakyApp\SqueakyApp
-           %USERPROFILE%\.nuget\packages\Fabulous.LiveUpdate\0.20.0\tools\fscd.exe --watch --webhook:http://localhost:9867/update 
+           %USERPROFILE%\.nuget\packages\Fabulous.LiveUpdate\<Fabulous version>\tools\fscd.exe --watch --webhook:http://localhost:9867/update 
 
        OSX (Android):
 
            cd SqueakyApp/SqueakyApp
-           mono ~/.nuget/packages/Fabulous.LiveUpdate/0.20.0/tools/fscd.exe --watch --webhook:http://localhost:9867/update  
+           mono ~/.nuget/packages/Fabulous.LiveUpdate/<Fabulous version>/tools/fscd.exe --watch --webhook:http://localhost:9867/update  
 
        OSX (iOS): Similar except use the explicit IP address of the emulator or device, e.g. 192.168.1.8, see the application log from launch
 
            cd SqueakyApp/SqueakyApp
-           mono ~/.nuget/packages/Fabulous.LiveUpdate/0.20.0/tools/fscd.exe --watch --webhook:http://192.168.1.8:9867/update
+           mono ~/.nuget/packages/Fabulous.LiveUpdate/<Fabulous version>/tools/fscd.exe --watch --webhook:http://192.168.1.8:9867/update
 
 Now, whenever you save a file in your core project directory, the `fscd.exe` daemon will attempt to recompile your changed file and
 send a representation of its contents to your app via a PUT request to the given webhook.  The app then deserializes this representation and

--- a/templates/content/blank/.template.config/template.json
+++ b/templates/content/blank/.template.config/template.json
@@ -1,322 +1,241 @@
-﻿{
-    "author": "fsprojects",
-    "classifications": [
-        "Fabulous",
-        "Mobile",
-        "Elmish",
-        "Cross-platform"
-    ],
-    "name": "Fabulous App",
-    "groupIdentity": "Fabulous.App",
-    "identity": "Fabulous.FSharp",
-    "shortName": "fabulous-app",
-    "tags": {
-        "language": "F#",
-        "type": "project"
+{
+  "author": "fsprojects",
+  "classifications": [
+    "Fabulous",
+    "Mobile",
+    "Elmish",
+    "Cross-platform"
+  ],
+  "name": "Fabulous App",
+  "groupIdentity": "Fabulous.App",
+  "identity": "Fabulous.FSharp",
+  "shortName": "fabulous-app",
+  "tags": {
+    "language": "F#",
+    "type": "project"
+  },
+  "sourceName": "NewApp",
+  "primaryOutputs": [
+    {
+      "path": "NewApp\\NewApp.fs"
     },
-    "sourceName": "NewApp",
-    "primaryOutputs": [
-        {
-            "path": "NewApp\\NewApp.fs"
-        },
-        {
-            "condition": "CreateAndroidProject",
-            "path": "NewApp.Android\\NewApp.Android.fsproj"
-        },
-        {
-            "condition": "CreateiOSProject",
-            "path": "NewApp.iOS\\NewApp.iOS.fsproj"
-        }
-        //{
-        //    "condition": "CreateBackendProject",
-        //    "path": "NewApp.MobileAppService\\NewApp.MobileAppService.fsproj"
-        //},
-        //{
-        //    "condition": "CreateUITestProject",
-        //    "path": "NewApp.UITests\\NewApp.UITests.fsproj"
-        //}
-    ],
-    "defaultName": "App",
-    "preferNameDirectory": "true",
-    "guids": [
-        "99E19497-29A6-4B77-B773-BEC55F9B55DC", // .NET Standard Library project identity
-        "8D9F8CF0-E178-402D-8D40-A88B7B5F3D42", // Android project identity
-        "91D74A40-E440-42AD-B51F-C2D641C49384", // iOS project identity
-        "B445DF73-AC9E-4276-9FBA-7CB5AD5D2518", // macOS project identity
-        "3EA9E612-E717-4E55-9034-C415CD62AF9A" // UWP project identity
-    ],
-    "symbols": {
-        "kind": {
-            "type": "parameter",
-            "datatype": "choice",
-            "defaultValue": "blank",
-            "choices": [
-                {
-                    "choice": "blank",
-                    "description": "An empty Fabulous app"
-                }
-            ]
-        },
-        "AppIdentifier": {
-            "type": "parameter",
-            "description": "Overrides the Info.plist's CFBundleIdentifier",
-            "datatype": "string",
-            "defaultValue": "com.companyname"
-        },
-        "AndroidAppIdentifier": {
-            "type": "parameter",
-            "description": "Overrides the package name in the AndroidManifest.xml",
-            "datatype": "string"
-        },
-        "iOSAppIdentifier": {
-            "type": "parameter",
-            "description": "Overrides the Info.plist's CFBundleIdentifier",
-            "datatype": "string"
-        },
-        "AndroidAppIdentifierReplacer": {
-            "type": "generated",
-            "generator": "coalesce",
-            "parameters": {
-                "sourceVariableName": "AndroidAppIdentifier",
-                "fallbackVariableName": "AppIdentifier"
-            },
-            "replaces": "com.companyname.NewApp.Android"
-        },
-        "iOSAppIdentifierReplacer": {
-            "type": "generated",
-            "generator": "coalesce",
-            "parameters": {
-                "sourceVariableName": "iOSAppIdentifier",
-                "fallbackVariableName": "AppIdentifier"
-            },
-            "replaces": "com.companyname.NewApp.iOS"
-        },
-        "WindowsSdk": {
-            "type": "parameter",
-            "description": "Windows SDK Target Version. Minimum Version is Fall Creator's Update (10.0.16278).",
-            "dataType": "string",
-            "replaces": "WindowsSdk"
-        },
-        "AndroidSDKVersion": {
-            "type": "parameter",
-            "datatype": "string",
-            "replaces": "AndroidSDKVersion",
-            "defaultValue": "v8.1"
-        },
-        "TargetAndroidAPI": {
-            "type": "parameter",
-            "datatype": "string",
-            "replaces": "TargetAndroidAPI",
-            "defaultValue": "27"
-        },
-        "MinAndroidAPI": {
-            "type": "parameter",
-            "datatype": "int",
-            "replaces": "MinAndroidAPI",
-            "defaultValue": "19"
-        },
-        "XamarinAndroidSdkVersion": {
-            "type": "parameter",
-            "datatype": "string",
-            "replaces": "XamarinAndroidSdkVersion",
-            "defaultValue": "27.0.2.1"
-        },
-        "XamarinEssentialsSdk": {
-            "type": "parameter",
-            "dataType": "string",
-            "replaces": "XamarinEssentialsSdk",
-            "defaultValue": "0.6.0-preview"
-        },
-        "XamarinFormsSdk": {
-            "type": "parameter",
-            "dataType": "string",
-            "replaces": "XamarinFormsSdk",
-            "defaultValue": "3.1.0.697729"
-        },
-        "FabulousPkgsVersion": {
-            "type": "parameter",
-            "dataType": "string",
-            "replaces": "FabulousPkgsVersion",
-            "defaultValue": "0.20.0"
-        },
-        "NewtonsoftJsonPkg": {
-            "type": "parameter",
-            "dataType": "string",
-            "replaces": "NewtonsoftJsonPkg",
-            "defaultValue": "11.0.2"
-        },
-        "XamarinAndroidFSharpResourceProviderPkg": {
-            "type": "parameter",
-            "dataType": "string",
-            "replaces": "XamarinAndroidFSharpResourceProviderPkg",
-            "defaultValue": "1.0.0.25"
-        },
-        "FSharpCorePkgVersion": {
-            "type": "parameter",
-            "dataType": "string",
-            "replaces": "FSharpCorePkgVersion",
-            "defaultValue": "4.5.2"
-        },
-        "ProjectID": {
-            "type": "generated",
-            "generator": "guid",
-            "replaces": "Project_ID"
-        },
-        "UserID": {
-            "type": "generated",
-            "generator": "guid",
-            "replaces": "User_ID"
-        },
-        // Project Symbols
-        //"CreateSharedProject": {
-        //    "type": "parameter",
-        //    "dataType": "bool",
-        //    "defaultValue": "true"
-        //},
-        "CreateiOSProject": {
-            "type": "parameter",
-            "dataType": "bool",
-            "defaultValue": "true"
-        },
-        "CreateMacProject": {
-            "type": "parameter",
-            "dataType": "bool",
-            "defaultValue": "false"
-        },
-        "CreateAndroidProject": {
-            "type": "parameter",
-            "dataType": "bool",
-            "defaultValue": "true"
-        }
-        //"CreateUWPProject": {
-        //    "type": "parameter",
-        //    "dataType": "bool",
-        //    "defaultValue": "true"
-        //},
-        //"CreateBackendProject": {
-        //    "type": "parameter",
-        //    "dataType": "bool",
-        //    "defaultValue": "false"
-        //},
-        //"CreateUITestProject": {
-        //    "type": "parameter",
-        //    "dataType": "bool",
-        //    "defaultValue": "false"
-       // }
+    {
+      "condition": "CreateAndroidProject",
+      "path": "NewApp.Android\\NewApp.Android.fsproj"
     },
-    "postActions": [
+    {
+      "condition": "CreateiOSProject",
+      "path": "NewApp.iOS\\NewApp.iOS.fsproj"
+    }
+  ],
+  "defaultName": "App",
+  "preferNameDirectory": "true",
+  "guids": [
+    "99E19497-29A6-4B77-B773-BEC55F9B55DC",
+    "8D9F8CF0-E178-402D-8D40-A88B7B5F3D42",
+    "91D74A40-E440-42AD-B51F-C2D641C49384",
+    "B445DF73-AC9E-4276-9FBA-7CB5AD5D2518",
+    "3EA9E612-E717-4E55-9034-C415CD62AF9A"
+  ],
+  "symbols": {
+    "kind": {
+      "type": "parameter",
+      "datatype": "choice",
+      "defaultValue": "blank",
+      "choices": [
         {
-            "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
-            "description": "Opens NewApp.fs in the editor.",
-            "manualInstructions": [],
-            "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
-            "args": {
-                "files": "0"
-            },
-            "continueOnError": true
+          "choice": "blank",
+          "description": "An empty Fabulous app"
         }
-    ],
-    "sources": [
+      ]
+    },
+    "AppIdentifier": {
+      "type": "parameter",
+      "description": "Overrides the Info.plist's CFBundleIdentifier",
+      "datatype": "string",
+      "defaultValue": "com.companyname"
+    },
+    "AndroidAppIdentifier": {
+      "type": "parameter",
+      "description": "Overrides the package name in the AndroidManifest.xml",
+      "datatype": "string"
+    },
+    "iOSAppIdentifier": {
+      "type": "parameter",
+      "description": "Overrides the Info.plist's CFBundleIdentifier",
+      "datatype": "string"
+    },
+    "AndroidAppIdentifierReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "AndroidAppIdentifier",
+        "fallbackVariableName": "AppIdentifier"
+      },
+      "replaces": "com.companyname.NewApp.Android"
+    },
+    "iOSAppIdentifierReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "iOSAppIdentifier",
+        "fallbackVariableName": "AppIdentifier"
+      },
+      "replaces": "com.companyname.NewApp.iOS"
+    },
+    "WindowsSdk": {
+      "type": "parameter",
+      "description": "Windows SDK Target Version. Minimum Version is Fall Creator's Update (10.0.16278).",
+      "dataType": "string",
+      "replaces": "WindowsSdk"
+    },
+    "AndroidSDKVersion": {
+      "type": "parameter",
+      "datatype": "string",
+      "replaces": "AndroidSDKVersion",
+      "defaultValue": "v8.1"
+    },
+    "TargetAndroidAPI": {
+      "type": "parameter",
+      "datatype": "string",
+      "replaces": "TargetAndroidAPI",
+      "defaultValue": "27"
+    },
+    "MinAndroidAPI": {
+      "type": "parameter",
+      "datatype": "int",
+      "replaces": "MinAndroidAPI",
+      "defaultValue": "19"
+    },
+    "XamarinAndroidSdkVersion": {
+      "type": "parameter",
+      "datatype": "string",
+      "replaces": "XamarinAndroidSdkVersion",
+      "defaultValue": "27.0.2.1"
+    },
+    "XamarinEssentialsSdk": {
+      "type": "parameter",
+      "dataType": "string",
+      "replaces": "XamarinEssentialsSdk",
+      "defaultValue": "0.6.0-preview"
+    },
+    "XamarinFormsSdk": {
+      "type": "parameter",
+      "dataType": "string",
+      "replaces": "XamarinFormsSdk",
+      "defaultValue": "3.1.0.697729"
+    },
+    "FabulousPkgsVersion": {
+      "type": "parameter",
+      "dataType": "string",
+      "replaces": "FabulousPkgsVersion",
+      "defaultValue": "0.20.0"
+    },
+    "NewtonsoftJsonPkg": {
+      "type": "parameter",
+      "dataType": "string",
+      "replaces": "NewtonsoftJsonPkg",
+      "defaultValue": "11.0.2"
+    },
+    "XamarinAndroidFSharpResourceProviderPkg": {
+      "type": "parameter",
+      "dataType": "string",
+      "replaces": "XamarinAndroidFSharpResourceProviderPkg",
+      "defaultValue": "1.0.0.25"
+    },
+    "FSharpCorePkgVersion": {
+      "type": "parameter",
+      "dataType": "string",
+      "replaces": "FSharpCorePkgVersion",
+      "defaultValue": "4.5.2"
+    },
+    "ProjectID": {
+      "type": "generated",
+      "generator": "guid",
+      "replaces": "Project_ID"
+    },
+    "UserID": {
+      "type": "generated",
+      "generator": "guid",
+      "replaces": "User_ID"
+    },
+    "CreateiOSProject": {
+      "type": "parameter",
+      "dataType": "bool",
+      "defaultValue": "true"
+    },
+    "CreateMacProject": {
+      "type": "parameter",
+      "dataType": "bool",
+      "defaultValue": "false"
+    },
+    "CreateAndroidProject": {
+      "type": "parameter",
+      "dataType": "bool",
+      "defaultValue": "true"
+    }
+  },
+  "postActions": [
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens NewApp.fs in the editor.",
+      "manualInstructions": [],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "args": {
+        "files": "0"
+      },
+      "continueOnError": true
+    }
+  ],
+  "sources": [
+    {
+      "modifiers": [
         {
-            "modifiers": [
-                //{
-                //    "condition": "(!CreateSharedProject)",
-                //    "exclude": "NewApp/**/*"
-                //},
-                {
-                    "condition": "(!CreateiOSProject)",
-                    "exclude": [
-                        "NewApp.iOS/**/*"
-                    ]
-                },
-                {
-                    "condition": "(!CreateAndroidProject)",
-                    "exclude": [
-                        "NewApp.Android/**/*"
-                    ]
-                },
-                ////{
-                //    "condition": "(!CreateUWPProject)",
-                //    "exclude": [
-                //        "NewApp.UWP/**/*"
-                //    ]
-                //},
-                {
-                    "condition": "(!CreateMacProject)",
-                    "exclude": [
-                        "NewApp.macOS/**/*"
-                    ]
-                }
-            ]
+          "condition": "(!CreateiOSProject)",
+          "exclude": [
+            "NewApp.iOS/**/*"
+          ]
         },
         {
-            "source": "./",
-            "condition": "(kind == \"blank\")",
-            "modifiers": [
-                //{
-                //    "condition": "CreateSharedProject",
-                //    "exclude": [
-                //        "NewApp/NewApp.fsproj"
-                //    ]
-                //},
-                //{
-                //    "condition": "(!CreateSharedProject)",
-                //    "exclude": [
-                //        "NewApp/NewApp.projitems"
-                //    ]
-                //},
-                {
-                    "condition": "(!CreateiOSProject)",
-                    "exclude": [
-                        "NewApp.iOS/**/*"
-                    ]
-                },
-                {
-                    "condition": "(!CreateAndroidProject)",
-                    "exclude": [
-                        "NewApp.Android/**/*"
-                    ]
-                },
-                //{
-                //    "condition": "(!CreateUWPProject)",
-                //    "exclude": [
-                //        "NewApp.UWP/**/*"
-                 //   ]
-                //},
-                {
-                    "condition": "(!CreateMacProject)",
-                    "exclude": [
-                        "NewApp.macOS/**/*"
-                    ]
-                }
-            ],
-            "copyOnly": [
-                "**/*.targets"
-            ]
+          "condition": "(!CreateAndroidProject)",
+          "exclude": [
+            "NewApp.Android/**/*"
+          ]
+        },
+        {
+          "condition": "(!CreateMacProject)",
+          "exclude": [
+            "NewApp.macOS/**/*"
+          ]
         }
-        //,
-        //{
-        //    "source": "../uitest/",
-        //    "condition": "CreateUITestProject",
-        //    "target": "NewApp.UITests/",
-        //    "modifiers": [
-        //        {
-        //            "condition": "(kind == \"blank\")",
-        //            "exclude": [
-        //                "Pages/**/*",
-        //                "Tests/**/*"
-        //            ],
-        //            "rename": {
-        //                "BlankAppTests.cs": "Tests.cs"
-        //            }
-        //        },
-        //        {
-        //            "condition": "(kind == \"master-detail\")",
-        //            "exclude": [
-        //                "BlankAppTests.cs"
-        //            ]
-        //        }
-        //    ]
-        //}
-    ]
+      ]
+    },
+    {
+      "source": "./",
+      "condition": "(kind == \"blank\")",
+      "modifiers": [
+        {
+          "condition": "(!CreateiOSProject)",
+          "exclude": [
+            "NewApp.iOS/**/*"
+          ]
+        },
+        {
+          "condition": "(!CreateAndroidProject)",
+          "exclude": [
+            "NewApp.Android/**/*"
+          ]
+        },
+        {
+          "condition": "(!CreateMacProject)",
+          "exclude": [
+            "NewApp.macOS/**/*"
+          ]
+        }
+      ],
+      "copyOnly": [
+        "**/*.targets"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Fixes #171 

LiveUpdate.fs can use its own AssemblyInfo version at runtime.
For tools.md, I replaced with a generic `<Fabulous version>`.
For the last one, I still need to learn FAKE before being able to automate template.json

TODO:
* [x] LiveUpdate.fs
* [x] tools.md
* [x] template.json