### PR TITLE
improve exception protection

### DIFF
--- a/src/Fabulous.Core/ElmishProgram.fs
+++ b/src/Fabulous.Core/ElmishProgram.fs
@@ -156,7 +156,7 @@ type ProgramRunner<'model, 'msg>(app: Application, program: Program<'model, 'msg
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module Program =
     let internal onError (text: string, ex: exn) = 
-        Debug.WriteLine (sprintf "%s: %A" text ex)
+        Console.WriteLine (sprintf "%s: %A" text ex)
 
     /// Typical program, new commands are produced by `init` and `update` along with the new state.
     let mkProgram init update view =

--- a/src/Fabulous.Core/ElmishProgram.fs
+++ b/src/Fabulous.Core/ElmishProgram.fs
@@ -82,7 +82,12 @@ type ProgramRunner<'model, 'msg>(app: Application, program: Program<'model, 'msg
             lastViewDataOpt <- Some viewInfo
 
         | Some prevPageElement ->
-            let newPageElement = program.view updatedModel dispatch
+            let newPageElement = 
+                try program.view updatedModel dispatch
+                with ex -> 
+                    program.onError ("Unable to evaluate view:", ex)
+                    prevPageElement
+
             if canReuseChild prevPageElement newPageElement then
                 newPageElement.UpdateIncremental (prevPageElement, app.MainPage)
             else
@@ -109,7 +114,10 @@ type ProgramRunner<'model, 'msg>(app: Application, program: Program<'model, 'msg
 
         Debug.WriteLine "dispatching initial commands"
         for sub in (program.subscribe initialModel @ cmd) do
-            sub dispatch
+            try 
+                sub dispatch
+            with ex ->
+                program.onError ("Error executing commands:", ex)
 
     member __.InitialMainPage = mainPage
 

--- a/src/Fabulous.LiveUpdate/LiveUpdate.fs
+++ b/src/Fabulous.LiveUpdate/LiveUpdate.fs
@@ -204,13 +204,27 @@ module Extensions =
 
             let switchD (files: DFile[]) =
               lock interp (fun () -> 
-                for file in files do
-                    printfn "LiveUpdate: adding declarations...."
-                    interp.AddDecls file.Code
+                let res = 
+                    try 
+                        for file in files do
+                            printfn "LiveUpdate: adding declarations...."
+                            interp.AddDecls file.Code
 
-                for file in files do
-                    printfn "LiveUpdate: evaluating decls in code package for side effects...."
-                    interp.EvalDecls (envEmpty, file.Code)
+                        for file in files do
+                            printfn "LiveUpdate: evaluating decls in code package for side effects...."
+                            interp.EvalDecls (envEmpty, file.Code)
+                        Result.Ok ()
+                    with exn -> 
+                        Result.Error exn
+
+                match res with 
+                | Result.Error exn -> 
+                    printfn "*** LiveUpdate failure:"
+                    printfn "***   [x] got code pacakge"
+                    printfn "***   FAIL: the evaluation of the decalarations in the code package failed: %A" exn
+                    { Quacked = sprintf "couldn't quack! the evaluation of the decalarations in the code package failed: %A" exn }
+
+                | Result.Ok () -> 
 
                 match files.Length with 
                 | 0 -> { Quacked = "couldn't quack! Files were empty!" }


### PR DESCRIPTION
This fixes #121 by improving protection against uncaught exceptions from LiveUpdate evaluation and exceptions when evaluating the `view` function

Note that when the `view` function raises an exception then the previous view will just be used instead, but the exception will have been printed to stdout
