### PR TITLE
Fix nuget errors when building/generating files from blank on Windows

### DIFF
--- a/templates/content/blank/.nuget/NuGet.targets
+++ b/templates/content/blank/.nuget/NuGet.targets
@@ -50,7 +50,7 @@
         <RequireConsentSwitch Condition=" $(RequireRestoreConsent) == 'true' ">-RequireConsent</RequireConsentSwitch>
         <NonInteractiveSwitch Condition=" '$(VisualStudioVersion)' != '' AND '$(OS)' == 'Windows_NT' ">-NonInteractive</NonInteractiveSwitch>
         
-        <PaddedSolutionDir Condition=" '$(OS)' == 'Windows_NT'">"$(SolutionDir) "</PaddedSolutionDir>
+        <PaddedSolutionDir Condition=" '$(OS)' == 'Windows_NT'">"$(SolutionDir.Trim('\\'))"</PaddedSolutionDir>
         <PaddedSolutionDir Condition=" '$(OS)' != 'Windows_NT' ">"$(SolutionDir)"</PaddedSolutionDir>
 
         <!-- Commands -->


### PR DESCRIPTION
Fixes errors when creating Fabulous from scratch on Windows and then using the dotnet template to generate projects. This also allows running `build.cmd Test` on a CI build.

Fix of issue #288 