### PR TITLE
MacOS template is missing a reference to Fabulous

### DIFF
--- a/templates/content/blank/NewApp.macOS/NewApp.macOS.fsproj
+++ b/templates/content/blank/NewApp.macOS/NewApp.macOS.fsproj
@@ -100,6 +100,12 @@
     <Reference Include="FSharp.Core">
       <HintPath>..\packages\FSharp.Core.FSharpCorePkgVersion\lib\netstandard1.6\FSharp.Core.dll</HintPath>
     </Reference>
+    <Reference Include="Fabulous.CustomControls">
+      <HintPath>..\packages\Fabulous.CustomControls.FabulousPkgsVersion\lib\netstandard2.0\Fabulous.CustomControls.dll</HintPath>
+    </Reference>
+    <Reference Include="Fabulous.Core">
+      <HintPath>..\packages\Fabulous.Core.FabulousPkgsVersion\lib\netstandard2.0\Fabulous.Core.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.FSharp.targets" Condition="Exists('$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.FSharp.targets')"/>
   <ItemGroup>

--- a/templates/content/blank/NewApp.macOS/NewApp.macOS.fsproj
+++ b/templates/content/blank/NewApp.macOS/NewApp.macOS.fsproj
@@ -82,7 +82,6 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Numerics" />
-    <Reference Include="netstandard" />
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.Mac" />
     <Reference Include="Xamarin.Forms.Core">


### PR DESCRIPTION
After running `dotnet new fabulous-app -n SqueakyApp --macOS`, the MacOS fsproj is invalid.
`Fabulous.Core` and `Fabulous.CustomControls` are here in the `packages.config` of the project, but the dlls are missing in the fsproj.

This results in a successful build but a runtime error.
The app complains to be unable to find `Fabulous.Core`.