### PR TITLE
Comestic fix to NuGet packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,12 +2,12 @@
   <!-- NuGet Specs -->
   <PropertyGroup>
     <Version>0.25.0</Version>
-    <Description>Added "CurrentPage" and "CurrentPageChanged" to TabbedPage and CarouselPage (https://github.com/fsprojects/Fabulous/pull/215)
-Added support for byte array with Image.Source (https://github.com/fsprojects/Fabulous/pull/217)
-Improved exception protection in LiveUpdate (https://github.com/fsprojects/Fabulous/pull/214)
-Fixed an issue in LiveUpdate preventing the use of some kinds of discriminated unions (https://github.com/fsprojects/Fabulous/pull/213)</Description>
     <Authors>Fabulous Contributors</Authors>
     <PackageVersion>0.25.0</PackageVersion>
+    <PackageReleaseNotes>Added "CurrentPage" and "CurrentPageChanged" to TabbedPage and CarouselPage (https://github.com/fsprojects/Fabulous/pull/215)
+Added support for byte array with Image.Source (https://github.com/fsprojects/Fabulous/pull/217)
+Improved exception protection in LiveUpdate (https://github.com/fsprojects/Fabulous/pull/214)
+Fixed an issue in LiveUpdate preventing the use of some kinds of discriminated unions (https://github.com/fsprojects/Fabulous/pull/213)</PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
     <PackageLicenseUrl>https://github.com/fsprojects/Fabulous/blob/master/LICENSE.md</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/fsprojects/Fabulous</PackageProjectUrl>

--- a/build.fsx
+++ b/build.fsx
@@ -105,7 +105,7 @@ Target.create "UpdateVersion" (fun _ ->
     let props = "./Directory.Build.props"
     Xml.loadDoc props
     |> Xml.replaceXPath "//Version/text()" release.AssemblyVersion
-    |> Xml.replaceXPath "//Description/text()" (String.toLines release.Notes)
+    |> Xml.replaceXPath "//PackageReleaseNotes/text()" (String.toLines release.Notes)
     |> Xml.replaceXPath "//PackageVersion/text()" release.NugetVersion
     |> Xml.saveDoc props
 

--- a/src/Fabulous.Core/Fabulous.Core.fsproj
+++ b/src/Fabulous.Core/Fabulous.Core.fsproj
@@ -5,6 +5,7 @@
     </PropertyGroup>
     <PropertyGroup>
         <PackageId>Fabulous.Core</PackageId>
+        <Description>F# Functional App Dev Framework</Description>
     </PropertyGroup>
     <ItemGroup>
         <Compile Include="ViewElement.fs" />

--- a/src/Fabulous.LiveUpdate/Fabulous.LiveUpdate.fsproj
+++ b/src/Fabulous.LiveUpdate/Fabulous.LiveUpdate.fsproj
@@ -5,6 +5,7 @@
     </PropertyGroup>
     <PropertyGroup>
         <PackageId>Fabulous.LiveUpdate</PackageId>
+        <Description>F# Functional App Dev Framework Live Update</Description>
         <PackageTags>LiveUpdate;Android;iOS</PackageTags>
     </PropertyGroup>
     <ItemGroup>


### PR DESCRIPTION
Release notes were set as description for NuGet packages, leading to some issues (no actual description for Fabulous.Core and Fabulous.LiveUpdate, and no release notes for the extensions).
Changed it to be correctly put in the "Release notes" category instead.
