### PR TITLE
Templates - Fix build warnings Microsoft.CSharp

### DIFF
--- a/templates/content/blank/NewApp.Android/NewApp.Android.fsproj
+++ b/templates/content/blank/NewApp.Android/NewApp.Android.fsproj
@@ -181,7 +181,7 @@
       <HintPath>..\packages/Fabulous.LiveUpdate.FabulousPkgsVersion/lib/netstandard2.0/Fabulous.LiveUpdate.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages/Newtonsoft.Json.NewtonsoftJsonPkg/lib/netstandard1.3/Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages/Newtonsoft.Json.NewtonsoftJsonPkg/lib/netstandard2.0/Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Essentials">
       <HintPath>..\packages/Xamarin.Essentials.0.6.0-preview/lib/monoandroid71/Xamarin.Essentials.dll</HintPath>

--- a/templates/content/blank/NewApp.iOS/NewApp.iOS.fsproj
+++ b/templates/content/blank/NewApp.iOS/NewApp.iOS.fsproj
@@ -173,7 +173,7 @@
       <HintPath>..\packages\Fabulous.LiveUpdate.FabulousPkgsVersion\lib\netstandard2.0\Fabulous.LiveUpdate.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.NewtonsoftJsonPkg\lib\netstandard1.3\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.NewtonsoftJsonPkg\lib\netstandard2.0\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Essentials">
       <HintPath>..\packages\Xamarin.Essentials.0.6.0-preview\lib\monoandroid71\Xamarin.Essentials.dll</HintPath>


### PR DESCRIPTION
Started to work on #172 

The `Microsoft.CSharp` warning was due to referencing the wrong `Newtonsoft.Json` framework.
.NET Standard 1.3 was used instead of .NET Standard 2.0 (which doesn't require Microsoft.CSharp anymore)

The warning about `System.Runtime` remains.
Tried to use binding redirects but with no effect.

According to MSBuild, the conflict comes from the facades dll of MonoAndroid and FSharp.Core.
Both referencing a different version of System.Runtime.
```
/Library/Frameworks/Mono.framework/Versions/5.12.0/lib/mono/msbuild/15.0/bin/Microsoft.Common.CurrentVersion.targets(2126,5): warning MSB3277: Found conflicts between different versions of "System.Runtime" that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed. [/Git/Test/test172/test172.Android/test172.Android.fsproj]

There was a conflict between "System.Runtime, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" and "System.Runtime, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a".
      "System.Runtime, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" was chosen because it was primary and "System.Runtime, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" was not.
      References which depend on "System.Runtime, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" [/Library/Frameworks/Mono.framework/External/xbuild-frameworks/MonoAndroid/v1.0/Facades/System.Runtime.dll].
          /Library/Frameworks/Mono.framework/External/xbuild-frameworks/MonoAndroid/v1.0/Facades/System.Runtime.dll
            Project file item includes which caused reference "/Library/Frameworks/Mono.framework/External/xbuild-frameworks/MonoAndroid/v1.0/Facades/System.Runtime.dll".
              System.Runtime
      References which depend on "System.Runtime, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" [].
          /Git/Test/test172/packages/Fabulous.Core.0.24.0/lib/netstandard2.0/Fabulous.Core.dll
            Project file item includes which caused reference "/Git/Test/test172/packages/Fabulous.Core.0.24.0/lib/netstandard2.0/Fabulous.Core.dll".
              /Git/Test/test172/test172/bin/Debug/netstandard2.0/test172.dll
              Fabulous.Core
              Fabulous.LiveUpdate
          /Git/Test/test172/test172.Android/bin/Debug/FSharp.Core.dll
            Project file item includes which caused reference "/Git/Test/test172/test172.Android/bin/Debug/FSharp.Core.dll".
              /Git/Test/test172/test172/bin/Debug/netstandard2.0/test172.dll
              Fabulous.Core
              Fabulous.LiveUpdate
          /Git/Test/test172/packages/Fabulous.LiveUpdate.0.24.0/lib/netstandard2.0/Fabulous.LiveUpdate.dll
            Project file item includes which caused reference "/Git/Test/test172/packages/Fabulous.LiveUpdate.0.24.0/lib/netstandard2.0/Fabulous.LiveUpdate.dll".
              Fabulous.LiveUpdate
```

Any idea?