### PR TITLE
Fixed ViewRef<T>.TryValue

### DIFF
--- a/samples/AllControls/AllControls/AllControls.fs
+++ b/samples/AllControls/AllControls/AllControls.fs
@@ -215,8 +215,11 @@ module App =
             Application.Current.MainPage.DisplayAlert("Clicked", "You clicked the button", "OK") |> ignore
             model
         | AnimationPoked -> 
-            animatedLabelRef.Value.Rotation <- 0.0
-            animatedLabelRef.Value.RotateTo (360.0, 2000u) |> ignore
+            match animatedLabelRef.TryValue with
+            | Some animated ->
+                animatedLabelRef.Value.Rotation <- 0.0
+                animatedLabelRef.Value.RotateTo (360.0, 2000u) |> ignore
+            | None -> ()
             model
         | AnimationPoked2 -> 
             ViewExtensions.CancelAnimations (animatedLabelRef.Value)

--- a/src/Fabulous.Core/ViewElement.fs
+++ b/src/Fabulous.Core/ViewElement.fs
@@ -156,7 +156,7 @@ and ViewRef<'T when 'T : not struct>() =
 
     member __.TryValue : 'T option = 
         match handle.TryValue with 
-        | Some res -> unbox res 
+        | Some res -> Some (unbox res)
         | _ -> None
 
 


### PR DESCRIPTION
Fixes #234 

ViewRef<T>.TryValue was incorrectly unboxing an object into `'T` and returning it directly, instead of wrapping it into a `'T option`.
The compiler inferred that the control was already an option, which it was not thus the exception.