### PR TITLE
Fixed Generator + Added Fake target to run it

### DIFF
--- a/DEVGUIDE.md
+++ b/DEVGUIDE.md
@@ -41,6 +41,23 @@ It is recommended to run this command at least once before working on Fabulous.
 
 Alternatively, you can run `.paket/paket.exe restore` and `dotnet restore` to ensure that you have all the dependencies before opening Visual Studio.
 
+## Dev Notes - Running the generator
+
+The Generator is built and run as part of the default build command
+If you only want to build the tools and run the generator, use the following commands:
+
+On OSX:
+
+```
+./build.sh RunGenerator
+```
+
+On Windows:
+
+```
+.\build RunGenerator
+```
+
 ## Dev Notes - Testing
 
 On OSX:

--- a/build.fsx
+++ b/build.fsx
@@ -50,12 +50,12 @@ let removeIncompatiblePlatformProjects pattern =
         pattern
 
 let projects = [
-    { Name = "Tools";       Path = !! "tools/**/*.fsproj";      Action = MSBuild Release;    OutputPath = buildDir + "/tools" }
     { Name = "Src";         Path = !! "src/**/*.fsproj";        Action = DotNetPack;         OutputPath = buildDir }
     { Name = "Extensions";  Path = !! "extensions/**/*.fsproj"; Action = DotNetPack;         OutputPath = buildDir }
     { Name = "Tests";       Path = !! "tests/**/*.fsproj";      Action = MSBuild Release;    OutputPath = buildDir + "/tests" }
     { Name = "Templates";   Path = !! "templates/**/*.nuspec";  Action = NuGetPack;          OutputPath = buildDir }
 ]
+let tools = { Name = "Tools"; Path = !! "tools/**/*.fsproj"; Action = MSBuild Release; OutputPath = buildDir + "/tools" }
 let samples = { Name = "Samples"; Path = (!! "samples/**/*.fsproj" |> removeIncompatiblePlatformProjects); Action = MSBuild Debug; OutputPath = buildDir + "/samples" } 
 
 
@@ -128,17 +128,20 @@ Target.create "Restore" (fun _ ->
     DotNet.restore id "Fabulous.sln"
 )
 
+Target.create "BuildTools" (fun _ ->
+    tools |> buildProject
+)
+
+Target.create "RunGenerator" (fun _ ->
+    DotNet.exec id "build_output/tools/Generator/Generator.dll" "tools/Generator/Xamarin.Forms.Core.json src/Fabulous.Core/Xamarin.Forms.Core.fs" |> ignore
+)
+
 Target.create "Build" (fun _ -> 
     projects |> List.iter buildProject
 )
 
 Target.create "BuildSamples" (fun _ ->
     samples |> buildProject
-)
-
-Target.create "RunGenerator" (fun _ ->
-    DotNet.build (fun p -> { p with Configuration = DotNet.BuildConfiguration.Release }) "tools/Generator/Generator.fsproj"
-    DotNet.exec id "tools/Generator/bin/Release/netcoreapp2.0/Generator.dll" "tools/Generator/Xamarin.Forms.Core.json src/Fabulous.Core/Xamarin.Forms.Core.fs" |> ignore
 )
 
 Target.create "RunTests" (fun _ ->
@@ -196,6 +199,8 @@ open Fake.Core.TargetOperators
 "Clean"
   ==> "Restore"
   ==> "UpdateVersion"
+  ==> "BuildTools"
+  ==> "RunGenerator"
   ==> "Build"
 
 "Build"

--- a/build.fsx
+++ b/build.fsx
@@ -133,7 +133,7 @@ Target.create "BuildTools" (fun _ ->
 )
 
 Target.create "RunGenerator" (fun _ ->
-    DotNet.exec id "build_output/tools/Generator/Generator.dll" "tools/Generator/Xamarin.Forms.Core.json src/Fabulous.Core/Xamarin.Forms.Core.fs" |> ignore
+    DotNet.exec id (tools.OutputPath + "/Generator/Generator.dll") "tools/Generator/Xamarin.Forms.Core.json src/Fabulous.Core/Xamarin.Forms.Core.fs" |> ignore
 )
 
 Target.create "Build" (fun _ -> 

--- a/build.fsx
+++ b/build.fsx
@@ -136,6 +136,11 @@ Target.create "BuildSamples" (fun _ ->
     samples |> buildProject
 )
 
+Target.create "RunGenerator" (fun _ ->
+    DotNet.build (fun p -> { p with Configuration = DotNet.BuildConfiguration.Release }) "tools/Generator/Generator.fsproj"
+    DotNet.exec id "tools/Generator/bin/Release/netcoreapp2.0/Generator.dll" "tools/Generator/Xamarin.Forms.Core.json src/Fabulous.Core/Xamarin.Forms.Core.fs" |> ignore
+)
+
 Target.create "RunTests" (fun _ ->
     !! (buildDir + "/tests/*test*.dll")
     -- "**/*TestAdapter*.dll"

--- a/tools/Generator/Generator.fsproj
+++ b/tools/Generator/Generator.fsproj
@@ -8,6 +8,7 @@
         <Compile Include="Program.fs" />
     </ItemGroup>
     <ItemGroup>
+        <PackageReference Include="FSharp.Core" />
         <PackageReference Include="Mono.Cecil" />
         <PackageReference Include="Newtonsoft.Json" />
     </ItemGroup>

--- a/tools/Generator/Program.fs
+++ b/tools/Generator/Program.fs
@@ -2,7 +2,7 @@
 
 // Windows: dotnet build -c Release tools\Generator\Generator.fsproj && dotnet tools\Generator\bin\Release\netcoreapp2.0\Generator.dll tools\Generator\Xamarin.Forms.Core.json src\Fabulous.Core\Xamarin.Forms.Core.fs
 
-// OSX: dotnet build -c Release Generator/Generator.fsproj && dotnet Generator/bin/Release/netcoreapp2.0/Generator.dll Generator/Xamarin.Forms.Core.json Fabulous.Core/Xamarin.Forms.Core.fs
+// OSX: dotnet build -c Release tools/Generator/Generator.fsproj && dotnet tools/Generator/bin/Release/netcoreapp2.0/Generator.dll tools/Generator/Xamarin.Forms.Core.json src/Fabulous.Core/Xamarin.Forms.Core.fs
 
 module Generator
 


### PR DESCRIPTION
- FSharp.Core was missing in the references of the Generator project
- Updated the manual generator build/run instructions inside the Program.fs file
- Included a new FAKE target that will generate Xamarin.Forms.Core.fs at each build
- Added documentation in the contributor guide