### PR TITLE
Fixed Fabulous.Maps package

### DIFF
--- a/extensions/Maps/paket.template
+++ b/extensions/Maps/paket.template
@@ -17,4 +17,4 @@ dependencies
   FSharp.Core >= LOCKEDVERSION-neutral
   Xamarin.Forms >= LOCKEDVERSION-neutral
   Xamarin.Forms.Maps >= LOCKEDVERSION-neutral
-  Fabulous ~> CURRENTVERSION
+  Fabulous.Core ~> CURRENTVERSION


### PR DESCRIPTION
Fabulous.Maps paket.template was referencing `Fabulous` which does not exist.
Thanks draganjovanovic1 to notice it.