### PR TITLE
Add json bindings formatting in build process

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -98,6 +98,19 @@ Target.create "Clean" (fun _ ->
     Shell.cleanDir buildDir
 )
 
+Target.create "Restore" (fun _ ->
+    Paket.restore id
+    DotNet.restore id "Fabulous.sln"
+)
+
+Target.create "FormatBindings" (fun _ ->
+    for binding in !! "tools/Generator/*.json" do
+        File.ReadAllText binding
+        |> JToken.Parse
+        |> (fun token -> token.ToString(Formatting.Indented))
+        |> (fun json -> File.WriteAllText(binding, json))
+)
+
 Target.create "UpdateVersion" (fun _ ->
     // Updates Directory.Build.props
     let props = "./Directory.Build.props"
@@ -119,11 +132,6 @@ Target.create "UpdateVersion" (fun _ ->
         )
         |> (fun o -> JsonConvert.SerializeObject(o, Formatting.Indented))
         |> File.writeString false template
-)
-
-Target.create "Restore" (fun _ ->
-    Paket.restore id
-    DotNet.restore id "Fabulous.sln"
 )
 
 Target.create "BuildControls" (fun _ ->
@@ -200,6 +208,7 @@ open Fake.Core.TargetOperators
 
 "Clean"
   ==> "Restore"
+  ==> "FormatBindings"
   ==> "UpdateVersion"
   ==> "BuildTools"
   ==> "BuildControls"

--- a/tools/Generator/Xamarin.Forms.Core.json
+++ b/tools/Generator/Xamarin.Forms.Core.json
@@ -3,1053 +3,1046 @@
     "packages/neutral/Xamarin.Forms/lib/netstandard1.0/Xamarin.Forms.Core.dll",
     "build_output/controls/Fabulous.CustomControls/Fabulous.CustomControls.dll"
   ],
-	"outputNamespace": "Fabulous.DynamicViews",
-	"types": [
-		{
-			"name": "Xamarin.Forms.Element",
-			"members": [
-				{
-					"name": "ClassId",
-					"defaultValue": "null"
-				},
-				{
-					"name": "StyleId",
-					"defaultValue": "null"
-				},
-				{  
-				  "name": "AutomationId",  
-				  "defaultValue": "null"  
-				},
-				{  
-				  "name": "Created",  
-					"uniqueName": "ElementCreated",
-					"inputType": "obj -> unit",
-					"modelType": "obj -> unit",
-					"updateCode": "(fun _ _ _ -> ())"
-				},
-				{  
-				  "name": "Ref",  
-					"uniqueName": "ElementViewRef",
-					"inputType": "ViewRef",
-					"modelType": "ViewRef",
-					"updateCode": "(fun _ _ _ -> ())"
-				} 
-			]
-		},
-		{
-			"name": "Xamarin.Forms.VisualElement",
-			"members": [
-				{
-					"name": "AnchorX",
-					"defaultValue": "0.0"
-				},
-				{
-					"name": "AnchorY",
-					"defaultValue": "0.0"
-				},
-				{
-					"name": "BackgroundColor",
-					"defaultValue": "Xamarin.Forms.Color.Default"
-				},
-				{
-					"name": "HeightRequest",
-					"defaultValue": "-1.0"
-				},
-				{
-					"name": "InputTransparent",
-					"defaultValue": "false"
-				},
-				{
-					"name": "IsEnabled",
-					"defaultValue": "true"
-				},
-				{
-					"name": "IsVisible",
-					"defaultValue": "true"
-				},
-				{
-					"name": "MinimumHeightRequest",
-					"defaultValue": "-1.0"
-				},
-				{
-					"name": "MinimumWidthRequest",
-					"defaultValue": "-1.0"
-				},
-				{
-					"name": "Opacity",
-					"defaultValue": "1.0"
-				},
-				{
-					"name": "Rotation",
-					"defaultValue": "0.0"
-				},
-				{
-					"name": "RotationX",
-					"defaultValue": "0.0"
-				},
-				{
-					"name": "RotationY",
-					"defaultValue": "0.0"
-				},
-				{
-					"name": "Scale",
-					"defaultValue": "1.0"
-				},
-				{
-					"name": "Style",
-					"defaultValue": "null"
-				},
-				{
-					"name": "StyleClass",
-					"defaultValue": "null",
-					"inputType": "obj",
-					"modelType": "System.Collections.Generic.IList<string>",
-					"convToModel": "makeStyleClass",
-					"updateCode":  "updateStyleClass"
-				},
-				{
-					"name": "TranslationX",
-					"defaultValue": "0.0"
-				},
-				{
-					"name": "TranslationY",
-					"defaultValue": "0.0"
-				},
-				{
-					"name": "WidthRequest",
-					"defaultValue": "-1.0"
-				},
-				{
-					"name": "Resources",
-					"defaultValue": "null",
-					"inputType": "(string * obj) list",
-					"modelType": "(string * obj) list",
-					"updateCode": "updateResources"
-				},
-				{
-					"name": "Styles",
-					"defaultValue": "null",
-					"inputType": "Xamarin.Forms.Style list",
-					"modelType": "Xamarin.Forms.Style list",
-					"updateCode": "updateStyles"
-				},
-				{
-					"name": "StyleSheets",
-					"defaultValue": "null",
-					"inputType": "Xamarin.Forms.StyleSheets.StyleSheet list",
-					"modelType": "Xamarin.Forms.StyleSheets.StyleSheet list",
-					"updateCode": "updateStyleSheets"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.View",
-			"members": [
-				{
-					"name": "HorizontalOptions",
-					"defaultValue": "Xamarin.Forms.LayoutOptions.Fill"
-				},
-				{
-					"name": "VerticalOptions",
-					"defaultValue": "Xamarin.Forms.LayoutOptions.Fill"
-				},
-				{
-					"name": "Margin",
-					"inputType": "obj",
-					"modelType": "Xamarin.Forms.Thickness",
-					"convToModel": "makeThickness",
-					"defaultValue": "Unchecked.defaultof<Xamarin.Forms.Thickness>"
-				},
-				{
-					"name": "GestureRecognizers",
-					"defaultValue": "null",
-					"inputType": "ViewElement list",
-					"modelType": "ViewElement[]",
-					"convToModel": "Array.ofList"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.IGestureRecognizer",
-			"members": [
-			]
-		},
-		{
-			"name": "Xamarin.Forms.PanGestureRecognizer",
-			"members": [
-				{
-					"name": "TouchPoints",
-					"defaultValue": "1"
-				},
-				{
-					"name": "PanUpdated",
-					"defaultValue": "null",
-					"inputType": "Xamarin.Forms.PanUpdatedEventArgs -> unit",
-					"convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.PanUpdatedEventArgs>(fun _sender args -> f args))"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.TapGestureRecognizer",
-			"members": [
-				{
-					"name": "Command",
-					"defaultValue": "null",
-					"inputType": "unit -> unit",
-					"convToModel": "makeCommand"
-				},
-				{
-					"name": "NumberOfTapsRequired",
-					"defaultValue": "1"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.ClickGestureRecognizer",
-			"members": [
-				{
-					"name": "Command",
-					"defaultValue": "null",
-					"inputType": "unit -> unit",
-					"convToModel": "makeCommand"
-				},
-				{
-					"name": "NumberOfClicksRequired",
-					"defaultValue": "1"
-				},
-				{
-					"name": "Buttons",
-					"defaultValue": "Xamarin.Forms.ButtonsMask.Primary"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.PinchGestureRecognizer",
-			"members": [
-				{
-					"name": "IsPinching",
-					"defaultValue": "false"
-				},
-				{
-					"name": "PinchUpdated",
-					"defaultValue": "null",
-					"inputType": "Xamarin.Forms.PinchGestureUpdatedEventArgs -> unit",
-					"convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.PinchGestureUpdatedEventArgs>(fun _sender args -> f args))"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.ActivityIndicator",
-			"members": [
-				{
-					"name": "Color",
-					"defaultValue": "Xamarin.Forms.Color.Default"
-				},
-				{
-					"name": "IsRunning",
-					"defaultValue": "false"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.BoxView",
-			"members": [
-				{
-					"name": "Color",
-					"defaultValue": "Xamarin.Forms.Color.Default"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.ProgressBar",
-			"members": [
-				{
-					"name": "Progress",
-					"defaultValue": "0.0"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.Layout",
-			"members": [
-				{
-					"name": "IsClippedToBounds",
-					"defaultValue": "false"
-				},
-				{
-					"name": "Padding",
-					"inputType": "obj",
-					"modelType": "Xamarin.Forms.Thickness",
-					"convToModel": "makeThickness",
-					"defaultValue": "Unchecked.defaultof<Xamarin.Forms.Thickness>"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.ScrollView",
-			"members": [
-				{
-					"name": "Content",
-					"defaultValue": "null"
-				},
-				{
-					"name": "Orientation",
-					"uniqueName": "ScrollOrientation",
-					"defaultValue": "Unchecked.defaultof<Xamarin.Forms.ScrollOrientation>"
-				},
-				{
-					"name": "HorizontalScrollBarVisibility",
-					"defaultValue": "Xamarin.Forms.ScrollBarVisibility.Default"
-				},
-				{
-					"name": "VerticalScrollBarVisibility",
-					"defaultValue": "Xamarin.Forms.ScrollBarVisibility.Default"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.SearchBar",
-			"members": [
-				{
-					"name": "CancelButtonColor",
-					"defaultValue": "Xamarin.Forms.Color.Default"
-				},
-				{
-					"name": "FontFamily",
-					"defaultValue": "null"
-				},
-				{
-					"name": "FontAttributes",
-					"defaultValue": "Xamarin.Forms.FontAttributes.None"
-				},
-				{
-					"name": "FontSize",
-					"defaultValue": "-1.0",
-					"inputType": "obj",
-					"convToModel": "makeFontSize"
-				},
-				{
-					"name": "HorizontalTextAlignment",
-					"defaultValue": "Xamarin.Forms.TextAlignment.Start"
-				},
-				{
-					"name": "Placeholder",
-					"defaultValue": "null"
-				},
-				{
-					"name": "PlaceholderColor",
-					"defaultValue": "Xamarin.Forms.Color.Default"
-				},
-				{
-					"name": "SearchCommand",
-					"uniqueName": "SearchBarCommand",
-					"inputType": "string -> unit",
-					"modelType": "string -> unit",
-					"updateCode": "(fun _ _ _ -> ())" // set below in CanExecute
-				},
-				{
-					"name": "CanExecute",
-					"uniqueName": "SearchBarCanExecute",
-					"inputType": "bool",
-					"modelType": "bool",
-					"updateCode": "updateCommand prevSearchBarCommandOpt currSearchBarCommandOpt (fun (target: Xamarin.Forms.SearchBar) -> target.Text) (fun (target: Xamarin.Forms.SearchBar) cmd -> target.SearchCommand <- cmd)"
-				},
-				{
-					"name": "Text",
-					"defaultValue": "null"
-				},
-				{
-					"name": "TextColor",
-					"defaultValue": "Xamarin.Forms.Color.Default"
-				},
-				{
-					"name": "TextChanged",
-					"uniqueName": "SearchBarTextChanged",
-					"defaultValue": "null",
-					"inputType": "Xamarin.Forms.TextChangedEventArgs -> unit",
-					"convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.TextChangedEventArgs>(fun _sender args -> f args))"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.Button",
-			"members": [
-				{
-					"name": "Text",
-					"defaultValue": "null"
-				},
-				{
-					"name": "Command",
-					"uniqueName": "ButtonCommand",
-					"inputType": "unit -> unit",
-					"modelType": "unit -> unit",
-					"updateCode": "(fun _ _ _ -> ())" // set below in CanExecute
-				},
-				{
-					"name": "CanExecute",
-					"uniqueName": "ButtonCanExecute",
-					"inputType": "bool",
-					"modelType": "bool",
-					"updateCode": "updateCommand prevButtonCommandOpt currButtonCommandOpt (fun _target -> ()) (fun (target: Xamarin.Forms.Button) cmd -> target.Command <- cmd)"
-				},
-				{
-					"name": "BorderColor",
-					"defaultValue": "Xamarin.Forms.Color.Default"
-				},
-				{
-					"name": "BorderWidth",
-					"defaultValue": "-1.0"
-				},
-				{
-					"name": "CommandParameter",
-					"defaultValue": "null"
-				},
-				{
-					"name": "ContentLayout",
-					"defaultValue": "null"
-				},
-				{
-					"name": "CornerRadius",
-					"uniqueName": "ButtonCornerRadius",
-					"defaultValue": "0"
-				},
-				{
-					"name": "FontFamily",
-					"defaultValue": "null"
-				},
-				{
-					"name": "FontAttributes",
-					"defaultValue": "Xamarin.Forms.FontAttributes.None"
-				},
-				{
-					"name": "FontSize",
-					"defaultValue": "-1.0",
-					"inputType": "obj",
-					"convToModel": "makeFontSize"
-				},
-				{
-					"name": "Image",
-					"uniqueName": "ButtonImageSource",
-					"inputType": "string",
-					"modelType": "string",
-					"convToValue": "makeFileImageSource",
-					"defaultValue": "null"
-				},
-				{
-					"name": "TextColor",
-					"defaultValue": "Xamarin.Forms.Color.Default"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.Slider",
-			"members": [
-				{
-					"name": "MinimumMaximum",
-					"inputType": "float * float",
-					"modelType": "float * float",
-					"defaultValue": "(0.0, 1.0)",
-					"updateCode": "updateSliderMinimumMaximum"
-				},
-				{
-					"name": "Value",
-					"defaultValue": "0.0"
-				},
-				{
-					"name": "ValueChanged",
-					"defaultValue": "null",
-					"inputType": "Xamarin.Forms.ValueChangedEventArgs -> unit",
-					"convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.ValueChangedEventArgs>(fun _sender args -> f args))"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.Stepper",
-			"members": [
-				{
-					"name": "MinimumMaximum",
-					"inputType": "float * float",
-					"modelType": "float * float",
-					"defaultValue": "(0.0, 1.0)",
-					"updateCode": "updateStepperMinimumMaximum"
-				},
-				{
-					"name": "Value",
-					"defaultValue": "0.0"
-				},
-				{
-					"name": "Increment",
-					"defaultValue": "1.0"
-				},
-				{
-					"name": "ValueChanged",
-					"defaultValue": "null",
-					"inputType": "Xamarin.Forms.ValueChangedEventArgs -> unit",
-					"convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.ValueChangedEventArgs>(fun _sender args -> f args))"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.Switch",
-			"members": [
-				{
-					"name": "IsToggled",
-					"defaultValue": "false"
-				},
-				{
-					"name": "Toggled",
-					"defaultValue": "null",
-					"inputType": "Xamarin.Forms.ToggledEventArgs -> unit",
-					"convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.ToggledEventArgs>(fun _sender args -> f args))"
-				},
-				{
-					"name": "OnColor",
-					"defaultValue": "Xamarin.Forms.Color.Default"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.Cell",
-			"members": [
-				{
-					"name": "Height",
-					"defaultValue": "-1.0"
-				},
-				{
-					"name": "IsEnabled",
-					"defaultValue": "true"
-				}
-				//ContextActions	- A list of MenuItem objects to display when the user performs the context action.
-			]
-		},
-		{
-			"name": "Xamarin.Forms.SwitchCell",
-			"members": [
-				{
-					"name": "On",
-					"defaultValue": "false"
-				},
-				{
-					"name": "Text",
-					"defaultValue": "null"
-				},
-				{
-					"name": "OnChanged",
-					"defaultValue": "null",
-					"inputType": "Xamarin.Forms.ToggledEventArgs -> unit",
-					"convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.ToggledEventArgs>(fun _sender args -> f args))"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.TableView",
-			"members": [
-				{
-					"name": "Intent",
-					"defaultValue": "Unchecked.defaultof<Xamarin.Forms.TableIntent>"
-				},
-				{
-					"name": "HasUnevenRows",
-					"defaultValue": "false"
-				},
-				{
-					"name": "RowHeight",
-					"defaultValue": "-1"
-				},
-				{
-					"name": "Root",
-					"uniqueName": "TableRoot",
-					"shortName": "items",
-					"defaultValue": "null",
-					"elementType": "Xamarin.Forms.TableSection",
-					"modelType": "(string * ViewElement[])[]",
-					"inputType": "(string * ViewElement list) list",
-					"convToModel": "(fun es -> es |> Array.ofList |> Array.map (fun (title, es) -> (title, Array.ofList es)))",
-					"updateCode": "updateTableViewItems"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.RowDefinition",
-			"members": [
-				{
-					"name": "Height",
-					"uniqueName": "RowDefinitionHeight",
-					"inputType": "obj",
-					"convToModel": "makeGridLength",
-					"defaultValue": "Xamarin.Forms.GridLength.Auto"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.ColumnDefinition",
-			"members": [
-				{
-					"name": "Width",
-					"uniqueName": "ColumnDefinitionWidth",
-					"inputType": "obj",
-					"convToModel": "makeGridLength",
-					"defaultValue": "Xamarin.Forms.GridLength.Auto"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.Grid",
-			"members": [
-				{
-					"name": "RowDefinitions",
-					"uniqueName": "GridRowDefinitions",
-					"shortName": "rowdefs",
-					"defaultValue": "null",
-					"elementType": "Xamarin.Forms.RowDefinition",
-					"modelType": "ViewElement[]",
-					"inputType": "obj list",
-					"convToModel": "(fun es -> es |> Array.ofList |> Array.map (fun h -> View.RowDefinition(height=h)))"
-				},
-				{
-					"name": "ColumnDefinitions",
-					"uniqueName": "GridColumnDefinitions",
-					"shortName": "coldefs",
-					"defaultValue": "null",
-					"elementType": "Xamarin.Forms.ColumnDefinition",
-					"modelType": "ViewElement[]",
-					"inputType": "obj list",
-					"convToModel": "(fun es -> es |> Array.ofList |> Array.map (fun h -> View.ColumnDefinition(width=h)))"
-				},
-				{
-					"name": "RowSpacing",
-					"inputType": "double",
-					"defaultValue": "0.0"
-				},
-				{
-					"name": "ColumnSpacing",
-					"inputType": "double",
-					"defaultValue": "0.0"
-				},
-				{
-					"name": "Children",
-					"defaultValue": "null",
-					"inputType": "ViewElement list",
-					"modelType": "ViewElement[]",
-					"convToModel": "Array.ofList",
-					"attached": [
-						{
-							"name": "Row",
-							"uniqueName": "GridRow",
-							"modelType": "int",
-							"defaultValue": "0"
-						},
-						{
-							"name": "RowSpan",
-							"uniqueName": "GridRowSpan",
-							"modelType": "int",
-							"defaultValue": "0"
-						},
-						{
-							"name": "Column",
-							"uniqueName": "GridColumn",
-							"modelType": "int",
-							"defaultValue": "0"
-						},
-						{
-							"name": "ColumnSpan",
-							"uniqueName": "GridColumnSpan",
-							"modelType": "int",
-							"defaultValue": "0"
-						}
-					]
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.AbsoluteLayout",
-			"members": [
-				{
-					"name": "Children",
-					"defaultValue": "null",
-					"inputType": "ViewElement list",
-					"modelType": "ViewElement[]",
-					"convToModel": "Array.ofList",
-					"attached": [
-						{
-							"name": "LayoutBounds",
-							"uniqueName": "LayoutBounds",
-							"modelType": "Xamarin.Forms.Rectangle",
-							"defaultValue": "Xamarin.Forms.Rectangle.Zero"
-						},
-						{
-							"name": "LayoutFlags",
-							"uniqueName": "LayoutFlags",
-							"modelType": "Xamarin.Forms.AbsoluteLayoutFlags",
-							"defaultValue": "Xamarin.Forms.AbsoluteLayoutFlags.None"
-						}
-					]
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.RelativeLayout",
-			"members": [
-				{
-					"name": "Children",
-					"defaultValue": "null",
-					"inputType": "ViewElement list",
-					"modelType": "ViewElement[]",
-					"convToModel": "Array.ofList",
-					"attached": [
-						{
-							"name": "BoundsConstraint",
-							"uniqueName": "BoundsConstraint",
-							"modelType": "Xamarin.Forms.BoundsConstraint",
-							"defaultValue": "null"
-						},
-						{
-							"name": "HeightConstraint",
-							"uniqueName": "HeightConstraint",
-							"modelType": "Xamarin.Forms.Constraint",
-							"defaultValue": "null"
-						},
-						{
-							"name": "WidthConstraint",
-							"uniqueName": "WidthConstraint",
-							"modelType": "Xamarin.Forms.Constraint",
-							"defaultValue": "null"
-						},
-						{
-							"name": "XConstraint",
-							"uniqueName": "XConstraint",
-							"modelType": "Xamarin.Forms.Constraint",
-							"defaultValue": "null"
-						},
-						{
-							"name": "YConstraint",
-							"uniqueName": "YConstraint",
-							"modelType": "Xamarin.Forms.Constraint",
-							"defaultValue": "null"
-						}
-					]
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.FlexLayout",
-			"members": [
-				{
-					"name": "AlignContent",
-					"modelType": "Xamarin.Forms.FlexAlignContent",
-					"defaultValue": "Unchecked.defaultof<Xamarin.Forms.FlexAlignContent>"
-				},
-				{
-					"name": "AlignItems",
-					"modelType": "Xamarin.Forms.FlexAlignItems",
-					"defaultValue": "Unchecked.defaultof<Xamarin.Forms.FlexAlignItems>"
-				},
-				{
-					"name": "Direction",
-					"modelType": "Xamarin.Forms.FlexDirection",
-					"defaultValue": "Unchecked.defaultof<Xamarin.Forms.FlexDirection>"
-				},
-				{
-					"name": "Position",
-					"modelType": "Xamarin.Forms.FlexPosition",
-					"defaultValue": "Unchecked.defaultof<Xamarin.Forms.FlexPosition>"
-				},
-				{
-					"name": "Wrap",
-					"modelType": "Xamarin.Forms.FlexWrap",
-					"defaultValue": "Unchecked.defaultof<Xamarin.Forms.FlexWrap>"
-				},
-				{
-					"name": "JustifyContent",
-					"modelType": "Xamarin.Forms.FlexJustify",
-					"defaultValue": "Unchecked.defaultof<Xamarin.Forms.FlexJustify>"
-				},
-				{
-					"name": "Children",
-					"defaultValue": "null",
-					"inputType": "ViewElement list",
-					"modelType": "ViewElement[]",
-					"convToModel": "Array.ofList",
-					"attached": [
-						{
-							"name": "AlignSelf",
-							"uniqueName": "FlexAlignSelf",
-							"modelType": "Xamarin.Forms.FlexAlignSelf",
-							"defaultValue": "Unchecked.defaultof<Xamarin.Forms.FlexAlignSelf>"
-						},
-						{
-							"name": "Order",
-							"uniqueName": "FlexOrder",
-							"modelType": "int",
-							"defaultValue": "0"
-						},
-						{
-							"name": "Basis",
-							"uniqueName": "FlexBasis",
-							"modelType": "Xamarin.Forms.FlexBasis",
-							"defaultValue": "Unchecked.defaultof<Xamarin.Forms.FlexBasis>"
-						},
-						{
-							"name": "Grow",
-							"uniqueName": "FlexGrow",
-							"inputType": "double",
-							"modelType": "single",
-							"convToModel": "single",
-							"defaultValue": "0.0f"
-						},
-						{
-							"name": "Shrink",
-							"uniqueName": "FlexShrink",
-							"inputType": "double",
-							"modelType": "single",
-							"convToModel": "single",
-							"defaultValue": "1.0f"
-						}
-					]
-				}
-			]
-
-		},
-		{
-			"name": "Xamarin.Forms.TemplatedView",
-			"members": []
-		},
-		{
-			"name": "Xamarin.Forms.ContentView",
-			"members": [
-				{
-					"name": "Content",
-					"defaultValue": "null"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.DatePicker",
-			"members": [
-				{
-					"name": "Date",
-					"defaultValue": "Unchecked.defaultof<System.DateTime>"
-				},
-				{
-					"name": "Format",
-					"defaultValue": "\"d\""
-				},
-				{
-					"name": "MinimumDate",
-					"defaultValue": "new System.DateTime(1900, 1, 1)"
-				},
-				{
-					"name": "MaximumDate",
-					"defaultValue": "new System.DateTime(2100, 12, 31)"
-				},
-				{
-					"name": "DateSelected",
-					"defaultValue": "null",
-					"inputType": "Xamarin.Forms.DateChangedEventArgs -> unit",
-					"convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.DateChangedEventArgs>(fun _sender args -> f args))"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.Picker",
-			"members": [
-				{
-					"name": "ItemsSource",
-					"uniqueName": "PickerItemsSource",
-					"inputType": "seq<'T>",
-					"modelType": "System.Collections.IList",
-					"convToModel": "seqToIListUntyped",
-					"defaultValue": "null"
-				},
-				{
-					"name": "SelectedIndex",
-					"defaultValue": "0"
-				},
-				//{
-				//    "name": "SelectedItem",
-				//    "defaultValue": "null"
-				//},
-				{
-					"name": "Title",
-					"defaultValue": "null"
-				},
-				{
-					"name": "TextColor",
-					"defaultValue": "Xamarin.Forms.Color.Default"
-				},
-				{
-					"name": "SelectedIndexChanged",
-					"defaultValue": "null",
-					"inputType": "(int * 'T option) -> unit",
-					"convToModel": "(fun f -> System.EventHandler(fun sender args -> let picker = (sender :?> Xamarin.Forms.Picker) in f (picker.SelectedIndex, (picker.SelectedItem |> Option.ofObj |> Option.map unbox<'T>))))"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.Frame",
-			"members": [
-				{
-					"name": "BorderColor",
-					"defaultValue": "Xamarin.Forms.Color.Default"
-				},
-				{
-					"name": "CornerRadius",
-					"uniqueName": "FrameCornerRadius",
-					"inputType": "double",
-					"modelType": "single",
-					"convToModel": "single",
-					"defaultValue": "-1.0f"
-				},
-				{
-					"name": "HasShadow",
-					"defaultValue": "true"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.Image",
-			"members": [
-				{
-					"name": "Source",
-					"uniqueName": "ImageSource",
-					"inputType": "obj",
-					"modelType": "obj",
-					"convToValue": "makeImageSource",
-					"defaultValue": "null"
-				},
-				{
-					"name": "Aspect",
-					"defaultValue": "Xamarin.Forms.Aspect.AspectFit"
-				},
-				{
-					"name": "IsOpaque",
-					"defaultValue": "true"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.InputView",
-			"members": [
-				{
-					"name": "Keyboard",
-					"defaultValue": "Xamarin.Forms.Keyboard.Default"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.Editor",
-			"members": [
-				{
-					"name": "Text",
-					"defaultValue": "null"
-				},
-				{
-					"name": "FontSize",
-					"defaultValue": "-1.0",
-					"inputType": "obj",
-					"convToModel": "makeFontSize"
-				},
-				{
-					"name": "FontFamily",
-					"defaultValue": "null"
-				},
-				{
-					"name": "FontAttributes",
-					"defaultValue": "Xamarin.Forms.FontAttributes.None"
-				},
-				{
-					"name": "TextColor",
-					"defaultValue": "Xamarin.Forms.Color.Default"
-				},
-				{
-					"name": "Completed",
-					"uniqueName": "EditorCompleted",
-					"defaultValue": "null",
-					"inputType": "string -> unit",
-					"convToModel": "(fun f -> System.EventHandler(fun sender args -> f (sender :?> Xamarin.Forms.Editor).Text))"
-				},
-				{
-					"name": "TextChanged",
-					"defaultValue": "null",
-					"inputType": "Xamarin.Forms.TextChangedEventArgs -> unit",
-					"convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.TextChangedEventArgs>(fun _sender args -> f args))"
-				},
-				{
-					"name": "AutoSize",
-					"defaultValue": "Xamarin.Forms.EditorAutoSizeOption.Disabled"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.Entry",
-			"members": [
-				{
-					"name": "Text",
-					"defaultValue": "null"
-				},
-				{
-					"name": "Placeholder",
-					"defaultValue": "null"
-				},
-				{
-					"name": "HorizontalTextAlignment",
-					"defaultValue": "Xamarin.Forms.TextAlignment.Start"
-				},
-				{
-					"name": "FontSize",
-					"defaultValue": "-1.0",
-					"inputType": "obj",
-					"convToModel": "makeFontSize"
-				},
-				{
-					"name": "FontFamily",
-					"defaultValue": "null"
-				},
-				{
-					"name": "FontAttributes",
-					"defaultValue": "Xamarin.Forms.FontAttributes.None"
-				},
-				{
-					"name": "TextColor",
-					"defaultValue": "Xamarin.Forms.Color.Default"
-				},
-				{
-					"name": "PlaceholderColor",
-					"defaultValue": "Xamarin.Forms.Color.Default"
-				},
-				{
-					"name": "IsPassword",
-					"defaultValue": "false"
-				},
-				{
-					"name": "Completed",
-					"uniqueName": "EntryCompleted",
-					"defaultValue": "null",
-					"inputType": "string -> unit",
-					"convToModel": "(fun f -> System.EventHandler(fun sender args -> f (sender :?> Xamarin.Forms.Entry).Text))"
-				},
-				{
-					"name": "TextChanged",
-					"defaultValue": "null",
-					"inputType": "Xamarin.Forms.TextChangedEventArgs -> unit",
-					"convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.TextChangedEventArgs>(fun _sender args -> f args))"
-				},
-				{
-					"name": "IsTextPredictionEnabled",
-					"defaultValue": "true"
-				},
-				{
-					"name": "ReturnType",
-					"defaultValue": "Xamarin.Forms.ReturnType.Default"
-				},
-				{
-					"name": "ReturnCommand",
-					"defaultValue": "null",
-					"inputType": "unit -> unit",
-					"convToModel": "makeCommand"
-				}
-			]
-		},
+  "outputNamespace": "Fabulous.DynamicViews",
+  "types": [
+    {
+      "name": "Xamarin.Forms.Element",
+      "members": [
+        {
+          "name": "ClassId",
+          "defaultValue": "null"
+        },
+        {
+          "name": "StyleId",
+          "defaultValue": "null"
+        },
+        {
+          "name": "AutomationId",
+          "defaultValue": "null"
+        },
+        {
+          "name": "Created",
+          "uniqueName": "ElementCreated",
+          "inputType": "obj -> unit",
+          "modelType": "obj -> unit",
+          "updateCode": "(fun _ _ _ -> ())"
+        },
+        {
+          "name": "Ref",
+          "uniqueName": "ElementViewRef",
+          "inputType": "ViewRef",
+          "modelType": "ViewRef",
+          "updateCode": "(fun _ _ _ -> ())"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.VisualElement",
+      "members": [
+        {
+          "name": "AnchorX",
+          "defaultValue": "0.0"
+        },
+        {
+          "name": "AnchorY",
+          "defaultValue": "0.0"
+        },
+        {
+          "name": "BackgroundColor",
+          "defaultValue": "Xamarin.Forms.Color.Default"
+        },
+        {
+          "name": "HeightRequest",
+          "defaultValue": "-1.0"
+        },
+        {
+          "name": "InputTransparent",
+          "defaultValue": "false"
+        },
+        {
+          "name": "IsEnabled",
+          "defaultValue": "true"
+        },
+        {
+          "name": "IsVisible",
+          "defaultValue": "true"
+        },
+        {
+          "name": "MinimumHeightRequest",
+          "defaultValue": "-1.0"
+        },
+        {
+          "name": "MinimumWidthRequest",
+          "defaultValue": "-1.0"
+        },
+        {
+          "name": "Opacity",
+          "defaultValue": "1.0"
+        },
+        {
+          "name": "Rotation",
+          "defaultValue": "0.0"
+        },
+        {
+          "name": "RotationX",
+          "defaultValue": "0.0"
+        },
+        {
+          "name": "RotationY",
+          "defaultValue": "0.0"
+        },
+        {
+          "name": "Scale",
+          "defaultValue": "1.0"
+        },
+        {
+          "name": "Style",
+          "defaultValue": "null"
+        },
+        {
+          "name": "StyleClass",
+          "defaultValue": "null",
+          "inputType": "obj",
+          "modelType": "System.Collections.Generic.IList<string>",
+          "convToModel": "makeStyleClass",
+          "updateCode": "updateStyleClass"
+        },
+        {
+          "name": "TranslationX",
+          "defaultValue": "0.0"
+        },
+        {
+          "name": "TranslationY",
+          "defaultValue": "0.0"
+        },
+        {
+          "name": "WidthRequest",
+          "defaultValue": "-1.0"
+        },
+        {
+          "name": "Resources",
+          "defaultValue": "null",
+          "inputType": "(string * obj) list",
+          "modelType": "(string * obj) list",
+          "updateCode": "updateResources"
+        },
+        {
+          "name": "Styles",
+          "defaultValue": "null",
+          "inputType": "Xamarin.Forms.Style list",
+          "modelType": "Xamarin.Forms.Style list",
+          "updateCode": "updateStyles"
+        },
+        {
+          "name": "StyleSheets",
+          "defaultValue": "null",
+          "inputType": "Xamarin.Forms.StyleSheets.StyleSheet list",
+          "modelType": "Xamarin.Forms.StyleSheets.StyleSheet list",
+          "updateCode": "updateStyleSheets"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.View",
+      "members": [
+        {
+          "name": "HorizontalOptions",
+          "defaultValue": "Xamarin.Forms.LayoutOptions.Fill"
+        },
+        {
+          "name": "VerticalOptions",
+          "defaultValue": "Xamarin.Forms.LayoutOptions.Fill"
+        },
+        {
+          "name": "Margin",
+          "inputType": "obj",
+          "modelType": "Xamarin.Forms.Thickness",
+          "convToModel": "makeThickness",
+          "defaultValue": "Unchecked.defaultof<Xamarin.Forms.Thickness>"
+        },
+        {
+          "name": "GestureRecognizers",
+          "defaultValue": "null",
+          "inputType": "ViewElement list",
+          "modelType": "ViewElement[]",
+          "convToModel": "Array.ofList"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.IGestureRecognizer",
+      "members": []
+    },
+    {
+      "name": "Xamarin.Forms.PanGestureRecognizer",
+      "members": [
+        {
+          "name": "TouchPoints",
+          "defaultValue": "1"
+        },
+        {
+          "name": "PanUpdated",
+          "defaultValue": "null",
+          "inputType": "Xamarin.Forms.PanUpdatedEventArgs -> unit",
+          "convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.PanUpdatedEventArgs>(fun _sender args -> f args))"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.TapGestureRecognizer",
+      "members": [
+        {
+          "name": "Command",
+          "defaultValue": "null",
+          "inputType": "unit -> unit",
+          "convToModel": "makeCommand"
+        },
+        {
+          "name": "NumberOfTapsRequired",
+          "defaultValue": "1"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.ClickGestureRecognizer",
+      "members": [
+        {
+          "name": "Command",
+          "defaultValue": "null",
+          "inputType": "unit -> unit",
+          "convToModel": "makeCommand"
+        },
+        {
+          "name": "NumberOfClicksRequired",
+          "defaultValue": "1"
+        },
+        {
+          "name": "Buttons",
+          "defaultValue": "Xamarin.Forms.ButtonsMask.Primary"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.PinchGestureRecognizer",
+      "members": [
+        {
+          "name": "IsPinching",
+          "defaultValue": "false"
+        },
+        {
+          "name": "PinchUpdated",
+          "defaultValue": "null",
+          "inputType": "Xamarin.Forms.PinchGestureUpdatedEventArgs -> unit",
+          "convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.PinchGestureUpdatedEventArgs>(fun _sender args -> f args))"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.ActivityIndicator",
+      "members": [
+        {
+          "name": "Color",
+          "defaultValue": "Xamarin.Forms.Color.Default"
+        },
+        {
+          "name": "IsRunning",
+          "defaultValue": "false"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.BoxView",
+      "members": [
+        {
+          "name": "Color",
+          "defaultValue": "Xamarin.Forms.Color.Default"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.ProgressBar",
+      "members": [
+        {
+          "name": "Progress",
+          "defaultValue": "0.0"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.Layout",
+      "members": [
+        {
+          "name": "IsClippedToBounds",
+          "defaultValue": "false"
+        },
+        {
+          "name": "Padding",
+          "inputType": "obj",
+          "modelType": "Xamarin.Forms.Thickness",
+          "convToModel": "makeThickness",
+          "defaultValue": "Unchecked.defaultof<Xamarin.Forms.Thickness>"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.ScrollView",
+      "members": [
+        {
+          "name": "Content",
+          "defaultValue": "null"
+        },
+        {
+          "name": "Orientation",
+          "uniqueName": "ScrollOrientation",
+          "defaultValue": "Unchecked.defaultof<Xamarin.Forms.ScrollOrientation>"
+        },
+        {
+          "name": "HorizontalScrollBarVisibility",
+          "defaultValue": "Xamarin.Forms.ScrollBarVisibility.Default"
+        },
+        {
+          "name": "VerticalScrollBarVisibility",
+          "defaultValue": "Xamarin.Forms.ScrollBarVisibility.Default"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.SearchBar",
+      "members": [
+        {
+          "name": "CancelButtonColor",
+          "defaultValue": "Xamarin.Forms.Color.Default"
+        },
+        {
+          "name": "FontFamily",
+          "defaultValue": "null"
+        },
+        {
+          "name": "FontAttributes",
+          "defaultValue": "Xamarin.Forms.FontAttributes.None"
+        },
+        {
+          "name": "FontSize",
+          "defaultValue": "-1.0",
+          "inputType": "obj",
+          "convToModel": "makeFontSize"
+        },
+        {
+          "name": "HorizontalTextAlignment",
+          "defaultValue": "Xamarin.Forms.TextAlignment.Start"
+        },
+        {
+          "name": "Placeholder",
+          "defaultValue": "null"
+        },
+        {
+          "name": "PlaceholderColor",
+          "defaultValue": "Xamarin.Forms.Color.Default"
+        },
+        {
+          "name": "SearchCommand",
+          "uniqueName": "SearchBarCommand",
+          "inputType": "string -> unit",
+          "modelType": "string -> unit",
+          "updateCode": "(fun _ _ _ -> ())"
+        },
+        {
+          "name": "CanExecute",
+          "uniqueName": "SearchBarCanExecute",
+          "inputType": "bool",
+          "modelType": "bool",
+          "updateCode": "updateCommand prevSearchBarCommandOpt currSearchBarCommandOpt (fun (target: Xamarin.Forms.SearchBar) -> target.Text) (fun (target: Xamarin.Forms.SearchBar) cmd -> target.SearchCommand <- cmd)"
+        },
+        {
+          "name": "Text",
+          "defaultValue": "null"
+        },
+        {
+          "name": "TextColor",
+          "defaultValue": "Xamarin.Forms.Color.Default"
+        },
+        {
+          "name": "TextChanged",
+          "uniqueName": "SearchBarTextChanged",
+          "defaultValue": "null",
+          "inputType": "Xamarin.Forms.TextChangedEventArgs -> unit",
+          "convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.TextChangedEventArgs>(fun _sender args -> f args))"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.Button",
+      "members": [
+        {
+          "name": "Text",
+          "defaultValue": "null"
+        },
+        {
+          "name": "Command",
+          "uniqueName": "ButtonCommand",
+          "inputType": "unit -> unit",
+          "modelType": "unit -> unit",
+          "updateCode": "(fun _ _ _ -> ())"
+        },
+        {
+          "name": "CanExecute",
+          "uniqueName": "ButtonCanExecute",
+          "inputType": "bool",
+          "modelType": "bool",
+          "updateCode": "updateCommand prevButtonCommandOpt currButtonCommandOpt (fun _target -> ()) (fun (target: Xamarin.Forms.Button) cmd -> target.Command <- cmd)"
+        },
+        {
+          "name": "BorderColor",
+          "defaultValue": "Xamarin.Forms.Color.Default"
+        },
+        {
+          "name": "BorderWidth",
+          "defaultValue": "-1.0"
+        },
+        {
+          "name": "CommandParameter",
+          "defaultValue": "null"
+        },
+        {
+          "name": "ContentLayout",
+          "defaultValue": "null"
+        },
+        {
+          "name": "CornerRadius",
+          "uniqueName": "ButtonCornerRadius",
+          "defaultValue": "0"
+        },
+        {
+          "name": "FontFamily",
+          "defaultValue": "null"
+        },
+        {
+          "name": "FontAttributes",
+          "defaultValue": "Xamarin.Forms.FontAttributes.None"
+        },
+        {
+          "name": "FontSize",
+          "defaultValue": "-1.0",
+          "inputType": "obj",
+          "convToModel": "makeFontSize"
+        },
+        {
+          "name": "Image",
+          "uniqueName": "ButtonImageSource",
+          "inputType": "string",
+          "modelType": "string",
+          "convToValue": "makeFileImageSource",
+          "defaultValue": "null"
+        },
+        {
+          "name": "TextColor",
+          "defaultValue": "Xamarin.Forms.Color.Default"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.Slider",
+      "members": [
+        {
+          "name": "MinimumMaximum",
+          "inputType": "float * float",
+          "modelType": "float * float",
+          "defaultValue": "(0.0, 1.0)",
+          "updateCode": "updateSliderMinimumMaximum"
+        },
+        {
+          "name": "Value",
+          "defaultValue": "0.0"
+        },
+        {
+          "name": "ValueChanged",
+          "defaultValue": "null",
+          "inputType": "Xamarin.Forms.ValueChangedEventArgs -> unit",
+          "convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.ValueChangedEventArgs>(fun _sender args -> f args))"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.Stepper",
+      "members": [
+        {
+          "name": "MinimumMaximum",
+          "inputType": "float * float",
+          "modelType": "float * float",
+          "defaultValue": "(0.0, 1.0)",
+          "updateCode": "updateStepperMinimumMaximum"
+        },
+        {
+          "name": "Value",
+          "defaultValue": "0.0"
+        },
+        {
+          "name": "Increment",
+          "defaultValue": "1.0"
+        },
+        {
+          "name": "ValueChanged",
+          "defaultValue": "null",
+          "inputType": "Xamarin.Forms.ValueChangedEventArgs -> unit",
+          "convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.ValueChangedEventArgs>(fun _sender args -> f args))"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.Switch",
+      "members": [
+        {
+          "name": "IsToggled",
+          "defaultValue": "false"
+        },
+        {
+          "name": "Toggled",
+          "defaultValue": "null",
+          "inputType": "Xamarin.Forms.ToggledEventArgs -> unit",
+          "convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.ToggledEventArgs>(fun _sender args -> f args))"
+        },
+        {
+          "name": "OnColor",
+          "defaultValue": "Xamarin.Forms.Color.Default"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.Cell",
+      "members": [
+        {
+          "name": "Height",
+          "defaultValue": "-1.0"
+        },
+        {
+          "name": "IsEnabled",
+          "defaultValue": "true"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.SwitchCell",
+      "members": [
+        {
+          "name": "On",
+          "defaultValue": "false"
+        },
+        {
+          "name": "Text",
+          "defaultValue": "null"
+        },
+        {
+          "name": "OnChanged",
+          "defaultValue": "null",
+          "inputType": "Xamarin.Forms.ToggledEventArgs -> unit",
+          "convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.ToggledEventArgs>(fun _sender args -> f args))"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.TableView",
+      "members": [
+        {
+          "name": "Intent",
+          "defaultValue": "Unchecked.defaultof<Xamarin.Forms.TableIntent>"
+        },
+        {
+          "name": "HasUnevenRows",
+          "defaultValue": "false"
+        },
+        {
+          "name": "RowHeight",
+          "defaultValue": "-1"
+        },
+        {
+          "name": "Root",
+          "uniqueName": "TableRoot",
+          "shortName": "items",
+          "defaultValue": "null",
+          "elementType": "Xamarin.Forms.TableSection",
+          "modelType": "(string * ViewElement[])[]",
+          "inputType": "(string * ViewElement list) list",
+          "convToModel": "(fun es -> es |> Array.ofList |> Array.map (fun (title, es) -> (title, Array.ofList es)))",
+          "updateCode": "updateTableViewItems"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.RowDefinition",
+      "members": [
+        {
+          "name": "Height",
+          "uniqueName": "RowDefinitionHeight",
+          "inputType": "obj",
+          "convToModel": "makeGridLength",
+          "defaultValue": "Xamarin.Forms.GridLength.Auto"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.ColumnDefinition",
+      "members": [
+        {
+          "name": "Width",
+          "uniqueName": "ColumnDefinitionWidth",
+          "inputType": "obj",
+          "convToModel": "makeGridLength",
+          "defaultValue": "Xamarin.Forms.GridLength.Auto"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.Grid",
+      "members": [
+        {
+          "name": "RowDefinitions",
+          "uniqueName": "GridRowDefinitions",
+          "shortName": "rowdefs",
+          "defaultValue": "null",
+          "elementType": "Xamarin.Forms.RowDefinition",
+          "modelType": "ViewElement[]",
+          "inputType": "obj list",
+          "convToModel": "(fun es -> es |> Array.ofList |> Array.map (fun h -> View.RowDefinition(height=h)))"
+        },
+        {
+          "name": "ColumnDefinitions",
+          "uniqueName": "GridColumnDefinitions",
+          "shortName": "coldefs",
+          "defaultValue": "null",
+          "elementType": "Xamarin.Forms.ColumnDefinition",
+          "modelType": "ViewElement[]",
+          "inputType": "obj list",
+          "convToModel": "(fun es -> es |> Array.ofList |> Array.map (fun h -> View.ColumnDefinition(width=h)))"
+        },
+        {
+          "name": "RowSpacing",
+          "inputType": "double",
+          "defaultValue": "0.0"
+        },
+        {
+          "name": "ColumnSpacing",
+          "inputType": "double",
+          "defaultValue": "0.0"
+        },
+        {
+          "name": "Children",
+          "defaultValue": "null",
+          "inputType": "ViewElement list",
+          "modelType": "ViewElement[]",
+          "convToModel": "Array.ofList",
+          "attached": [
+            {
+              "name": "Row",
+              "uniqueName": "GridRow",
+              "modelType": "int",
+              "defaultValue": "0"
+            },
+            {
+              "name": "RowSpan",
+              "uniqueName": "GridRowSpan",
+              "modelType": "int",
+              "defaultValue": "0"
+            },
+            {
+              "name": "Column",
+              "uniqueName": "GridColumn",
+              "modelType": "int",
+              "defaultValue": "0"
+            },
+            {
+              "name": "ColumnSpan",
+              "uniqueName": "GridColumnSpan",
+              "modelType": "int",
+              "defaultValue": "0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.AbsoluteLayout",
+      "members": [
+        {
+          "name": "Children",
+          "defaultValue": "null",
+          "inputType": "ViewElement list",
+          "modelType": "ViewElement[]",
+          "convToModel": "Array.ofList",
+          "attached": [
+            {
+              "name": "LayoutBounds",
+              "uniqueName": "LayoutBounds",
+              "modelType": "Xamarin.Forms.Rectangle",
+              "defaultValue": "Xamarin.Forms.Rectangle.Zero"
+            },
+            {
+              "name": "LayoutFlags",
+              "uniqueName": "LayoutFlags",
+              "modelType": "Xamarin.Forms.AbsoluteLayoutFlags",
+              "defaultValue": "Xamarin.Forms.AbsoluteLayoutFlags.None"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.RelativeLayout",
+      "members": [
+        {
+          "name": "Children",
+          "defaultValue": "null",
+          "inputType": "ViewElement list",
+          "modelType": "ViewElement[]",
+          "convToModel": "Array.ofList",
+          "attached": [
+            {
+              "name": "BoundsConstraint",
+              "uniqueName": "BoundsConstraint",
+              "modelType": "Xamarin.Forms.BoundsConstraint",
+              "defaultValue": "null"
+            },
+            {
+              "name": "HeightConstraint",
+              "uniqueName": "HeightConstraint",
+              "modelType": "Xamarin.Forms.Constraint",
+              "defaultValue": "null"
+            },
+            {
+              "name": "WidthConstraint",
+              "uniqueName": "WidthConstraint",
+              "modelType": "Xamarin.Forms.Constraint",
+              "defaultValue": "null"
+            },
+            {
+              "name": "XConstraint",
+              "uniqueName": "XConstraint",
+              "modelType": "Xamarin.Forms.Constraint",
+              "defaultValue": "null"
+            },
+            {
+              "name": "YConstraint",
+              "uniqueName": "YConstraint",
+              "modelType": "Xamarin.Forms.Constraint",
+              "defaultValue": "null"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.FlexLayout",
+      "members": [
+        {
+          "name": "AlignContent",
+          "modelType": "Xamarin.Forms.FlexAlignContent",
+          "defaultValue": "Unchecked.defaultof<Xamarin.Forms.FlexAlignContent>"
+        },
+        {
+          "name": "AlignItems",
+          "modelType": "Xamarin.Forms.FlexAlignItems",
+          "defaultValue": "Unchecked.defaultof<Xamarin.Forms.FlexAlignItems>"
+        },
+        {
+          "name": "Direction",
+          "modelType": "Xamarin.Forms.FlexDirection",
+          "defaultValue": "Unchecked.defaultof<Xamarin.Forms.FlexDirection>"
+        },
+        {
+          "name": "Position",
+          "modelType": "Xamarin.Forms.FlexPosition",
+          "defaultValue": "Unchecked.defaultof<Xamarin.Forms.FlexPosition>"
+        },
+        {
+          "name": "Wrap",
+          "modelType": "Xamarin.Forms.FlexWrap",
+          "defaultValue": "Unchecked.defaultof<Xamarin.Forms.FlexWrap>"
+        },
+        {
+          "name": "JustifyContent",
+          "modelType": "Xamarin.Forms.FlexJustify",
+          "defaultValue": "Unchecked.defaultof<Xamarin.Forms.FlexJustify>"
+        },
+        {
+          "name": "Children",
+          "defaultValue": "null",
+          "inputType": "ViewElement list",
+          "modelType": "ViewElement[]",
+          "convToModel": "Array.ofList",
+          "attached": [
+            {
+              "name": "AlignSelf",
+              "uniqueName": "FlexAlignSelf",
+              "modelType": "Xamarin.Forms.FlexAlignSelf",
+              "defaultValue": "Unchecked.defaultof<Xamarin.Forms.FlexAlignSelf>"
+            },
+            {
+              "name": "Order",
+              "uniqueName": "FlexOrder",
+              "modelType": "int",
+              "defaultValue": "0"
+            },
+            {
+              "name": "Basis",
+              "uniqueName": "FlexBasis",
+              "modelType": "Xamarin.Forms.FlexBasis",
+              "defaultValue": "Unchecked.defaultof<Xamarin.Forms.FlexBasis>"
+            },
+            {
+              "name": "Grow",
+              "uniqueName": "FlexGrow",
+              "inputType": "double",
+              "modelType": "single",
+              "convToModel": "single",
+              "defaultValue": "0.0f"
+            },
+            {
+              "name": "Shrink",
+              "uniqueName": "FlexShrink",
+              "inputType": "double",
+              "modelType": "single",
+              "convToModel": "single",
+              "defaultValue": "1.0f"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.TemplatedView",
+      "members": []
+    },
+    {
+      "name": "Xamarin.Forms.ContentView",
+      "members": [
+        {
+          "name": "Content",
+          "defaultValue": "null"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.DatePicker",
+      "members": [
+        {
+          "name": "Date",
+          "defaultValue": "Unchecked.defaultof<System.DateTime>"
+        },
+        {
+          "name": "Format",
+          "defaultValue": "\"d\""
+        },
+        {
+          "name": "MinimumDate",
+          "defaultValue": "new System.DateTime(1900, 1, 1)"
+        },
+        {
+          "name": "MaximumDate",
+          "defaultValue": "new System.DateTime(2100, 12, 31)"
+        },
+        {
+          "name": "DateSelected",
+          "defaultValue": "null",
+          "inputType": "Xamarin.Forms.DateChangedEventArgs -> unit",
+          "convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.DateChangedEventArgs>(fun _sender args -> f args))"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.Picker",
+      "members": [
+        {
+          "name": "ItemsSource",
+          "uniqueName": "PickerItemsSource",
+          "inputType": "seq<'T>",
+          "modelType": "System.Collections.IList",
+          "convToModel": "seqToIListUntyped",
+          "defaultValue": "null"
+        },
+        {
+          "name": "SelectedIndex",
+          "defaultValue": "0"
+        },
+        {
+          "name": "Title",
+          "defaultValue": "null"
+        },
+        {
+          "name": "TextColor",
+          "defaultValue": "Xamarin.Forms.Color.Default"
+        },
+        {
+          "name": "SelectedIndexChanged",
+          "defaultValue": "null",
+          "inputType": "(int * 'T option) -> unit",
+          "convToModel": "(fun f -> System.EventHandler(fun sender args -> let picker = (sender :?> Xamarin.Forms.Picker) in f (picker.SelectedIndex, (picker.SelectedItem |> Option.ofObj |> Option.map unbox<'T>))))"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.Frame",
+      "members": [
+        {
+          "name": "BorderColor",
+          "defaultValue": "Xamarin.Forms.Color.Default"
+        },
+        {
+          "name": "CornerRadius",
+          "uniqueName": "FrameCornerRadius",
+          "inputType": "double",
+          "modelType": "single",
+          "convToModel": "single",
+          "defaultValue": "-1.0f"
+        },
+        {
+          "name": "HasShadow",
+          "defaultValue": "true"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.Image",
+      "members": [
+        {
+          "name": "Source",
+          "uniqueName": "ImageSource",
+          "inputType": "obj",
+          "modelType": "obj",
+          "convToValue": "makeImageSource",
+          "defaultValue": "null"
+        },
+        {
+          "name": "Aspect",
+          "defaultValue": "Xamarin.Forms.Aspect.AspectFit"
+        },
+        {
+          "name": "IsOpaque",
+          "defaultValue": "true"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.InputView",
+      "members": [
+        {
+          "name": "Keyboard",
+          "defaultValue": "Xamarin.Forms.Keyboard.Default"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.Editor",
+      "members": [
+        {
+          "name": "Text",
+          "defaultValue": "null"
+        },
+        {
+          "name": "FontSize",
+          "defaultValue": "-1.0",
+          "inputType": "obj",
+          "convToModel": "makeFontSize"
+        },
+        {
+          "name": "FontFamily",
+          "defaultValue": "null"
+        },
+        {
+          "name": "FontAttributes",
+          "defaultValue": "Xamarin.Forms.FontAttributes.None"
+        },
+        {
+          "name": "TextColor",
+          "defaultValue": "Xamarin.Forms.Color.Default"
+        },
+        {
+          "name": "Completed",
+          "uniqueName": "EditorCompleted",
+          "defaultValue": "null",
+          "inputType": "string -> unit",
+          "convToModel": "(fun f -> System.EventHandler(fun sender args -> f (sender :?> Xamarin.Forms.Editor).Text))"
+        },
+        {
+          "name": "TextChanged",
+          "defaultValue": "null",
+          "inputType": "Xamarin.Forms.TextChangedEventArgs -> unit",
+          "convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.TextChangedEventArgs>(fun _sender args -> f args))"
+        },
+        {
+          "name": "AutoSize",
+          "defaultValue": "Xamarin.Forms.EditorAutoSizeOption.Disabled"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.Entry",
+      "members": [
+        {
+          "name": "Text",
+          "defaultValue": "null"
+        },
+        {
+          "name": "Placeholder",
+          "defaultValue": "null"
+        },
+        {
+          "name": "HorizontalTextAlignment",
+          "defaultValue": "Xamarin.Forms.TextAlignment.Start"
+        },
+        {
+          "name": "FontSize",
+          "defaultValue": "-1.0",
+          "inputType": "obj",
+          "convToModel": "makeFontSize"
+        },
+        {
+          "name": "FontFamily",
+          "defaultValue": "null"
+        },
+        {
+          "name": "FontAttributes",
+          "defaultValue": "Xamarin.Forms.FontAttributes.None"
+        },
+        {
+          "name": "TextColor",
+          "defaultValue": "Xamarin.Forms.Color.Default"
+        },
+        {
+          "name": "PlaceholderColor",
+          "defaultValue": "Xamarin.Forms.Color.Default"
+        },
+        {
+          "name": "IsPassword",
+          "defaultValue": "false"
+        },
+        {
+          "name": "Completed",
+          "uniqueName": "EntryCompleted",
+          "defaultValue": "null",
+          "inputType": "string -> unit",
+          "convToModel": "(fun f -> System.EventHandler(fun sender args -> f (sender :?> Xamarin.Forms.Entry).Text))"
+        },
+        {
+          "name": "TextChanged",
+          "defaultValue": "null",
+          "inputType": "Xamarin.Forms.TextChangedEventArgs -> unit",
+          "convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.TextChangedEventArgs>(fun _sender args -> f args))"
+        },
+        {
+          "name": "IsTextPredictionEnabled",
+          "defaultValue": "true"
+        },
+        {
+          "name": "ReturnType",
+          "defaultValue": "Xamarin.Forms.ReturnType.Default"
+        },
+        {
+          "name": "ReturnCommand",
+          "defaultValue": "null",
+          "inputType": "unit -> unit",
+          "convToModel": "makeCommand"
+        }
+      ]
+    },
     {
       "name": "Fabulous.CustomControls.CustomEntryCell",
       "modelName": "EntryCell",
@@ -1090,758 +1083,723 @@
         }
       ]
     },
-		{
-			"name": "Xamarin.Forms.Label",
-			"members": [
-				{
-					"name": "Text",
-					"defaultValue": "null"
-				},
-				{
-					"name": "HorizontalTextAlignment",
-					"defaultValue": "Xamarin.Forms.TextAlignment.Start"
-				},
-				{
-					"name": "VerticalTextAlignment",
-					"defaultValue": "Xamarin.Forms.TextAlignment.Start"
-				},
-				{
-					"name": "FontSize",
-					"defaultValue": "-1.0",
-					"inputType": "obj",
-					"convToModel": "makeFontSize"
-				},
-				{
-					"name": "FontFamily",
-					"defaultValue": "null"
-				},
-				{
-					"name": "FontAttributes",
-					"defaultValue": "Xamarin.Forms.FontAttributes.None"
-				},
-				{
-					"name": "TextColor",
-					"defaultValue": "Xamarin.Forms.Color.Default"
-				},
-				{
-					"name": "FormattedText",
-					"defaultValue": "null"
-				},
-				{
-					"name": "LineBreakMode",
-					"defaultValue": "Xamarin.Forms.LineBreakMode.WordWrap"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.StackLayout",
-			"members": [
-				{
-					"name": "Children",
-					"defaultValue": "null",
-					"inputType": "ViewElement list",
-					"modelType": "ViewElement[]",
-					"convToModel": "Array.ofList"
-				},
-				{
-					"name": "Orientation",
-					"uniqueName": "StackOrientation",
-					"defaultValue": "Xamarin.Forms.StackOrientation.Vertical"
-				},
-				{
-					"name": "Spacing",
-					"defaultValue": "6.0"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.Span",
-			"members": [
-				{
-					"name": "FontFamily",
-					"defaultValue": "null"
-				},
-				{
-					"name": "FontAttributes",
-					"defaultValue": "Xamarin.Forms.FontAttributes.None"
-				},
-				{
-					"name": "FontSize",
-					"defaultValue": "-1.0",
-					"inputType": "obj",
-					"convToModel": "makeFontSize"
-				},
-				{
-					"name": "BackgroundColor",
-					"defaultValue": "Xamarin.Forms.Color.Default"
-				},
-				{
-					"name": "ForegroundColor",
-					"defaultValue": "Xamarin.Forms.Color.Default"
-				},
-				{
-					"name": "Text",
-					"defaultValue": "null"
-				},
-				{
-					"name": "PropertyChanged",
-					"defaultValue": "null",
-					"inputType": "System.ComponentModel.PropertyChangedEventArgs -> unit",
-					"convToModel": "(fun f -> System.EventHandler<System.ComponentModel.PropertyChangedEventArgs>(fun _sender args -> f args))"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.FormattedString",
-			"members": [
-				{
-					"name": "Spans",
-					"defaultValue": "null",
-					"inputType": "ViewElement[]",
-					"modelType": "ViewElement[]"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.TimePicker",
-			"members": [
-				{
-					"name": "Time",
-					"defaultValue": "new System.TimeSpan()"
-				},
-				{
-					"name": "Format",
-					"defaultValue": "\"t\""
-				},
-				{
-					"name": "TextColor",
-					"defaultValue": "Xamarin.Forms.Color.Default"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.WebView",
-			"members": [
-				{
-					"name": "Source",
-					"uniqueName": "WebSource",
-					"defaultValue": "null"
-				},
-				{
-					"name": "Navigated",
-					"defaultValue": "null",
-					"inputType": "Xamarin.Forms.WebNavigatedEventArgs -> unit",
-					"convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.WebNavigatedEventArgs>(fun _sender args -> f args))"
-				},
-				{
-					"name": "Navigating",
-					"defaultValue": "null",
-					"inputType": "Xamarin.Forms.WebNavigatingEventArgs -> unit",
-					"convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.WebNavigatingEventArgs>(fun _sender args -> f args))"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.Page",
-			"members": [
-				{
-					"name": "Title",
-					"defaultValue": "\"\""
-				},
-				{
-					"name": "BackgroundImage",
-					"inputType": "string",
-					"modelType": "string",
-					"defaultValue": "null"
-				},
-				{
-					"name": "Icon",
-					"inputType": "string",
-					"modelType": "string",
-					"convToValue": "makeFileImageSource",
-					"defaultValue": "null"
-				},
-				{
-					"name": "IsBusy",
-					"inputType": "bool",
-					"modelType": "bool",
-					"defaultValue": "false"
-				},
-				{
-					"name": "Padding",
-					"inputType": "obj",
-					"modelType": "Xamarin.Forms.Thickness",
-					"convToModel": "makeThickness",
-					"defaultValue": "Unchecked.defaultof<Xamarin.Forms.Thickness>"
-				},
-				{
-					"name": "ToolbarItems",
-					"inputType": "ViewElement list",
-					"modelType": "ViewElement[]",
-					"convToModel": "Array.ofList"
-				},
-				{
-					"name": "UseSafeArea",
-					"inputType": "bool",
-					"modelType": "bool",
-					"updateCode": "(fun _ _ target -> Xamarin.Forms.PlatformConfiguration.iOSSpecific.Page.SetUseSafeArea((target : Xamarin.Forms.Page).On<Xamarin.Forms.PlatformConfiguration.iOS>(), true) |> ignore)"
-				},
-				{
-					"name": "Appearing",
-					"uniqueName": "Page_Appearing",
-					"defaultValue": "null",
-					"inputType": "unit -> unit",
-					"convToModel": "(fun f -> System.EventHandler(fun _sender _args -> f ()))"
-				},
-				{
-					"name": "Disappearing",
-					"uniqueName": "Page_Disappearing",
-					"defaultValue": "null",
-					"inputType": "unit -> unit",
-					"convToModel": "(fun f -> System.EventHandler(fun _sender _args -> f ()))"
-				},
-				{
-					"name": "LayoutChanged",
-					"uniqueName": "Page_LayoutChanged",
-					"defaultValue": "null",
-					"inputType": "unit -> unit",
-					"convToModel": "(fun f -> System.EventHandler(fun _sender _args -> f ()))"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.CarouselPage",
-			"members": [
-				{
-					"name": "Children",
-					"defaultValue": "null",
-					"inputType": "ViewElement list",
-					"modelType": "ViewElement[]",
-					"convToModel": "Array.ofList"
-				},
-				{
-					"name": "CurrentPage",
-					"uniqueName": "CarouselPage_CurrentPage",
-					"defaultValue": "0",
-					"inputType": "int",
-					"modelType": "int",
-					"updateCode": "updateCurrentPage<Xamarin.Forms.ContentPage>" 
-				},
-				{
-					"name": "CurrentPageChanged",
-					"uniqueName": "CarouselPage_CurrentPageChanged",
-					"defaultValue": "null",
-					"inputType": "int option -> unit",
-					"convToModel": "makeCurrentPageChanged<Xamarin.Forms.ContentPage>"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.NavigationPage",
-			"members": [
-				{
-					"name": "Pages",
-					"inputType": "ViewElement list",
-					"shortName": "pages",
-					"modelType": "ViewElement[]",
-					"convToModel": "Array.ofList",
-					"updateCode": "updateNavigationPages",
-					"attached": [
-						{
-							"name": "BackButtonTitle",
-							"modelType": "string",
-							"defaultValue": "null"
-						},
-						{
-							"name": "HasBackButton",
-							"modelType": "bool",
-							"defaultValue": "true"
-						},
-						{
-							"name": "HasNavigationBar",
-							"modelType": "bool",
-							"defaultValue": "true"
-						},
-						{
-							"name": "TitleIcon",
-							"inputType": "string",
-							"modelType": "string",
-							"convToValue": "makeFileImageSource",
-							"defaultValue": "null"
-						}
-					]
-				},
-				{
-					"name": "BarBackgroundColor",
-					"defaultValue": "Xamarin.Forms.Color.Default"
-				},
-				{
-					"name": "BarTextColor",
-					"defaultValue": "Xamarin.Forms.Color.Default"
-				},
-				{
-					"name": "Popped",
-					"defaultValue": "null",
-					"inputType": "Xamarin.Forms.NavigationEventArgs -> unit",
-					"convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.NavigationEventArgs>(fun sender args -> f args))"
-				},
-				{
-					"name": "PoppedToRoot",
-					"defaultValue": "null",
-					"inputType": "Xamarin.Forms.NavigationEventArgs -> unit",
-					"convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.NavigationEventArgs>(fun sender args -> f args))"
-				},
-				{
-					"name": "Pushed",
-					"defaultValue": "null",
-					"inputType": "Xamarin.Forms.NavigationEventArgs -> unit",
-					"convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.NavigationEventArgs>(fun sender args -> f args))"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.TabbedPage",
-			"members": [
-				{
-					"name": "Children",
-					"defaultValue": "null",
-					"inputType": "ViewElement list",
-					"modelType": "ViewElement[]",
-					"convToModel": "Array.ofList"
-				},
-				{
-					"name": "BarBackgroundColor",
-					"defaultValue": "Xamarin.Forms.Color.Default"
-				},
-				{
-					"name": "BarTextColor",
-					"defaultValue": "Xamarin.Forms.Color.Default"
-				},
-				{
-					"name": "CurrentPage",
-					"uniqueName": "TabbedPage_CurrentPage",
-					"defaultValue": "0",
-					"inputType": "int",
-					"modelType": "int",
-					"updateCode": "updateCurrentPage<Xamarin.Forms.Page>" 
-				},
-				{
-					"name": "CurrentPageChanged",
-					"uniqueName": "TabbedPage_CurrentPageChanged",
-					"defaultValue": "null",
-					"inputType": "int option -> unit",
-					"convToModel": "makeCurrentPageChanged<Xamarin.Forms.Page>"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.ContentPage",
-			"customType": "Fabulous.DynamicViews.CustomContentPage",
-			"members": [
-				{
-					"name": "Content",
-					"defaultValue": "null"
-				},
-				{
-					"name": "OnSizeAllocatedCallback",
-					"shortName": "onSizeAllocated",
-					"modelType": "FSharp.Control.Handler<(double * double)>",
-					"inputType": "(double * double) -> unit",
-					"convToModel": "(fun f -> FSharp.Control.Handler<_>(fun _sender args -> f args))",
-					"updateCode": "updateOnSizeAllocated"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.MasterDetailPage",
-			"members": [
-				{
-					"name": "Master",
-					"defaultValue": "null"
-				},
-				{
-					"name": "Detail",
-					"defaultValue": "null"
-				},
-				{
-					"name": "IsGestureEnabled",
-					"defaultValue": "true"
-				},
-				{
-					"name": "IsPresented",
-					"defaultValue": "true"
-				},
-				{
-					"name": "MasterBehavior",
-					"defaultValue": "Xamarin.Forms.MasterBehavior.Default"
-				},
-				{
-					"name": "IsPresentedChanged",
-					"defaultValue": "null",
-					"inputType": "bool -> unit",
-					"convToModel": "(fun f -> System.EventHandler(fun sender args -> f (sender :?> Xamarin.Forms.MasterDetailPage).IsPresented))"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.MenuItem",
-			"members": [
-				{
-					"name": "Text",
-					"defaultValue": "null"
-				},
-				{
-					"name": "Command",
-					"defaultValue": "null",
-					"inputType": "unit -> unit",
-					"convToModel": "makeCommand"
-				},
-				{
-					"name": "CommandParameter",
-					"defaultValue": "null"
-				},
-				{
-					"name": "Icon",
-					"inputType": "string",
-					"modelType": "string",
-					"convToValue": "makeFileImageSource",
-					"defaultValue": "null"
-				}
-			],
-			"attached": [
-				{
-					"name": "Accelerator",
-					"inputType": "string",
-					"modelType": "string",
-					"convToValue": "makeAccelerator",
-					"defaultValue": "null"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.TextCell",
-			"members": [
-				{
-					"name": "Text",
-					"defaultValue": "null"
-				},
-				{
-					"name": "Detail",
-					"uniqueName": "TextDetail",
-					"defaultValue": "null"
-				},
-				{
-					"name": "TextColor",
-					"defaultValue": "Xamarin.Forms.Color.Default"
-				},
-				{
-					"name": "DetailColor",
-					"uniqueName": "TextDetailColor",
-					"defaultValue": "Xamarin.Forms.Color.Default"
-				},
-				{
-					"name": "Command",
-					"uniqueName": "TextCellCommand",
-					"inputType": "unit -> unit",
-					"modelType": "unit -> unit",
-					"updateCode": "(fun _ _ _ -> ())" // set below in CanExecute
-				},
-				{
-					"name": "CanExecute",
-					"uniqueName": "TextCellCanExecute",
-					"inputType": "bool",
-					"modelType": "bool",
-					"updateCode": "updateCommand prevTextCellCommandOpt currTextCellCommandOpt (fun _target -> ()) (fun (target: Xamarin.Forms.TextCell) cmd -> target.Command <- cmd)"
-				},
-				{
-					"name": "CommandParameter",
-					"defaultValue": "null"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.ToolbarItem",
-			"members": [
-				{
-					"name": "Order",
-					"defaultValue": "Xamarin.Forms.ToolbarItemOrder.Default"
-				},
-				{
-					"name": "Priority",
-					"defaultValue": "0"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.ImageCell",
-			"members": [
-				{
-					"name": "ImageSource",
-					"inputType": "obj",
-					"modelType": "obj",
-					"convToValue": "makeImageSource",
-					"defaultValue": "null"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.ViewCell",
-			"members": [
-				{
-					"name": "View",
-					"defaultValue": "null"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.ListView",
-			"customType": "Fabulous.DynamicViews.CustomListView",
-			"members": [
-				{
-					"name": "ItemsSource",
-					"uniqueName": "ListViewItems",
-					"shortName": "items",
-					"inputType": "seq<ViewElement>",
-					"modelType": "seq<ViewElement>",
-					"updateCode": "updateListViewItems"
-				},
-				//{
-				//	"name": "ListViewCachingStrategy",
-				//		"inputType": "Xamarin.Forms.ListViewCachingStrategy",
-				//		"isParam": true
-				//	},
-				//{
-				//	"name": "ItemTemplate",
-				//	"defaultValue": "null"
-				//},
-				{
-					"name": "Footer",
-					"defaultValue": "null"
-				},
-				//{
-				//		"name": "FooterTemplate",
-				//		"defaultValue": "null"
-				//		},
-				//	{
-				//			"name": "GroupHeaderTemplate",
-				//			"defaultValue": "null"
-				//		},
-				{
-					"name": "HasUnevenRows",
-					"defaultValue": "false"
-				},
-				{
-					"name": "Header",
-					"defaultValue": "null"
-				},
-				{
-					"name": "HeaderTemplate",
-					"defaultValue": "null"
-				},
-				{
-					"name": "IsGroupingEnabled",
-					"defaultValue": "false"
-				},
-				{
-					"name": "IsPullToRefreshEnabled",
-					"defaultValue": "false"
-				},
-				{
-					"name": "IsRefreshing",
-					"defaultValue": "false"
-				},
-				{
-					"name": "RefreshCommand",
-					"defaultValue": "null",
-					"inputType": "unit -> unit",
-					"convToModel": "makeCommand"
-				},
-				{
-					"name": "RowHeight",
-					"defaultValue": "-1"
-				},
-				{
-					// the SelectedItem is stored as an index integer, when we apply it we fetch out the element from the source
-					"name": "SelectedItem",
-					"uniqueName": "ListView_SelectedItem",
-					"defaultValue": "null",
-					"modelType": "int option",
-					"convToValue": "(function None -> null | Some i -> let items = target.ItemsSource :?> System.Collections.Generic.IList<ListElementData<ViewElement>> in if i >= 0 && i < items.Count then items.[i] else null)"
-				},
-				{
-					"name": "SeparatorVisibility",
-					"uniqueName": "ListView_SeparatorVisibility",
-					"defaultValue": "Xamarin.Forms.SeparatorVisibility.Default"
-				},
-				{
-					"name": "SeparatorColor",
-					"uniqueName": "ListView_SeparatorColor",
-					"defaultValue": "Xamarin.Forms.Color.Default"
-				},
-				{
-					"name": "ItemAppearing",
-					"uniqueName": "ListView_ItemAppearing",
-					"defaultValue": "null",
-					"inputType": "int -> unit",
-					"convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.ItemVisibilityEventArgs>(fun sender args -> f (tryFindListViewItem sender args.Item).Value))"
-				},
-				{
-					"name": "ItemDisappearing",
-					"uniqueName": "ListView_ItemDisappearing",
-					"defaultValue": "null",
-					"inputType": "int -> unit",
-					"convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.ItemVisibilityEventArgs>(fun sender args -> f (tryFindListViewItem sender args.Item).Value))"
-				},
-				{
-					"name": "ItemSelected",
-					"uniqueName": "ListView_ItemSelected",
-					"defaultValue": "null",
-					"inputType": "int option -> unit",
-					"convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.SelectedItemChangedEventArgs>(fun sender args -> f (tryFindListViewItem sender args.SelectedItem)))"
-				},
-				{
-					"name": "ItemTapped",
-					"uniqueName": "ListView_ItemTapped",
-					"defaultValue": "null",
-					"inputType": "int -> unit",
-					"convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.ItemTappedEventArgs>(fun sender args -> f (tryFindListViewItem sender args.Item).Value))"
-				},
-				{
-					"name": "Refreshing",
-					"uniqueName": "ListView_Refreshing",
-					"defaultValue": "null",
-					"inputType": "unit -> unit",
-					"convToModel": "(fun f -> System.EventHandler(fun sender args -> f ()))"
-				},
-				{
-					"name": "SelectionMode",
-					"defaultValue": "Xamarin.Forms.ListViewSelectionMode.Single"
-				}
-			]
-		},
-		{
-			"name": "Xamarin.Forms.ListView",
-			"modelName": "ListViewGrouped",
-			"customType": "Fabulous.DynamicViews.CustomGroupListView",
-			"members": [
-				{
-					"name": "ItemsSource",
-					"uniqueName": "ListViewGrouped_ItemsSource",
-					"shortName": "items",
-					"inputType": "(string * ViewElement * ViewElement list) list",
-					"modelType": "(string * ViewElement * ViewElement[])[]",
-					"convToModel": "(fun es -> es |> Array.ofList |> Array.map (fun (g, e, l) -> (g, e, Array.ofList l)))",
-					"updateCode": "updateListViewGroupedItems"
-				},
-				{
-					"name": "ShowJumpList",
-					"uniqueName": "ListViewGrouped_ShowJumpList",
-					"inputType": "bool",
-					"modelType": "bool",
-					"defaultValue": "false",
-					"updateCode": "updateListViewGroupedShowJumpList"
-				},
-				//{
-				//	"name": "ItemTemplate",
-				//	"defaultValue": "null"
-				//},
-				{
-					"name": "Footer",
-					"defaultValue": "null"
-				},
-				//{
-				//		"name": "FooterTemplate",
-				//		"defaultValue": "null"
-				//		},
-				//	{
-				//			"name": "GroupHeaderTemplate",
-				//			"defaultValue": "null"
-				//		},
-				{
-					"name": "HasUnevenRows",
-					"defaultValue": "false"
-				},
-				{
-					"name": "Header",
-					"defaultValue": "null"
-				},
-				//{
-				//	"name": "HeaderTemplate",
-				//	"defaultValue": "null"
-				//},
-				{
-					"name": "IsPullToRefreshEnabled",
-					"defaultValue": "false"
-				},
-				{
-					"name": "IsRefreshing",
-					"defaultValue": "false"
-				},
-				{
-					"name": "RefreshCommand",
-					"defaultValue": "null",
-					"inputType": "unit -> unit",
-					"convToModel": "makeCommand"
-				},
-				{
-					"name": "RowHeight",
-					"defaultValue": "-1"
-				},
-				{
-					// the SelectedItem is stored as an index integer, when we apply it we fetch out the element from the source
-					"name": "SelectedItem",
-					"uniqueName": "ListViewGrouped_SelectedItem",
-					"defaultValue": "null",
-					"modelType": "(int * int) option",
-					"convToValue": "(function None -> null | Some (i,j) -> let items = target.ItemsSource :?> System.Collections.Generic.IList<ListGroupData<ViewElement>> in (if i >= 0 && i < items.Count then (let items2 = items.[i] in if j >= 0 && j < items2.Count then items2.[j] else null) else null))"
-				},
-				{
-					"name": "SeparatorVisibility",
-					"defaultValue": "Xamarin.Forms.SeparatorVisibility.Default"
-				},
-				{
-					"name": "SeparatorColor",
-					"defaultValue": "Xamarin.Forms.Color.Default"
-				},
-				{
-					"name": "ItemAppearing",
-					"uniqueName": "ListViewGrouped_ItemAppearing",
-					"defaultValue": "null",
-					"inputType": "int * int option -> unit",
-					"convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.ItemVisibilityEventArgs>(fun sender args -> f (tryFindGroupedListViewItemOrGroupItem sender args.Item).Value))"
-				},
-				{
-					"name": "ItemDisappearing",
-					"uniqueName": "ListViewGrouped_ItemDisappearing",
-					"defaultValue": "null",
-					"inputType": "int * int option -> unit",
-					"convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.ItemVisibilityEventArgs>(fun sender args -> f (tryFindGroupedListViewItemOrGroupItem sender args.Item).Value))"
-				},
-				{
-					"name": "ItemSelected",
-					"uniqueName": "ListViewGrouped_ItemSelected",
-					"defaultValue": "null",
-					"inputType": "(int * int) option -> unit",
-					"convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.SelectedItemChangedEventArgs>(fun sender args -> f (tryFindGroupedListViewItem sender args.SelectedItem)))"
-				},
-				{
-					"name": "ItemTapped",
-					"uniqueName": "ListViewGrouped_ItemTapped",
-					"defaultValue": "null",
-					"inputType": "int * int -> unit",
-					"convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.ItemTappedEventArgs>(fun sender args -> f (tryFindGroupedListViewItem sender args.Item).Value))"
-				},
-				{
-					"name": "Refreshing",
-					"defaultValue": "null",
-					"inputType": "unit -> unit",
-					"convToModel": "(fun f -> System.EventHandler(fun sender args -> f ()))"
-				},
-				{
-					"name": "SelectionMode",
-					"defaultValue": "Xamarin.Forms.ListViewSelectionMode.Single"
-				}
-			]
-		}
-	]
+    {
+      "name": "Xamarin.Forms.Label",
+      "members": [
+        {
+          "name": "Text",
+          "defaultValue": "null"
+        },
+        {
+          "name": "HorizontalTextAlignment",
+          "defaultValue": "Xamarin.Forms.TextAlignment.Start"
+        },
+        {
+          "name": "VerticalTextAlignment",
+          "defaultValue": "Xamarin.Forms.TextAlignment.Start"
+        },
+        {
+          "name": "FontSize",
+          "defaultValue": "-1.0",
+          "inputType": "obj",
+          "convToModel": "makeFontSize"
+        },
+        {
+          "name": "FontFamily",
+          "defaultValue": "null"
+        },
+        {
+          "name": "FontAttributes",
+          "defaultValue": "Xamarin.Forms.FontAttributes.None"
+        },
+        {
+          "name": "TextColor",
+          "defaultValue": "Xamarin.Forms.Color.Default"
+        },
+        {
+          "name": "FormattedText",
+          "defaultValue": "null"
+        },
+        {
+          "name": "LineBreakMode",
+          "defaultValue": "Xamarin.Forms.LineBreakMode.WordWrap"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.StackLayout",
+      "members": [
+        {
+          "name": "Children",
+          "defaultValue": "null",
+          "inputType": "ViewElement list",
+          "modelType": "ViewElement[]",
+          "convToModel": "Array.ofList"
+        },
+        {
+          "name": "Orientation",
+          "uniqueName": "StackOrientation",
+          "defaultValue": "Xamarin.Forms.StackOrientation.Vertical"
+        },
+        {
+          "name": "Spacing",
+          "defaultValue": "6.0"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.Span",
+      "members": [
+        {
+          "name": "FontFamily",
+          "defaultValue": "null"
+        },
+        {
+          "name": "FontAttributes",
+          "defaultValue": "Xamarin.Forms.FontAttributes.None"
+        },
+        {
+          "name": "FontSize",
+          "defaultValue": "-1.0",
+          "inputType": "obj",
+          "convToModel": "makeFontSize"
+        },
+        {
+          "name": "BackgroundColor",
+          "defaultValue": "Xamarin.Forms.Color.Default"
+        },
+        {
+          "name": "ForegroundColor",
+          "defaultValue": "Xamarin.Forms.Color.Default"
+        },
+        {
+          "name": "Text",
+          "defaultValue": "null"
+        },
+        {
+          "name": "PropertyChanged",
+          "defaultValue": "null",
+          "inputType": "System.ComponentModel.PropertyChangedEventArgs -> unit",
+          "convToModel": "(fun f -> System.EventHandler<System.ComponentModel.PropertyChangedEventArgs>(fun _sender args -> f args))"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.FormattedString",
+      "members": [
+        {
+          "name": "Spans",
+          "defaultValue": "null",
+          "inputType": "ViewElement[]",
+          "modelType": "ViewElement[]"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.TimePicker",
+      "members": [
+        {
+          "name": "Time",
+          "defaultValue": "new System.TimeSpan()"
+        },
+        {
+          "name": "Format",
+          "defaultValue": "\"t\""
+        },
+        {
+          "name": "TextColor",
+          "defaultValue": "Xamarin.Forms.Color.Default"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.WebView",
+      "members": [
+        {
+          "name": "Source",
+          "uniqueName": "WebSource",
+          "defaultValue": "null"
+        },
+        {
+          "name": "Navigated",
+          "defaultValue": "null",
+          "inputType": "Xamarin.Forms.WebNavigatedEventArgs -> unit",
+          "convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.WebNavigatedEventArgs>(fun _sender args -> f args))"
+        },
+        {
+          "name": "Navigating",
+          "defaultValue": "null",
+          "inputType": "Xamarin.Forms.WebNavigatingEventArgs -> unit",
+          "convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.WebNavigatingEventArgs>(fun _sender args -> f args))"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.Page",
+      "members": [
+        {
+          "name": "Title",
+          "defaultValue": "\"\""
+        },
+        {
+          "name": "BackgroundImage",
+          "inputType": "string",
+          "modelType": "string",
+          "defaultValue": "null"
+        },
+        {
+          "name": "Icon",
+          "inputType": "string",
+          "modelType": "string",
+          "convToValue": "makeFileImageSource",
+          "defaultValue": "null"
+        },
+        {
+          "name": "IsBusy",
+          "inputType": "bool",
+          "modelType": "bool",
+          "defaultValue": "false"
+        },
+        {
+          "name": "Padding",
+          "inputType": "obj",
+          "modelType": "Xamarin.Forms.Thickness",
+          "convToModel": "makeThickness",
+          "defaultValue": "Unchecked.defaultof<Xamarin.Forms.Thickness>"
+        },
+        {
+          "name": "ToolbarItems",
+          "inputType": "ViewElement list",
+          "modelType": "ViewElement[]",
+          "convToModel": "Array.ofList"
+        },
+        {
+          "name": "UseSafeArea",
+          "inputType": "bool",
+          "modelType": "bool",
+          "updateCode": "(fun _ _ target -> Xamarin.Forms.PlatformConfiguration.iOSSpecific.Page.SetUseSafeArea((target : Xamarin.Forms.Page).On<Xamarin.Forms.PlatformConfiguration.iOS>(), true) |> ignore)"
+        },
+        {
+          "name": "Appearing",
+          "uniqueName": "Page_Appearing",
+          "defaultValue": "null",
+          "inputType": "unit -> unit",
+          "convToModel": "(fun f -> System.EventHandler(fun _sender _args -> f ()))"
+        },
+        {
+          "name": "Disappearing",
+          "uniqueName": "Page_Disappearing",
+          "defaultValue": "null",
+          "inputType": "unit -> unit",
+          "convToModel": "(fun f -> System.EventHandler(fun _sender _args -> f ()))"
+        },
+        {
+          "name": "LayoutChanged",
+          "uniqueName": "Page_LayoutChanged",
+          "defaultValue": "null",
+          "inputType": "unit -> unit",
+          "convToModel": "(fun f -> System.EventHandler(fun _sender _args -> f ()))"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.CarouselPage",
+      "members": [
+        {
+          "name": "Children",
+          "defaultValue": "null",
+          "inputType": "ViewElement list",
+          "modelType": "ViewElement[]",
+          "convToModel": "Array.ofList"
+        },
+        {
+          "name": "CurrentPage",
+          "uniqueName": "CarouselPage_CurrentPage",
+          "defaultValue": "0",
+          "inputType": "int",
+          "modelType": "int",
+          "updateCode": "updateCurrentPage<Xamarin.Forms.ContentPage>"
+        },
+        {
+          "name": "CurrentPageChanged",
+          "uniqueName": "CarouselPage_CurrentPageChanged",
+          "defaultValue": "null",
+          "inputType": "int option -> unit",
+          "convToModel": "makeCurrentPageChanged<Xamarin.Forms.ContentPage>"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.NavigationPage",
+      "members": [
+        {
+          "name": "Pages",
+          "inputType": "ViewElement list",
+          "shortName": "pages",
+          "modelType": "ViewElement[]",
+          "convToModel": "Array.ofList",
+          "updateCode": "updateNavigationPages",
+          "attached": [
+            {
+              "name": "BackButtonTitle",
+              "modelType": "string",
+              "defaultValue": "null"
+            },
+            {
+              "name": "HasBackButton",
+              "modelType": "bool",
+              "defaultValue": "true"
+            },
+            {
+              "name": "HasNavigationBar",
+              "modelType": "bool",
+              "defaultValue": "true"
+            },
+            {
+              "name": "TitleIcon",
+              "inputType": "string",
+              "modelType": "string",
+              "convToValue": "makeFileImageSource",
+              "defaultValue": "null"
+            }
+          ]
+        },
+        {
+          "name": "BarBackgroundColor",
+          "defaultValue": "Xamarin.Forms.Color.Default"
+        },
+        {
+          "name": "BarTextColor",
+          "defaultValue": "Xamarin.Forms.Color.Default"
+        },
+        {
+          "name": "Popped",
+          "defaultValue": "null",
+          "inputType": "Xamarin.Forms.NavigationEventArgs -> unit",
+          "convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.NavigationEventArgs>(fun sender args -> f args))"
+        },
+        {
+          "name": "PoppedToRoot",
+          "defaultValue": "null",
+          "inputType": "Xamarin.Forms.NavigationEventArgs -> unit",
+          "convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.NavigationEventArgs>(fun sender args -> f args))"
+        },
+        {
+          "name": "Pushed",
+          "defaultValue": "null",
+          "inputType": "Xamarin.Forms.NavigationEventArgs -> unit",
+          "convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.NavigationEventArgs>(fun sender args -> f args))"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.TabbedPage",
+      "members": [
+        {
+          "name": "Children",
+          "defaultValue": "null",
+          "inputType": "ViewElement list",
+          "modelType": "ViewElement[]",
+          "convToModel": "Array.ofList"
+        },
+        {
+          "name": "BarBackgroundColor",
+          "defaultValue": "Xamarin.Forms.Color.Default"
+        },
+        {
+          "name": "BarTextColor",
+          "defaultValue": "Xamarin.Forms.Color.Default"
+        },
+        {
+          "name": "CurrentPage",
+          "uniqueName": "TabbedPage_CurrentPage",
+          "defaultValue": "0",
+          "inputType": "int",
+          "modelType": "int",
+          "updateCode": "updateCurrentPage<Xamarin.Forms.Page>"
+        },
+        {
+          "name": "CurrentPageChanged",
+          "uniqueName": "TabbedPage_CurrentPageChanged",
+          "defaultValue": "null",
+          "inputType": "int option -> unit",
+          "convToModel": "makeCurrentPageChanged<Xamarin.Forms.Page>"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.ContentPage",
+      "customType": "Fabulous.DynamicViews.CustomContentPage",
+      "members": [
+        {
+          "name": "Content",
+          "defaultValue": "null"
+        },
+        {
+          "name": "OnSizeAllocatedCallback",
+          "shortName": "onSizeAllocated",
+          "modelType": "FSharp.Control.Handler<(double * double)>",
+          "inputType": "(double * double) -> unit",
+          "convToModel": "(fun f -> FSharp.Control.Handler<_>(fun _sender args -> f args))",
+          "updateCode": "updateOnSizeAllocated"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.MasterDetailPage",
+      "members": [
+        {
+          "name": "Master",
+          "defaultValue": "null"
+        },
+        {
+          "name": "Detail",
+          "defaultValue": "null"
+        },
+        {
+          "name": "IsGestureEnabled",
+          "defaultValue": "true"
+        },
+        {
+          "name": "IsPresented",
+          "defaultValue": "true"
+        },
+        {
+          "name": "MasterBehavior",
+          "defaultValue": "Xamarin.Forms.MasterBehavior.Default"
+        },
+        {
+          "name": "IsPresentedChanged",
+          "defaultValue": "null",
+          "inputType": "bool -> unit",
+          "convToModel": "(fun f -> System.EventHandler(fun sender args -> f (sender :?> Xamarin.Forms.MasterDetailPage).IsPresented))"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.MenuItem",
+      "members": [
+        {
+          "name": "Text",
+          "defaultValue": "null"
+        },
+        {
+          "name": "Command",
+          "defaultValue": "null",
+          "inputType": "unit -> unit",
+          "convToModel": "makeCommand"
+        },
+        {
+          "name": "CommandParameter",
+          "defaultValue": "null"
+        },
+        {
+          "name": "Icon",
+          "inputType": "string",
+          "modelType": "string",
+          "convToValue": "makeFileImageSource",
+          "defaultValue": "null"
+        }
+      ],
+      "attached": [
+        {
+          "name": "Accelerator",
+          "inputType": "string",
+          "modelType": "string",
+          "convToValue": "makeAccelerator",
+          "defaultValue": "null"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.TextCell",
+      "members": [
+        {
+          "name": "Text",
+          "defaultValue": "null"
+        },
+        {
+          "name": "Detail",
+          "uniqueName": "TextDetail",
+          "defaultValue": "null"
+        },
+        {
+          "name": "TextColor",
+          "defaultValue": "Xamarin.Forms.Color.Default"
+        },
+        {
+          "name": "DetailColor",
+          "uniqueName": "TextDetailColor",
+          "defaultValue": "Xamarin.Forms.Color.Default"
+        },
+        {
+          "name": "Command",
+          "uniqueName": "TextCellCommand",
+          "inputType": "unit -> unit",
+          "modelType": "unit -> unit",
+          "updateCode": "(fun _ _ _ -> ())"
+        },
+        {
+          "name": "CanExecute",
+          "uniqueName": "TextCellCanExecute",
+          "inputType": "bool",
+          "modelType": "bool",
+          "updateCode": "updateCommand prevTextCellCommandOpt currTextCellCommandOpt (fun _target -> ()) (fun (target: Xamarin.Forms.TextCell) cmd -> target.Command <- cmd)"
+        },
+        {
+          "name": "CommandParameter",
+          "defaultValue": "null"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.ToolbarItem",
+      "members": [
+        {
+          "name": "Order",
+          "defaultValue": "Xamarin.Forms.ToolbarItemOrder.Default"
+        },
+        {
+          "name": "Priority",
+          "defaultValue": "0"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.ImageCell",
+      "members": [
+        {
+          "name": "ImageSource",
+          "inputType": "obj",
+          "modelType": "obj",
+          "convToValue": "makeImageSource",
+          "defaultValue": "null"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.ViewCell",
+      "members": [
+        {
+          "name": "View",
+          "defaultValue": "null"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.ListView",
+      "customType": "Fabulous.DynamicViews.CustomListView",
+      "members": [
+        {
+          "name": "ItemsSource",
+          "uniqueName": "ListViewItems",
+          "shortName": "items",
+          "inputType": "seq<ViewElement>",
+          "modelType": "seq<ViewElement>",
+          "updateCode": "updateListViewItems"
+        },
+        {
+          "name": "Footer",
+          "defaultValue": "null"
+        },
+        {
+          "name": "HasUnevenRows",
+          "defaultValue": "false"
+        },
+        {
+          "name": "Header",
+          "defaultValue": "null"
+        },
+        {
+          "name": "HeaderTemplate",
+          "defaultValue": "null"
+        },
+        {
+          "name": "IsGroupingEnabled",
+          "defaultValue": "false"
+        },
+        {
+          "name": "IsPullToRefreshEnabled",
+          "defaultValue": "false"
+        },
+        {
+          "name": "IsRefreshing",
+          "defaultValue": "false"
+        },
+        {
+          "name": "RefreshCommand",
+          "defaultValue": "null",
+          "inputType": "unit -> unit",
+          "convToModel": "makeCommand"
+        },
+        {
+          "name": "RowHeight",
+          "defaultValue": "-1"
+        },
+        {
+          "name": "SelectedItem",
+          "uniqueName": "ListView_SelectedItem",
+          "defaultValue": "null",
+          "modelType": "int option",
+          "convToValue": "(function None -> null | Some i -> let items = target.ItemsSource :?> System.Collections.Generic.IList<ListElementData<ViewElement>> in if i >= 0 && i < items.Count then items.[i] else null)"
+        },
+        {
+          "name": "SeparatorVisibility",
+          "uniqueName": "ListView_SeparatorVisibility",
+          "defaultValue": "Xamarin.Forms.SeparatorVisibility.Default"
+        },
+        {
+          "name": "SeparatorColor",
+          "uniqueName": "ListView_SeparatorColor",
+          "defaultValue": "Xamarin.Forms.Color.Default"
+        },
+        {
+          "name": "ItemAppearing",
+          "uniqueName": "ListView_ItemAppearing",
+          "defaultValue": "null",
+          "inputType": "int -> unit",
+          "convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.ItemVisibilityEventArgs>(fun sender args -> f (tryFindListViewItem sender args.Item).Value))"
+        },
+        {
+          "name": "ItemDisappearing",
+          "uniqueName": "ListView_ItemDisappearing",
+          "defaultValue": "null",
+          "inputType": "int -> unit",
+          "convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.ItemVisibilityEventArgs>(fun sender args -> f (tryFindListViewItem sender args.Item).Value))"
+        },
+        {
+          "name": "ItemSelected",
+          "uniqueName": "ListView_ItemSelected",
+          "defaultValue": "null",
+          "inputType": "int option -> unit",
+          "convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.SelectedItemChangedEventArgs>(fun sender args -> f (tryFindListViewItem sender args.SelectedItem)))"
+        },
+        {
+          "name": "ItemTapped",
+          "uniqueName": "ListView_ItemTapped",
+          "defaultValue": "null",
+          "inputType": "int -> unit",
+          "convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.ItemTappedEventArgs>(fun sender args -> f (tryFindListViewItem sender args.Item).Value))"
+        },
+        {
+          "name": "Refreshing",
+          "uniqueName": "ListView_Refreshing",
+          "defaultValue": "null",
+          "inputType": "unit -> unit",
+          "convToModel": "(fun f -> System.EventHandler(fun sender args -> f ()))"
+        },
+        {
+          "name": "SelectionMode",
+          "defaultValue": "Xamarin.Forms.ListViewSelectionMode.Single"
+        }
+      ]
+    },
+    {
+      "name": "Xamarin.Forms.ListView",
+      "modelName": "ListViewGrouped",
+      "customType": "Fabulous.DynamicViews.CustomGroupListView",
+      "members": [
+        {
+          "name": "ItemsSource",
+          "uniqueName": "ListViewGrouped_ItemsSource",
+          "shortName": "items",
+          "inputType": "(string * ViewElement * ViewElement list) list",
+          "modelType": "(string * ViewElement * ViewElement[])[]",
+          "convToModel": "(fun es -> es |> Array.ofList |> Array.map (fun (g, e, l) -> (g, e, Array.ofList l)))",
+          "updateCode": "updateListViewGroupedItems"
+        },
+        {
+          "name": "ShowJumpList",
+          "uniqueName": "ListViewGrouped_ShowJumpList",
+          "inputType": "bool",
+          "modelType": "bool",
+          "defaultValue": "false",
+          "updateCode": "updateListViewGroupedShowJumpList"
+        },
+        {
+          "name": "Footer",
+          "defaultValue": "null"
+        },
+        {
+          "name": "HasUnevenRows",
+          "defaultValue": "false"
+        },
+        {
+          "name": "Header",
+          "defaultValue": "null"
+        },
+        {
+          "name": "IsPullToRefreshEnabled",
+          "defaultValue": "false"
+        },
+        {
+          "name": "IsRefreshing",
+          "defaultValue": "false"
+        },
+        {
+          "name": "RefreshCommand",
+          "defaultValue": "null",
+          "inputType": "unit -> unit",
+          "convToModel": "makeCommand"
+        },
+        {
+          "name": "RowHeight",
+          "defaultValue": "-1"
+        },
+        {
+          "name": "SelectedItem",
+          "uniqueName": "ListViewGrouped_SelectedItem",
+          "defaultValue": "null",
+          "modelType": "(int * int) option",
+          "convToValue": "(function None -> null | Some (i,j) -> let items = target.ItemsSource :?> System.Collections.Generic.IList<ListGroupData<ViewElement>> in (if i >= 0 && i < items.Count then (let items2 = items.[i] in if j >= 0 && j < items2.Count then items2.[j] else null) else null))"
+        },
+        {
+          "name": "SeparatorVisibility",
+          "defaultValue": "Xamarin.Forms.SeparatorVisibility.Default"
+        },
+        {
+          "name": "SeparatorColor",
+          "defaultValue": "Xamarin.Forms.Color.Default"
+        },
+        {
+          "name": "ItemAppearing",
+          "uniqueName": "ListViewGrouped_ItemAppearing",
+          "defaultValue": "null",
+          "inputType": "int * int option -> unit",
+          "convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.ItemVisibilityEventArgs>(fun sender args -> f (tryFindGroupedListViewItemOrGroupItem sender args.Item).Value))"
+        },
+        {
+          "name": "ItemDisappearing",
+          "uniqueName": "ListViewGrouped_ItemDisappearing",
+          "defaultValue": "null",
+          "inputType": "int * int option -> unit",
+          "convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.ItemVisibilityEventArgs>(fun sender args -> f (tryFindGroupedListViewItemOrGroupItem sender args.Item).Value))"
+        },
+        {
+          "name": "ItemSelected",
+          "uniqueName": "ListViewGrouped_ItemSelected",
+          "defaultValue": "null",
+          "inputType": "(int * int) option -> unit",
+          "convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.SelectedItemChangedEventArgs>(fun sender args -> f (tryFindGroupedListViewItem sender args.SelectedItem)))"
+        },
+        {
+          "name": "ItemTapped",
+          "uniqueName": "ListViewGrouped_ItemTapped",
+          "defaultValue": "null",
+          "inputType": "int * int -> unit",
+          "convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.ItemTappedEventArgs>(fun sender args -> f (tryFindGroupedListViewItem sender args.Item).Value))"
+        },
+        {
+          "name": "Refreshing",
+          "defaultValue": "null",
+          "inputType": "unit -> unit",
+          "convToModel": "(fun f -> System.EventHandler(fun sender args -> f ()))"
+        },
+        {
+          "name": "SelectionMode",
+          "defaultValue": "Xamarin.Forms.ListViewSelectionMode.Single"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Added an initial step in the build process to format the Json Bindings files used by the Generator.
I did this to avoid losing GitHub tooling when diffing PRs (IDEs tend to format differently, 4 indents/2 indents, space/tab chars, etc.)