### PR TITLE
#292 Move titileView from NavigationPage to Page.

### DIFF
--- a/src/Fabulous.Core/ViewConverters.fs
+++ b/src/Fabulous.Core/ViewConverters.fs
@@ -627,7 +627,7 @@ module Converters =
         | ValueNone, ValueSome curr -> updateFunc defaultValue curr
 
     /// Update the attached NavigationPage.TitleView property of a Page, given previous and current values
-    let internal updateNavigationPageTitleView (prevOpt: ViewElement voption) (currOpt: ViewElement voption) (target: Page) =
+    let internal updatePageTitleView (prevOpt: ViewElement voption) (currOpt: ViewElement voption) (target: Page) =
         match prevOpt, currOpt with
         | ValueSome prev, ValueSome curr when identical prev curr -> ()
         | ValueSome prev, ValueSome curr when canReuseChild prev curr ->

--- a/src/Fabulous.Core/ViewConverters.fs
+++ b/src/Fabulous.Core/ViewConverters.fs
@@ -626,8 +626,8 @@ module Converters =
         | ValueSome prev, ValueNone -> updateFunc prev defaultValue
         | ValueNone, ValueSome curr -> updateFunc defaultValue curr
 
-    /// Update the TitleView of a NavigationPage, given previous and current values
-    let internal updateNavigationPageTitleView (prevOpt: ViewElement voption) (currOpt: ViewElement voption) (target: Xamarin.Forms.NavigationPage) =
+    /// Update the attached NavigationPage.TitleView property of a Page, given previous and current values
+    let internal updateNavigationPageTitleView (prevOpt: ViewElement voption) (currOpt: ViewElement voption) (target: Page) =
         match prevOpt, currOpt with
         | ValueSome prev, ValueSome curr when identical prev curr -> ()
         | ValueSome prev, ValueSome curr when canReuseChild prev curr ->

--- a/src/Fabulous.Core/Xamarin.Forms.Core.fs
+++ b/src/Fabulous.Core/Xamarin.Forms.Core.fs
@@ -9266,7 +9266,7 @@ type View() =
         | _, ValueSome currValue -> target.Padding <-  currValue
         | ValueSome _, ValueNone -> target.Padding <- Unchecked.defaultof<Xamarin.Forms.Thickness>
         | ValueNone, ValueNone -> ()
-        updateNavigationPageTitleView prevTitleViewOpt currTitleViewOpt target
+        updatePageTitleView prevTitleViewOpt currTitleViewOpt target
         updateCollectionGeneric prevToolbarItemsOpt currToolbarItemsOpt target.ToolbarItems
             (fun (x:ViewElement) -> x.Create() :?> Xamarin.Forms.ToolbarItem)
             (fun _ _ _ -> ())

--- a/src/Fabulous.Core/Xamarin.Forms.Core.fs
+++ b/src/Fabulous.Core/Xamarin.Forms.Core.fs
@@ -350,6 +350,8 @@ type View() =
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
     static member val _IsBusyAttribKey : AttributeKey<_> = AttributeKey<_>("IsBusy")
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
+    static member val _TitleViewAttribKey : AttributeKey<_> = AttributeKey<_>("TitleView")
+    [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
     static member val _ToolbarItemsAttribKey : AttributeKey<_> = AttributeKey<_>("ToolbarItems")
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
     static member val _UseSafeAreaAttribKey : AttributeKey<_> = AttributeKey<_>("UseSafeArea")
@@ -377,8 +379,6 @@ type View() =
     static member val _BarBackgroundColorAttribKey : AttributeKey<_> = AttributeKey<_>("BarBackgroundColor")
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
     static member val _BarTextColorAttribKey : AttributeKey<_> = AttributeKey<_>("BarTextColor")
-    [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
-    static member val _TitleViewAttribKey : AttributeKey<_> = AttributeKey<_>("TitleView")
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
     static member val _PoppedAttribKey : AttributeKey<_> = AttributeKey<_>("Popped")
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
@@ -9091,6 +9091,7 @@ type View() =
                                    ?icon: string,
                                    ?isBusy: bool,
                                    ?padding: obj,
+                                   ?titleView: ViewElement,
                                    ?toolbarItems: ViewElement list,
                                    ?useSafeArea: bool,
                                    ?appearing: unit -> unit,
@@ -9133,6 +9134,7 @@ type View() =
         let attribCount = match icon with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match isBusy with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match padding with Some _ -> attribCount + 1 | None -> attribCount
+        let attribCount = match titleView with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match toolbarItems with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match useSafeArea with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match appearing with Some _ -> attribCount + 1 | None -> attribCount
@@ -9145,6 +9147,7 @@ type View() =
         match icon with None -> () | Some v -> attribBuilder.Add(View._IconAttribKey, (v)) 
         match isBusy with None -> () | Some v -> attribBuilder.Add(View._IsBusyAttribKey, (v)) 
         match padding with None -> () | Some v -> attribBuilder.Add(View._PaddingAttribKey, makeThickness(v)) 
+        match titleView with None -> () | Some v -> attribBuilder.Add(View._TitleViewAttribKey, (v)) 
         match toolbarItems with None -> () | Some v -> attribBuilder.Add(View._ToolbarItemsAttribKey, Array.ofList(v)) 
         match useSafeArea with None -> () | Some v -> attribBuilder.Add(View._UseSafeAreaAttribKey, (v)) 
         match appearing with None -> () | Some v -> attribBuilder.Add(View._Page_AppearingAttribKey, (fun f -> System.EventHandler(fun _sender _args -> f ()))(v)) 
@@ -9177,6 +9180,8 @@ type View() =
         let mutable currIsBusyOpt = ValueNone
         let mutable prevPaddingOpt = ValueNone
         let mutable currPaddingOpt = ValueNone
+        let mutable prevTitleViewOpt = ValueNone
+        let mutable currTitleViewOpt = ValueNone
         let mutable prevToolbarItemsOpt = ValueNone
         let mutable currToolbarItemsOpt = ValueNone
         let mutable prevUseSafeAreaOpt = ValueNone
@@ -9198,6 +9203,8 @@ type View() =
                 currIsBusyOpt <- ValueSome (kvp.Value :?> bool)
             if kvp.Key = View._PaddingAttribKey.KeyValue then 
                 currPaddingOpt <- ValueSome (kvp.Value :?> Xamarin.Forms.Thickness)
+            if kvp.Key = View._TitleViewAttribKey.KeyValue then 
+                currTitleViewOpt <- ValueSome (kvp.Value :?> ViewElement)
             if kvp.Key = View._ToolbarItemsAttribKey.KeyValue then 
                 currToolbarItemsOpt <- ValueSome (kvp.Value :?> ViewElement[])
             if kvp.Key = View._UseSafeAreaAttribKey.KeyValue then 
@@ -9222,6 +9229,8 @@ type View() =
                     prevIsBusyOpt <- ValueSome (kvp.Value :?> bool)
                 if kvp.Key = View._PaddingAttribKey.KeyValue then 
                     prevPaddingOpt <- ValueSome (kvp.Value :?> Xamarin.Forms.Thickness)
+                if kvp.Key = View._TitleViewAttribKey.KeyValue then 
+                    prevTitleViewOpt <- ValueSome (kvp.Value :?> ViewElement)
                 if kvp.Key = View._ToolbarItemsAttribKey.KeyValue then 
                     prevToolbarItemsOpt <- ValueSome (kvp.Value :?> ViewElement[])
                 if kvp.Key = View._UseSafeAreaAttribKey.KeyValue then 
@@ -9257,6 +9266,7 @@ type View() =
         | _, ValueSome currValue -> target.Padding <-  currValue
         | ValueSome _, ValueNone -> target.Padding <- Unchecked.defaultof<Xamarin.Forms.Thickness>
         | ValueNone, ValueNone -> ()
+        updateNavigationPageTitleView prevTitleViewOpt currTitleViewOpt target
         updateCollectionGeneric prevToolbarItemsOpt currToolbarItemsOpt target.ToolbarItems
             (fun (x:ViewElement) -> x.Create() :?> Xamarin.Forms.ToolbarItem)
             (fun _ _ _ -> ())
@@ -9288,6 +9298,7 @@ type View() =
                               ?icon: string,
                               ?isBusy: bool,
                               ?padding: obj,
+                              ?titleView: ViewElement,
                               ?toolbarItems: ViewElement list,
                               ?useSafeArea: bool,
                               ?appearing: unit -> unit,
@@ -9331,6 +9342,7 @@ type View() =
                                ?icon=icon,
                                ?isBusy=isBusy,
                                ?padding=padding,
+                               ?titleView=titleView,
                                ?toolbarItems=toolbarItems,
                                ?useSafeArea=useSafeArea,
                                ?appearing=appearing,
@@ -9384,6 +9396,7 @@ type View() =
                                            ?icon: string,
                                            ?isBusy: bool,
                                            ?padding: obj,
+                                           ?titleView: ViewElement,
                                            ?toolbarItems: ViewElement list,
                                            ?useSafeArea: bool,
                                            ?appearing: unit -> unit,
@@ -9425,7 +9438,7 @@ type View() =
         let attribCount = match currentPage with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match currentPageChanged with Some _ -> attribCount + 1 | None -> attribCount
 
-        let attribBuilder = View.BuildPage(attribCount, ?title=title, ?backgroundImage=backgroundImage, ?icon=icon, ?isBusy=isBusy, ?padding=padding, ?toolbarItems=toolbarItems, ?useSafeArea=useSafeArea, ?appearing=appearing, ?disappearing=disappearing, ?layoutChanged=layoutChanged, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?styleClass=styleClass, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?isTabStop=isTabStop, ?scaleX=scaleX, ?scaleY=scaleY, ?tabIndex=tabIndex, ?classId=classId, ?styleId=styleId, ?automationId=automationId, ?created=created, ?ref=ref)
+        let attribBuilder = View.BuildPage(attribCount, ?title=title, ?backgroundImage=backgroundImage, ?icon=icon, ?isBusy=isBusy, ?padding=padding, ?titleView=titleView, ?toolbarItems=toolbarItems, ?useSafeArea=useSafeArea, ?appearing=appearing, ?disappearing=disappearing, ?layoutChanged=layoutChanged, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?styleClass=styleClass, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?isTabStop=isTabStop, ?scaleX=scaleX, ?scaleY=scaleY, ?tabIndex=tabIndex, ?classId=classId, ?styleId=styleId, ?automationId=automationId, ?created=created, ?ref=ref)
         match children with None -> () | Some v -> attribBuilder.Add(View._ChildrenAttribKey, Array.ofList(v)) 
         match currentPage with None -> () | Some v -> attribBuilder.Add(View._CarouselPage_CurrentPageAttribKey, (v)) 
         match currentPageChanged with None -> () | Some v -> attribBuilder.Add(View._CarouselPage_CurrentPageChangedAttribKey, makeCurrentPageChanged<Xamarin.Forms.ContentPage>(v)) 
@@ -9491,6 +9504,7 @@ type View() =
                                       ?icon: string,
                                       ?isBusy: bool,
                                       ?padding: obj,
+                                      ?titleView: ViewElement,
                                       ?toolbarItems: ViewElement list,
                                       ?useSafeArea: bool,
                                       ?appearing: unit -> unit,
@@ -9537,6 +9551,7 @@ type View() =
                                ?icon=icon,
                                ?isBusy=isBusy,
                                ?padding=padding,
+                               ?titleView=titleView,
                                ?toolbarItems=toolbarItems,
                                ?useSafeArea=useSafeArea,
                                ?appearing=appearing,
@@ -9585,7 +9600,6 @@ type View() =
                                              ?pages: ViewElement list,
                                              ?barBackgroundColor: Xamarin.Forms.Color,
                                              ?barTextColor: Xamarin.Forms.Color,
-                                             ?titleView: ViewElement,
                                              ?popped: Xamarin.Forms.NavigationEventArgs -> unit,
                                              ?poppedToRoot: Xamarin.Forms.NavigationEventArgs -> unit,
                                              ?pushed: Xamarin.Forms.NavigationEventArgs -> unit,
@@ -9594,6 +9608,7 @@ type View() =
                                              ?icon: string,
                                              ?isBusy: bool,
                                              ?padding: obj,
+                                             ?titleView: ViewElement,
                                              ?toolbarItems: ViewElement list,
                                              ?useSafeArea: bool,
                                              ?appearing: unit -> unit,
@@ -9634,16 +9649,14 @@ type View() =
         let attribCount = match pages with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match barBackgroundColor with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match barTextColor with Some _ -> attribCount + 1 | None -> attribCount
-        let attribCount = match titleView with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match popped with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match poppedToRoot with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match pushed with Some _ -> attribCount + 1 | None -> attribCount
 
-        let attribBuilder = View.BuildPage(attribCount, ?title=title, ?backgroundImage=backgroundImage, ?icon=icon, ?isBusy=isBusy, ?padding=padding, ?toolbarItems=toolbarItems, ?useSafeArea=useSafeArea, ?appearing=appearing, ?disappearing=disappearing, ?layoutChanged=layoutChanged, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?styleClass=styleClass, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?isTabStop=isTabStop, ?scaleX=scaleX, ?scaleY=scaleY, ?tabIndex=tabIndex, ?classId=classId, ?styleId=styleId, ?automationId=automationId, ?created=created, ?ref=ref)
+        let attribBuilder = View.BuildPage(attribCount, ?title=title, ?backgroundImage=backgroundImage, ?icon=icon, ?isBusy=isBusy, ?padding=padding, ?titleView=titleView, ?toolbarItems=toolbarItems, ?useSafeArea=useSafeArea, ?appearing=appearing, ?disappearing=disappearing, ?layoutChanged=layoutChanged, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?styleClass=styleClass, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?isTabStop=isTabStop, ?scaleX=scaleX, ?scaleY=scaleY, ?tabIndex=tabIndex, ?classId=classId, ?styleId=styleId, ?automationId=automationId, ?created=created, ?ref=ref)
         match pages with None -> () | Some v -> attribBuilder.Add(View._PagesAttribKey, Array.ofList(v)) 
         match barBackgroundColor with None -> () | Some v -> attribBuilder.Add(View._BarBackgroundColorAttribKey, (v)) 
         match barTextColor with None -> () | Some v -> attribBuilder.Add(View._BarTextColorAttribKey, (v)) 
-        match titleView with None -> () | Some v -> attribBuilder.Add(View._TitleViewAttribKey, (v)) 
         match popped with None -> () | Some v -> attribBuilder.Add(View._PoppedAttribKey, (fun f -> System.EventHandler<Xamarin.Forms.NavigationEventArgs>(fun sender args -> f args))(v)) 
         match poppedToRoot with None -> () | Some v -> attribBuilder.Add(View._PoppedToRootAttribKey, (fun f -> System.EventHandler<Xamarin.Forms.NavigationEventArgs>(fun sender args -> f args))(v)) 
         match pushed with None -> () | Some v -> attribBuilder.Add(View._PushedAttribKey, (fun f -> System.EventHandler<Xamarin.Forms.NavigationEventArgs>(fun sender args -> f args))(v)) 
@@ -9670,8 +9683,6 @@ type View() =
         let mutable currBarBackgroundColorOpt = ValueNone
         let mutable prevBarTextColorOpt = ValueNone
         let mutable currBarTextColorOpt = ValueNone
-        let mutable prevTitleViewOpt = ValueNone
-        let mutable currTitleViewOpt = ValueNone
         let mutable prevPoppedOpt = ValueNone
         let mutable currPoppedOpt = ValueNone
         let mutable prevPoppedToRootOpt = ValueNone
@@ -9685,8 +9696,6 @@ type View() =
                 currBarBackgroundColorOpt <- ValueSome (kvp.Value :?> Xamarin.Forms.Color)
             if kvp.Key = View._BarTextColorAttribKey.KeyValue then 
                 currBarTextColorOpt <- ValueSome (kvp.Value :?> Xamarin.Forms.Color)
-            if kvp.Key = View._TitleViewAttribKey.KeyValue then 
-                currTitleViewOpt <- ValueSome (kvp.Value :?> ViewElement)
             if kvp.Key = View._PoppedAttribKey.KeyValue then 
                 currPoppedOpt <- ValueSome (kvp.Value :?> System.EventHandler<Xamarin.Forms.NavigationEventArgs>)
             if kvp.Key = View._PoppedToRootAttribKey.KeyValue then 
@@ -9703,8 +9712,6 @@ type View() =
                     prevBarBackgroundColorOpt <- ValueSome (kvp.Value :?> Xamarin.Forms.Color)
                 if kvp.Key = View._BarTextColorAttribKey.KeyValue then 
                     prevBarTextColorOpt <- ValueSome (kvp.Value :?> Xamarin.Forms.Color)
-                if kvp.Key = View._TitleViewAttribKey.KeyValue then 
-                    prevTitleViewOpt <- ValueSome (kvp.Value :?> ViewElement)
                 if kvp.Key = View._PoppedAttribKey.KeyValue then 
                     prevPoppedOpt <- ValueSome (kvp.Value :?> System.EventHandler<Xamarin.Forms.NavigationEventArgs>)
                 if kvp.Key = View._PoppedToRootAttribKey.KeyValue then 
@@ -9756,7 +9763,6 @@ type View() =
         | _, ValueSome currValue -> target.BarTextColor <-  currValue
         | ValueSome _, ValueNone -> target.BarTextColor <- Xamarin.Forms.Color.Default
         | ValueNone, ValueNone -> ()
-        updateNavigationPageTitleView prevTitleViewOpt currTitleViewOpt target
         match prevPoppedOpt, currPoppedOpt with
         | ValueSome prevValue, ValueSome currValue when identical prevValue currValue -> ()
         | ValueSome prevValue, ValueSome currValue -> target.Popped.RemoveHandler(prevValue); target.Popped.AddHandler(currValue)
@@ -9780,7 +9786,6 @@ type View() =
     static member inline NavigationPage(?pages: ViewElement list,
                                         ?barBackgroundColor: Xamarin.Forms.Color,
                                         ?barTextColor: Xamarin.Forms.Color,
-                                        ?titleView: ViewElement,
                                         ?popped: Xamarin.Forms.NavigationEventArgs -> unit,
                                         ?poppedToRoot: Xamarin.Forms.NavigationEventArgs -> unit,
                                         ?pushed: Xamarin.Forms.NavigationEventArgs -> unit,
@@ -9789,6 +9794,7 @@ type View() =
                                         ?icon: string,
                                         ?isBusy: bool,
                                         ?padding: obj,
+                                        ?titleView: ViewElement,
                                         ?toolbarItems: ViewElement list,
                                         ?useSafeArea: bool,
                                         ?appearing: unit -> unit,
@@ -9830,7 +9836,6 @@ type View() =
                                ?pages=pages,
                                ?barBackgroundColor=barBackgroundColor,
                                ?barTextColor=barTextColor,
-                               ?titleView=titleView,
                                ?popped=popped,
                                ?poppedToRoot=poppedToRoot,
                                ?pushed=pushed,
@@ -9839,6 +9844,7 @@ type View() =
                                ?icon=icon,
                                ?isBusy=isBusy,
                                ?padding=padding,
+                               ?titleView=titleView,
                                ?toolbarItems=toolbarItems,
                                ?useSafeArea=useSafeArea,
                                ?appearing=appearing,
@@ -9894,6 +9900,7 @@ type View() =
                                          ?icon: string,
                                          ?isBusy: bool,
                                          ?padding: obj,
+                                         ?titleView: ViewElement,
                                          ?toolbarItems: ViewElement list,
                                          ?useSafeArea: bool,
                                          ?appearing: unit -> unit,
@@ -9937,7 +9944,7 @@ type View() =
         let attribCount = match currentPage with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match currentPageChanged with Some _ -> attribCount + 1 | None -> attribCount
 
-        let attribBuilder = View.BuildPage(attribCount, ?title=title, ?backgroundImage=backgroundImage, ?icon=icon, ?isBusy=isBusy, ?padding=padding, ?toolbarItems=toolbarItems, ?useSafeArea=useSafeArea, ?appearing=appearing, ?disappearing=disappearing, ?layoutChanged=layoutChanged, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?styleClass=styleClass, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?isTabStop=isTabStop, ?scaleX=scaleX, ?scaleY=scaleY, ?tabIndex=tabIndex, ?classId=classId, ?styleId=styleId, ?automationId=automationId, ?created=created, ?ref=ref)
+        let attribBuilder = View.BuildPage(attribCount, ?title=title, ?backgroundImage=backgroundImage, ?icon=icon, ?isBusy=isBusy, ?padding=padding, ?titleView=titleView, ?toolbarItems=toolbarItems, ?useSafeArea=useSafeArea, ?appearing=appearing, ?disappearing=disappearing, ?layoutChanged=layoutChanged, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?styleClass=styleClass, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?isTabStop=isTabStop, ?scaleX=scaleX, ?scaleY=scaleY, ?tabIndex=tabIndex, ?classId=classId, ?styleId=styleId, ?automationId=automationId, ?created=created, ?ref=ref)
         match children with None -> () | Some v -> attribBuilder.Add(View._ChildrenAttribKey, Array.ofList(v)) 
         match barBackgroundColor with None -> () | Some v -> attribBuilder.Add(View._BarBackgroundColorAttribKey, (v)) 
         match barTextColor with None -> () | Some v -> attribBuilder.Add(View._BarTextColorAttribKey, (v)) 
@@ -10029,6 +10036,7 @@ type View() =
                                     ?icon: string,
                                     ?isBusy: bool,
                                     ?padding: obj,
+                                    ?titleView: ViewElement,
                                     ?toolbarItems: ViewElement list,
                                     ?useSafeArea: bool,
                                     ?appearing: unit -> unit,
@@ -10077,6 +10085,7 @@ type View() =
                                ?icon=icon,
                                ?isBusy=isBusy,
                                ?padding=padding,
+                               ?titleView=titleView,
                                ?toolbarItems=toolbarItems,
                                ?useSafeArea=useSafeArea,
                                ?appearing=appearing,
@@ -10129,6 +10138,7 @@ type View() =
                                           ?icon: string,
                                           ?isBusy: bool,
                                           ?padding: obj,
+                                          ?titleView: ViewElement,
                                           ?toolbarItems: ViewElement list,
                                           ?useSafeArea: bool,
                                           ?appearing: unit -> unit,
@@ -10169,7 +10179,7 @@ type View() =
         let attribCount = match content with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match onSizeAllocated with Some _ -> attribCount + 1 | None -> attribCount
 
-        let attribBuilder = View.BuildPage(attribCount, ?title=title, ?backgroundImage=backgroundImage, ?icon=icon, ?isBusy=isBusy, ?padding=padding, ?toolbarItems=toolbarItems, ?useSafeArea=useSafeArea, ?appearing=appearing, ?disappearing=disappearing, ?layoutChanged=layoutChanged, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?styleClass=styleClass, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?isTabStop=isTabStop, ?scaleX=scaleX, ?scaleY=scaleY, ?tabIndex=tabIndex, ?classId=classId, ?styleId=styleId, ?automationId=automationId, ?created=created, ?ref=ref)
+        let attribBuilder = View.BuildPage(attribCount, ?title=title, ?backgroundImage=backgroundImage, ?icon=icon, ?isBusy=isBusy, ?padding=padding, ?titleView=titleView, ?toolbarItems=toolbarItems, ?useSafeArea=useSafeArea, ?appearing=appearing, ?disappearing=disappearing, ?layoutChanged=layoutChanged, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?styleClass=styleClass, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?isTabStop=isTabStop, ?scaleX=scaleX, ?scaleY=scaleY, ?tabIndex=tabIndex, ?classId=classId, ?styleId=styleId, ?automationId=automationId, ?created=created, ?ref=ref)
         match content with None -> () | Some v -> attribBuilder.Add(View._ContentAttribKey, (v)) 
         match onSizeAllocated with None -> () | Some v -> attribBuilder.Add(View._OnSizeAllocatedCallbackAttribKey, (fun f -> FSharp.Control.Handler<_>(fun _sender args -> f args))(v)) 
         attribBuilder
@@ -10226,6 +10236,7 @@ type View() =
                                      ?icon: string,
                                      ?isBusy: bool,
                                      ?padding: obj,
+                                     ?titleView: ViewElement,
                                      ?toolbarItems: ViewElement list,
                                      ?useSafeArea: bool,
                                      ?appearing: unit -> unit,
@@ -10271,6 +10282,7 @@ type View() =
                                ?icon=icon,
                                ?isBusy=isBusy,
                                ?padding=padding,
+                               ?titleView=titleView,
                                ?toolbarItems=toolbarItems,
                                ?useSafeArea=useSafeArea,
                                ?appearing=appearing,
@@ -10327,6 +10339,7 @@ type View() =
                                                ?icon: string,
                                                ?isBusy: bool,
                                                ?padding: obj,
+                                               ?titleView: ViewElement,
                                                ?toolbarItems: ViewElement list,
                                                ?useSafeArea: bool,
                                                ?appearing: unit -> unit,
@@ -10371,7 +10384,7 @@ type View() =
         let attribCount = match masterBehavior with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match isPresentedChanged with Some _ -> attribCount + 1 | None -> attribCount
 
-        let attribBuilder = View.BuildPage(attribCount, ?title=title, ?backgroundImage=backgroundImage, ?icon=icon, ?isBusy=isBusy, ?padding=padding, ?toolbarItems=toolbarItems, ?useSafeArea=useSafeArea, ?appearing=appearing, ?disappearing=disappearing, ?layoutChanged=layoutChanged, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?styleClass=styleClass, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?isTabStop=isTabStop, ?scaleX=scaleX, ?scaleY=scaleY, ?tabIndex=tabIndex, ?classId=classId, ?styleId=styleId, ?automationId=automationId, ?created=created, ?ref=ref)
+        let attribBuilder = View.BuildPage(attribCount, ?title=title, ?backgroundImage=backgroundImage, ?icon=icon, ?isBusy=isBusy, ?padding=padding, ?titleView=titleView, ?toolbarItems=toolbarItems, ?useSafeArea=useSafeArea, ?appearing=appearing, ?disappearing=disappearing, ?layoutChanged=layoutChanged, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?styleClass=styleClass, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?isTabStop=isTabStop, ?scaleX=scaleX, ?scaleY=scaleY, ?tabIndex=tabIndex, ?classId=classId, ?styleId=styleId, ?automationId=automationId, ?created=created, ?ref=ref)
         match master with None -> () | Some v -> attribBuilder.Add(View._MasterAttribKey, (v)) 
         match detail with None -> () | Some v -> attribBuilder.Add(View._DetailAttribKey, (v)) 
         match isGestureEnabled with None -> () | Some v -> attribBuilder.Add(View._IsGestureEnabledAttribKey, (v)) 
@@ -10490,6 +10503,7 @@ type View() =
                                           ?icon: string,
                                           ?isBusy: bool,
                                           ?padding: obj,
+                                          ?titleView: ViewElement,
                                           ?toolbarItems: ViewElement list,
                                           ?useSafeArea: bool,
                                           ?appearing: unit -> unit,
@@ -10539,6 +10553,7 @@ type View() =
                                ?icon=icon,
                                ?isBusy=isBusy,
                                ?padding=padding,
+                               ?titleView=titleView,
                                ?toolbarItems=toolbarItems,
                                ?useSafeArea=useSafeArea,
                                ?appearing=appearing,
@@ -12522,6 +12537,9 @@ module ViewElementExtensions =
         /// Adjusts the IsBusy property in the visual element
         member x.IsBusy(value: bool) = x.WithAttribute(View._IsBusyAttribKey, (value))
 
+        /// Adjusts the TitleView property in the visual element
+        member x.TitleView(value: ViewElement) = x.WithAttribute(View._TitleViewAttribKey, (value))
+
         /// Adjusts the ToolbarItems property in the visual element
         member x.ToolbarItems(value: ViewElement list) = x.WithAttribute(View._ToolbarItemsAttribKey, Array.ofList(value))
 
@@ -12563,9 +12581,6 @@ module ViewElementExtensions =
 
         /// Adjusts the BarTextColor property in the visual element
         member x.BarTextColor(value: Xamarin.Forms.Color) = x.WithAttribute(View._BarTextColorAttribKey, (value))
-
-        /// Adjusts the TitleView property in the visual element
-        member x.TitleView(value: ViewElement) = x.WithAttribute(View._TitleViewAttribKey, (value))
 
         /// Adjusts the Popped property in the visual element
         member x.Popped(value: Xamarin.Forms.NavigationEventArgs -> unit) = x.WithAttribute(View._PoppedAttribKey, (fun f -> System.EventHandler<Xamarin.Forms.NavigationEventArgs>(fun sender args -> f args))(value))
@@ -13213,6 +13228,9 @@ module ViewElementExtensions =
     /// Adjusts the IsBusy property in the visual element
     let isBusy (value: bool) (x: ViewElement) = x.IsBusy(value)
 
+    /// Adjusts the TitleView property in the visual element
+    let titleView (value: ViewElement) (x: ViewElement) = x.TitleView(value)
+
     /// Adjusts the ToolbarItems property in the visual element
     let toolbarItems (value: ViewElement list) (x: ViewElement) = x.ToolbarItems(value)
 
@@ -13254,9 +13272,6 @@ module ViewElementExtensions =
 
     /// Adjusts the BarTextColor property in the visual element
     let barTextColor (value: Xamarin.Forms.Color) (x: ViewElement) = x.BarTextColor(value)
-
-    /// Adjusts the TitleView property in the visual element
-    let titleView (value: ViewElement) (x: ViewElement) = x.TitleView(value)
 
     /// Adjusts the Popped property in the visual element
     let popped (value: Xamarin.Forms.NavigationEventArgs -> unit) (x: ViewElement) = x.Popped(value)

--- a/src/Fabulous.Core/Xamarin.Forms.Core.fs
+++ b/src/Fabulous.Core/Xamarin.Forms.Core.fs
@@ -9739,11 +9739,7 @@ type View() =
                 // Adjust the attached properties
                 let prevChildValueOpt = match prevChildOpt with ValueNone -> ValueNone | ValueSome prevChild -> prevChild.TryGetAttributeKeyed<ViewElement>(View._TitleViewAttribKey)
                 let childValueOpt = newChild.TryGetAttributeKeyed<ViewElement>(View._TitleViewAttribKey)
-                match prevChildValueOpt, childValueOpt with
-                | ValueSome prevChildValue, ValueSome currValue when prevChildValue = currValue -> ()
-                | _, ValueSome currValue -> Xamarin.Forms.NavigationPage.SetTitleView(targetChild, (fun (elem:ViewElement) -> elem.Create() :?> Xamarin.Forms.View) currValue)
-                | ValueSome _, ValueNone -> Xamarin.Forms.NavigationPage.SetTitleView(targetChild, null) // TODO: not always perfect, should set back to original default?
-                | _ -> ()
+                updatePageTitleView prevChildValueOpt childValueOpt targetChild
                 ())
         match prevBarBackgroundColorOpt, currBarBackgroundColorOpt with
         | ValueSome prevValue, ValueSome currValue when prevValue = currValue -> ()

--- a/src/Fabulous.Core/Xamarin.Forms.Core.fs
+++ b/src/Fabulous.Core/Xamarin.Forms.Core.fs
@@ -350,8 +350,6 @@ type View() =
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
     static member val _IsBusyAttribKey : AttributeKey<_> = AttributeKey<_>("IsBusy")
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
-    static member val _TitleViewAttribKey : AttributeKey<_> = AttributeKey<_>("TitleView")
-    [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
     static member val _ToolbarItemsAttribKey : AttributeKey<_> = AttributeKey<_>("ToolbarItems")
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
     static member val _UseSafeAreaAttribKey : AttributeKey<_> = AttributeKey<_>("UseSafeArea")
@@ -375,6 +373,8 @@ type View() =
     static member val _HasNavigationBarAttribKey : AttributeKey<_> = AttributeKey<_>("HasNavigationBar")
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
     static member val _TitleIconAttribKey : AttributeKey<_> = AttributeKey<_>("TitleIcon")
+    [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
+    static member val _TitleViewAttribKey : AttributeKey<_> = AttributeKey<_>("TitleView")
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
     static member val _BarBackgroundColorAttribKey : AttributeKey<_> = AttributeKey<_>("BarBackgroundColor")
     [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
@@ -9091,7 +9091,6 @@ type View() =
                                    ?icon: string,
                                    ?isBusy: bool,
                                    ?padding: obj,
-                                   ?titleView: ViewElement,
                                    ?toolbarItems: ViewElement list,
                                    ?useSafeArea: bool,
                                    ?appearing: unit -> unit,
@@ -9134,7 +9133,6 @@ type View() =
         let attribCount = match icon with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match isBusy with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match padding with Some _ -> attribCount + 1 | None -> attribCount
-        let attribCount = match titleView with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match toolbarItems with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match useSafeArea with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match appearing with Some _ -> attribCount + 1 | None -> attribCount
@@ -9147,7 +9145,6 @@ type View() =
         match icon with None -> () | Some v -> attribBuilder.Add(View._IconAttribKey, (v)) 
         match isBusy with None -> () | Some v -> attribBuilder.Add(View._IsBusyAttribKey, (v)) 
         match padding with None -> () | Some v -> attribBuilder.Add(View._PaddingAttribKey, makeThickness(v)) 
-        match titleView with None -> () | Some v -> attribBuilder.Add(View._TitleViewAttribKey, (v)) 
         match toolbarItems with None -> () | Some v -> attribBuilder.Add(View._ToolbarItemsAttribKey, Array.ofList(v)) 
         match useSafeArea with None -> () | Some v -> attribBuilder.Add(View._UseSafeAreaAttribKey, (v)) 
         match appearing with None -> () | Some v -> attribBuilder.Add(View._Page_AppearingAttribKey, (fun f -> System.EventHandler(fun _sender _args -> f ()))(v)) 
@@ -9180,8 +9177,6 @@ type View() =
         let mutable currIsBusyOpt = ValueNone
         let mutable prevPaddingOpt = ValueNone
         let mutable currPaddingOpt = ValueNone
-        let mutable prevTitleViewOpt = ValueNone
-        let mutable currTitleViewOpt = ValueNone
         let mutable prevToolbarItemsOpt = ValueNone
         let mutable currToolbarItemsOpt = ValueNone
         let mutable prevUseSafeAreaOpt = ValueNone
@@ -9203,8 +9198,6 @@ type View() =
                 currIsBusyOpt <- ValueSome (kvp.Value :?> bool)
             if kvp.Key = View._PaddingAttribKey.KeyValue then 
                 currPaddingOpt <- ValueSome (kvp.Value :?> Xamarin.Forms.Thickness)
-            if kvp.Key = View._TitleViewAttribKey.KeyValue then 
-                currTitleViewOpt <- ValueSome (kvp.Value :?> ViewElement)
             if kvp.Key = View._ToolbarItemsAttribKey.KeyValue then 
                 currToolbarItemsOpt <- ValueSome (kvp.Value :?> ViewElement[])
             if kvp.Key = View._UseSafeAreaAttribKey.KeyValue then 
@@ -9229,8 +9222,6 @@ type View() =
                     prevIsBusyOpt <- ValueSome (kvp.Value :?> bool)
                 if kvp.Key = View._PaddingAttribKey.KeyValue then 
                     prevPaddingOpt <- ValueSome (kvp.Value :?> Xamarin.Forms.Thickness)
-                if kvp.Key = View._TitleViewAttribKey.KeyValue then 
-                    prevTitleViewOpt <- ValueSome (kvp.Value :?> ViewElement)
                 if kvp.Key = View._ToolbarItemsAttribKey.KeyValue then 
                     prevToolbarItemsOpt <- ValueSome (kvp.Value :?> ViewElement[])
                 if kvp.Key = View._UseSafeAreaAttribKey.KeyValue then 
@@ -9266,7 +9257,6 @@ type View() =
         | _, ValueSome currValue -> target.Padding <-  currValue
         | ValueSome _, ValueNone -> target.Padding <- Unchecked.defaultof<Xamarin.Forms.Thickness>
         | ValueNone, ValueNone -> ()
-        updatePageTitleView prevTitleViewOpt currTitleViewOpt target
         updateCollectionGeneric prevToolbarItemsOpt currToolbarItemsOpt target.ToolbarItems
             (fun (x:ViewElement) -> x.Create() :?> Xamarin.Forms.ToolbarItem)
             (fun _ _ _ -> ())
@@ -9298,7 +9288,6 @@ type View() =
                               ?icon: string,
                               ?isBusy: bool,
                               ?padding: obj,
-                              ?titleView: ViewElement,
                               ?toolbarItems: ViewElement list,
                               ?useSafeArea: bool,
                               ?appearing: unit -> unit,
@@ -9342,7 +9331,6 @@ type View() =
                                ?icon=icon,
                                ?isBusy=isBusy,
                                ?padding=padding,
-                               ?titleView=titleView,
                                ?toolbarItems=toolbarItems,
                                ?useSafeArea=useSafeArea,
                                ?appearing=appearing,
@@ -9396,7 +9384,6 @@ type View() =
                                            ?icon: string,
                                            ?isBusy: bool,
                                            ?padding: obj,
-                                           ?titleView: ViewElement,
                                            ?toolbarItems: ViewElement list,
                                            ?useSafeArea: bool,
                                            ?appearing: unit -> unit,
@@ -9438,7 +9425,7 @@ type View() =
         let attribCount = match currentPage with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match currentPageChanged with Some _ -> attribCount + 1 | None -> attribCount
 
-        let attribBuilder = View.BuildPage(attribCount, ?title=title, ?backgroundImage=backgroundImage, ?icon=icon, ?isBusy=isBusy, ?padding=padding, ?titleView=titleView, ?toolbarItems=toolbarItems, ?useSafeArea=useSafeArea, ?appearing=appearing, ?disappearing=disappearing, ?layoutChanged=layoutChanged, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?styleClass=styleClass, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?isTabStop=isTabStop, ?scaleX=scaleX, ?scaleY=scaleY, ?tabIndex=tabIndex, ?classId=classId, ?styleId=styleId, ?automationId=automationId, ?created=created, ?ref=ref)
+        let attribBuilder = View.BuildPage(attribCount, ?title=title, ?backgroundImage=backgroundImage, ?icon=icon, ?isBusy=isBusy, ?padding=padding, ?toolbarItems=toolbarItems, ?useSafeArea=useSafeArea, ?appearing=appearing, ?disappearing=disappearing, ?layoutChanged=layoutChanged, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?styleClass=styleClass, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?isTabStop=isTabStop, ?scaleX=scaleX, ?scaleY=scaleY, ?tabIndex=tabIndex, ?classId=classId, ?styleId=styleId, ?automationId=automationId, ?created=created, ?ref=ref)
         match children with None -> () | Some v -> attribBuilder.Add(View._ChildrenAttribKey, Array.ofList(v)) 
         match currentPage with None -> () | Some v -> attribBuilder.Add(View._CarouselPage_CurrentPageAttribKey, (v)) 
         match currentPageChanged with None -> () | Some v -> attribBuilder.Add(View._CarouselPage_CurrentPageChangedAttribKey, makeCurrentPageChanged<Xamarin.Forms.ContentPage>(v)) 
@@ -9504,7 +9491,6 @@ type View() =
                                       ?icon: string,
                                       ?isBusy: bool,
                                       ?padding: obj,
-                                      ?titleView: ViewElement,
                                       ?toolbarItems: ViewElement list,
                                       ?useSafeArea: bool,
                                       ?appearing: unit -> unit,
@@ -9551,7 +9537,6 @@ type View() =
                                ?icon=icon,
                                ?isBusy=isBusy,
                                ?padding=padding,
-                               ?titleView=titleView,
                                ?toolbarItems=toolbarItems,
                                ?useSafeArea=useSafeArea,
                                ?appearing=appearing,
@@ -9608,7 +9593,6 @@ type View() =
                                              ?icon: string,
                                              ?isBusy: bool,
                                              ?padding: obj,
-                                             ?titleView: ViewElement,
                                              ?toolbarItems: ViewElement list,
                                              ?useSafeArea: bool,
                                              ?appearing: unit -> unit,
@@ -9653,7 +9637,7 @@ type View() =
         let attribCount = match poppedToRoot with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match pushed with Some _ -> attribCount + 1 | None -> attribCount
 
-        let attribBuilder = View.BuildPage(attribCount, ?title=title, ?backgroundImage=backgroundImage, ?icon=icon, ?isBusy=isBusy, ?padding=padding, ?titleView=titleView, ?toolbarItems=toolbarItems, ?useSafeArea=useSafeArea, ?appearing=appearing, ?disappearing=disappearing, ?layoutChanged=layoutChanged, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?styleClass=styleClass, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?isTabStop=isTabStop, ?scaleX=scaleX, ?scaleY=scaleY, ?tabIndex=tabIndex, ?classId=classId, ?styleId=styleId, ?automationId=automationId, ?created=created, ?ref=ref)
+        let attribBuilder = View.BuildPage(attribCount, ?title=title, ?backgroundImage=backgroundImage, ?icon=icon, ?isBusy=isBusy, ?padding=padding, ?toolbarItems=toolbarItems, ?useSafeArea=useSafeArea, ?appearing=appearing, ?disappearing=disappearing, ?layoutChanged=layoutChanged, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?styleClass=styleClass, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?isTabStop=isTabStop, ?scaleX=scaleX, ?scaleY=scaleY, ?tabIndex=tabIndex, ?classId=classId, ?styleId=styleId, ?automationId=automationId, ?created=created, ?ref=ref)
         match pages with None -> () | Some v -> attribBuilder.Add(View._PagesAttribKey, Array.ofList(v)) 
         match barBackgroundColor with None -> () | Some v -> attribBuilder.Add(View._BarBackgroundColorAttribKey, (v)) 
         match barTextColor with None -> () | Some v -> attribBuilder.Add(View._BarTextColorAttribKey, (v)) 
@@ -9752,6 +9736,14 @@ type View() =
                 | _, ValueSome currValue -> Xamarin.Forms.NavigationPage.SetTitleIcon(targetChild, makeFileImageSource currValue)
                 | ValueSome _, ValueNone -> Xamarin.Forms.NavigationPage.SetTitleIcon(targetChild, null) // TODO: not always perfect, should set back to original default?
                 | _ -> ()
+                // Adjust the attached properties
+                let prevChildValueOpt = match prevChildOpt with ValueNone -> ValueNone | ValueSome prevChild -> prevChild.TryGetAttributeKeyed<ViewElement>(View._TitleViewAttribKey)
+                let childValueOpt = newChild.TryGetAttributeKeyed<ViewElement>(View._TitleViewAttribKey)
+                match prevChildValueOpt, childValueOpt with
+                | ValueSome prevChildValue, ValueSome currValue when prevChildValue = currValue -> ()
+                | _, ValueSome currValue -> Xamarin.Forms.NavigationPage.SetTitleView(targetChild, (fun (elem:ViewElement) -> elem.Create() :?> Xamarin.Forms.View) currValue)
+                | ValueSome _, ValueNone -> Xamarin.Forms.NavigationPage.SetTitleView(targetChild, null) // TODO: not always perfect, should set back to original default?
+                | _ -> ()
                 ())
         match prevBarBackgroundColorOpt, currBarBackgroundColorOpt with
         | ValueSome prevValue, ValueSome currValue when prevValue = currValue -> ()
@@ -9794,7 +9786,6 @@ type View() =
                                         ?icon: string,
                                         ?isBusy: bool,
                                         ?padding: obj,
-                                        ?titleView: ViewElement,
                                         ?toolbarItems: ViewElement list,
                                         ?useSafeArea: bool,
                                         ?appearing: unit -> unit,
@@ -9844,7 +9835,6 @@ type View() =
                                ?icon=icon,
                                ?isBusy=isBusy,
                                ?padding=padding,
-                               ?titleView=titleView,
                                ?toolbarItems=toolbarItems,
                                ?useSafeArea=useSafeArea,
                                ?appearing=appearing,
@@ -9900,7 +9890,6 @@ type View() =
                                          ?icon: string,
                                          ?isBusy: bool,
                                          ?padding: obj,
-                                         ?titleView: ViewElement,
                                          ?toolbarItems: ViewElement list,
                                          ?useSafeArea: bool,
                                          ?appearing: unit -> unit,
@@ -9944,7 +9933,7 @@ type View() =
         let attribCount = match currentPage with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match currentPageChanged with Some _ -> attribCount + 1 | None -> attribCount
 
-        let attribBuilder = View.BuildPage(attribCount, ?title=title, ?backgroundImage=backgroundImage, ?icon=icon, ?isBusy=isBusy, ?padding=padding, ?titleView=titleView, ?toolbarItems=toolbarItems, ?useSafeArea=useSafeArea, ?appearing=appearing, ?disappearing=disappearing, ?layoutChanged=layoutChanged, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?styleClass=styleClass, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?isTabStop=isTabStop, ?scaleX=scaleX, ?scaleY=scaleY, ?tabIndex=tabIndex, ?classId=classId, ?styleId=styleId, ?automationId=automationId, ?created=created, ?ref=ref)
+        let attribBuilder = View.BuildPage(attribCount, ?title=title, ?backgroundImage=backgroundImage, ?icon=icon, ?isBusy=isBusy, ?padding=padding, ?toolbarItems=toolbarItems, ?useSafeArea=useSafeArea, ?appearing=appearing, ?disappearing=disappearing, ?layoutChanged=layoutChanged, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?styleClass=styleClass, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?isTabStop=isTabStop, ?scaleX=scaleX, ?scaleY=scaleY, ?tabIndex=tabIndex, ?classId=classId, ?styleId=styleId, ?automationId=automationId, ?created=created, ?ref=ref)
         match children with None -> () | Some v -> attribBuilder.Add(View._ChildrenAttribKey, Array.ofList(v)) 
         match barBackgroundColor with None -> () | Some v -> attribBuilder.Add(View._BarBackgroundColorAttribKey, (v)) 
         match barTextColor with None -> () | Some v -> attribBuilder.Add(View._BarTextColorAttribKey, (v)) 
@@ -10036,7 +10025,6 @@ type View() =
                                     ?icon: string,
                                     ?isBusy: bool,
                                     ?padding: obj,
-                                    ?titleView: ViewElement,
                                     ?toolbarItems: ViewElement list,
                                     ?useSafeArea: bool,
                                     ?appearing: unit -> unit,
@@ -10085,7 +10073,6 @@ type View() =
                                ?icon=icon,
                                ?isBusy=isBusy,
                                ?padding=padding,
-                               ?titleView=titleView,
                                ?toolbarItems=toolbarItems,
                                ?useSafeArea=useSafeArea,
                                ?appearing=appearing,
@@ -10138,7 +10125,6 @@ type View() =
                                           ?icon: string,
                                           ?isBusy: bool,
                                           ?padding: obj,
-                                          ?titleView: ViewElement,
                                           ?toolbarItems: ViewElement list,
                                           ?useSafeArea: bool,
                                           ?appearing: unit -> unit,
@@ -10179,7 +10165,7 @@ type View() =
         let attribCount = match content with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match onSizeAllocated with Some _ -> attribCount + 1 | None -> attribCount
 
-        let attribBuilder = View.BuildPage(attribCount, ?title=title, ?backgroundImage=backgroundImage, ?icon=icon, ?isBusy=isBusy, ?padding=padding, ?titleView=titleView, ?toolbarItems=toolbarItems, ?useSafeArea=useSafeArea, ?appearing=appearing, ?disappearing=disappearing, ?layoutChanged=layoutChanged, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?styleClass=styleClass, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?isTabStop=isTabStop, ?scaleX=scaleX, ?scaleY=scaleY, ?tabIndex=tabIndex, ?classId=classId, ?styleId=styleId, ?automationId=automationId, ?created=created, ?ref=ref)
+        let attribBuilder = View.BuildPage(attribCount, ?title=title, ?backgroundImage=backgroundImage, ?icon=icon, ?isBusy=isBusy, ?padding=padding, ?toolbarItems=toolbarItems, ?useSafeArea=useSafeArea, ?appearing=appearing, ?disappearing=disappearing, ?layoutChanged=layoutChanged, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?styleClass=styleClass, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?isTabStop=isTabStop, ?scaleX=scaleX, ?scaleY=scaleY, ?tabIndex=tabIndex, ?classId=classId, ?styleId=styleId, ?automationId=automationId, ?created=created, ?ref=ref)
         match content with None -> () | Some v -> attribBuilder.Add(View._ContentAttribKey, (v)) 
         match onSizeAllocated with None -> () | Some v -> attribBuilder.Add(View._OnSizeAllocatedCallbackAttribKey, (fun f -> FSharp.Control.Handler<_>(fun _sender args -> f args))(v)) 
         attribBuilder
@@ -10236,7 +10222,6 @@ type View() =
                                      ?icon: string,
                                      ?isBusy: bool,
                                      ?padding: obj,
-                                     ?titleView: ViewElement,
                                      ?toolbarItems: ViewElement list,
                                      ?useSafeArea: bool,
                                      ?appearing: unit -> unit,
@@ -10282,7 +10267,6 @@ type View() =
                                ?icon=icon,
                                ?isBusy=isBusy,
                                ?padding=padding,
-                               ?titleView=titleView,
                                ?toolbarItems=toolbarItems,
                                ?useSafeArea=useSafeArea,
                                ?appearing=appearing,
@@ -10339,7 +10323,6 @@ type View() =
                                                ?icon: string,
                                                ?isBusy: bool,
                                                ?padding: obj,
-                                               ?titleView: ViewElement,
                                                ?toolbarItems: ViewElement list,
                                                ?useSafeArea: bool,
                                                ?appearing: unit -> unit,
@@ -10384,7 +10367,7 @@ type View() =
         let attribCount = match masterBehavior with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match isPresentedChanged with Some _ -> attribCount + 1 | None -> attribCount
 
-        let attribBuilder = View.BuildPage(attribCount, ?title=title, ?backgroundImage=backgroundImage, ?icon=icon, ?isBusy=isBusy, ?padding=padding, ?titleView=titleView, ?toolbarItems=toolbarItems, ?useSafeArea=useSafeArea, ?appearing=appearing, ?disappearing=disappearing, ?layoutChanged=layoutChanged, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?styleClass=styleClass, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?isTabStop=isTabStop, ?scaleX=scaleX, ?scaleY=scaleY, ?tabIndex=tabIndex, ?classId=classId, ?styleId=styleId, ?automationId=automationId, ?created=created, ?ref=ref)
+        let attribBuilder = View.BuildPage(attribCount, ?title=title, ?backgroundImage=backgroundImage, ?icon=icon, ?isBusy=isBusy, ?padding=padding, ?toolbarItems=toolbarItems, ?useSafeArea=useSafeArea, ?appearing=appearing, ?disappearing=disappearing, ?layoutChanged=layoutChanged, ?anchorX=anchorX, ?anchorY=anchorY, ?backgroundColor=backgroundColor, ?heightRequest=heightRequest, ?inputTransparent=inputTransparent, ?isEnabled=isEnabled, ?isVisible=isVisible, ?minimumHeightRequest=minimumHeightRequest, ?minimumWidthRequest=minimumWidthRequest, ?opacity=opacity, ?rotation=rotation, ?rotationX=rotationX, ?rotationY=rotationY, ?scale=scale, ?style=style, ?styleClass=styleClass, ?translationX=translationX, ?translationY=translationY, ?widthRequest=widthRequest, ?resources=resources, ?styles=styles, ?styleSheets=styleSheets, ?isTabStop=isTabStop, ?scaleX=scaleX, ?scaleY=scaleY, ?tabIndex=tabIndex, ?classId=classId, ?styleId=styleId, ?automationId=automationId, ?created=created, ?ref=ref)
         match master with None -> () | Some v -> attribBuilder.Add(View._MasterAttribKey, (v)) 
         match detail with None -> () | Some v -> attribBuilder.Add(View._DetailAttribKey, (v)) 
         match isGestureEnabled with None -> () | Some v -> attribBuilder.Add(View._IsGestureEnabledAttribKey, (v)) 
@@ -10503,7 +10486,6 @@ type View() =
                                           ?icon: string,
                                           ?isBusy: bool,
                                           ?padding: obj,
-                                          ?titleView: ViewElement,
                                           ?toolbarItems: ViewElement list,
                                           ?useSafeArea: bool,
                                           ?appearing: unit -> unit,
@@ -10553,7 +10535,6 @@ type View() =
                                ?icon=icon,
                                ?isBusy=isBusy,
                                ?padding=padding,
-                               ?titleView=titleView,
                                ?toolbarItems=toolbarItems,
                                ?useSafeArea=useSafeArea,
                                ?appearing=appearing,
@@ -12537,9 +12518,6 @@ module ViewElementExtensions =
         /// Adjusts the IsBusy property in the visual element
         member x.IsBusy(value: bool) = x.WithAttribute(View._IsBusyAttribKey, (value))
 
-        /// Adjusts the TitleView property in the visual element
-        member x.TitleView(value: ViewElement) = x.WithAttribute(View._TitleViewAttribKey, (value))
-
         /// Adjusts the ToolbarItems property in the visual element
         member x.ToolbarItems(value: ViewElement list) = x.WithAttribute(View._ToolbarItemsAttribKey, Array.ofList(value))
 
@@ -12575,6 +12553,9 @@ module ViewElementExtensions =
 
         /// Adjusts the TitleIcon property in the visual element
         member x.TitleIcon(value: string) = x.WithAttribute(View._TitleIconAttribKey, (value))
+
+        /// Adjusts the TitleView property in the visual element
+        member x.TitleView(value: ViewElement) = x.WithAttribute(View._TitleViewAttribKey, (value))
 
         /// Adjusts the BarBackgroundColor property in the visual element
         member x.BarBackgroundColor(value: Xamarin.Forms.Color) = x.WithAttribute(View._BarBackgroundColorAttribKey, (value))
@@ -13228,9 +13209,6 @@ module ViewElementExtensions =
     /// Adjusts the IsBusy property in the visual element
     let isBusy (value: bool) (x: ViewElement) = x.IsBusy(value)
 
-    /// Adjusts the TitleView property in the visual element
-    let titleView (value: ViewElement) (x: ViewElement) = x.TitleView(value)
-
     /// Adjusts the ToolbarItems property in the visual element
     let toolbarItems (value: ViewElement list) (x: ViewElement) = x.ToolbarItems(value)
 
@@ -13266,6 +13244,9 @@ module ViewElementExtensions =
 
     /// Adjusts the TitleIcon property in the visual element
     let titleIcon (value: string) (x: ViewElement) = x.TitleIcon(value)
+
+    /// Adjusts the TitleView property in the visual element
+    let titleView (value: ViewElement) (x: ViewElement) = x.TitleView(value)
 
     /// Adjusts the BarBackgroundColor property in the visual element
     let barBackgroundColor (value: Xamarin.Forms.Color) (x: ViewElement) = x.BarBackgroundColor(value)

--- a/tools/Generator/CodeGenerator.fs
+++ b/tools/Generator/CodeGenerator.fs
@@ -184,15 +184,18 @@ module CodeGenerator =
                     if (m.Attached.Length > 0) then
                         w.printfn "            (fun prevChildOpt newChild targetChild -> "
                         for ap in m.Attached do
-                            let apApply = getValueOrDefault "" (ap.ConvToValue + " ")
                             w.printfn "                // Adjust the attached properties"
                             w.printfn "                let prevChildValueOpt = match prevChildOpt with ValueNone -> ValueNone | ValueSome prevChild -> prevChild.TryGetAttributeKeyed<%s>(View._%sAttribKey)" ap.ModelType ap.UniqueName
                             w.printfn "                let childValueOpt = newChild.TryGetAttributeKeyed<%s>(View._%sAttribKey)" ap.ModelType ap.UniqueName
-                            w.printfn "                match prevChildValueOpt, childValueOpt with"
-                            w.printfn "                | ValueSome prevChildValue, ValueSome currChildValue when prevChildValue = currChildValue -> ()"
-                            w.printfn "                | _, ValueSome currChildValue -> %s.Set%s(targetChild, %scurrChildValue)" data.FullName ap.Name apApply
-                            w.printfn "                | ValueSome _, ValueNone -> %s.Set%s(targetChild, %s)" data.FullName ap.Name ap.DefaultValue
-                            w.printfn "                | _ -> ()"
+                            if System.String.IsNullOrWhiteSpace(ap.UpdateCode) then
+                                let apApply = getValueOrDefault "" (ap.ConvToValue + " ")
+                                w.printfn "                match prevChildValueOpt, childValueOpt with"
+                                w.printfn "                | ValueSome prevChildValue, ValueSome currChildValue when prevChildValue = currChildValue -> ()"
+                                w.printfn "                | _, ValueSome currChildValue -> %s.Set%s(targetChild, %scurrChildValue)" data.FullName ap.Name apApply
+                                w.printfn "                | ValueSome _, ValueNone -> %s.Set%s(targetChild, %s)" data.FullName ap.Name ap.DefaultValue
+                                w.printfn "                | _ -> ()"
+                            else
+                                w.printfn "                %s prevChildValueOpt childValueOpt targetChild" ap.UpdateCode
                         w.printfn "                ())"
                     else
                         w.printfn "            (fun _ _ _ -> ())"
@@ -230,15 +233,19 @@ module CodeGenerator =
                         if (m.Attached.Length > 0) then
                             w.printfn "            (fun prevChildOpt newChild targetChild -> "
                             for ap in m.Attached do
-                                let apApply = getValueOrDefault "" (ap.ConvToValue + " ")
                                 w.printfn "                // Adjust the attached properties"
                                 w.printfn "                let prevChildValueOpt = match prevChildOpt with ValueNone -> ValueNone | ValueSome prevChild -> prevChild.TryGetAttributeKeyed<%s>(View._%sAttribKey)" ap.ModelType ap.UniqueName
                                 w.printfn "                let childValueOpt = newChild.TryGetAttributeKeyed<%s>(View._%sAttribKey)" ap.ModelType ap.UniqueName
-                                w.printfn "                match prevChildValueOpt, childValueOpt with"
-                                w.printfn "                | ValueSome prevChildValue, ValueSome currValue when prevChildValue = currValue -> ()"
-                                w.printfn "                | _, ValueSome currValue -> %s.Set%s(targetChild, %scurrValue)" data.FullName ap.Name apApply
-                                w.printfn "                | ValueSome _, ValueNone -> %s.Set%s(targetChild, %s) // TODO: not always perfect, should set back to original default?" data.FullName ap.Name ap.DefaultValue
-                                w.printfn "                | _ -> ()"
+
+                                if System.String.IsNullOrWhiteSpace(ap.UpdateCode) then
+                                    let apApply = getValueOrDefault "" (ap.ConvToValue + " ")
+                                    w.printfn "                match prevChildValueOpt, childValueOpt with"
+                                    w.printfn "                | ValueSome prevChildValue, ValueSome currValue when prevChildValue = currValue -> ()"
+                                    w.printfn "                | _, ValueSome currValue -> %s.Set%s(targetChild, %scurrValue)" data.FullName ap.Name apApply
+                                    w.printfn "                | ValueSome _, ValueNone -> %s.Set%s(targetChild, %s) // TODO: not always perfect, should set back to original default?" data.FullName ap.Name ap.DefaultValue
+                                    w.printfn "                | _ -> ()"
+                                else
+                                    w.printfn "                %s prevChildValueOpt childValueOpt targetChild" ap.UpdateCode
                             w.printfn "                ())"
 
                     | _ -> 

--- a/tools/Generator/Xamarin.Forms.Core.json
+++ b/tools/Generator/Xamarin.Forms.Core.json
@@ -1434,6 +1434,13 @@
           "defaultValue": "Unchecked.defaultof<Xamarin.Forms.Thickness>"
         },
         {
+          "name": "TitleView",
+          "inputType": "ViewElement",
+          "modelType": "ViewElement",
+          "updateCode": "updateNavigationPageTitleView",
+          "defaultValue": "null"
+        },
+        {
           "name": "ToolbarItems",
           "inputType": "ViewElement list",
           "modelType": "ViewElement[]",
@@ -1537,13 +1544,6 @@
         {
           "name": "BarTextColor",
           "defaultValue": "Xamarin.Forms.Color.Default"
-        },
-        {
-          "name": "TitleView",
-          "inputType": "ViewElement",
-          "modelType": "ViewElement",
-          "updateCode": "updateNavigationPageTitleView",
-          "defaultValue": "null"
         },
         {
           "name": "Popped",

--- a/tools/Generator/Xamarin.Forms.Core.json
+++ b/tools/Generator/Xamarin.Forms.Core.json
@@ -1437,7 +1437,7 @@
           "name": "TitleView",
           "inputType": "ViewElement",
           "modelType": "ViewElement",
-          "updateCode": "updateNavigationPageTitleView",
+          "updateCode": "updatePageTitleView",
           "defaultValue": "null"
         },
         {

--- a/tools/Generator/Xamarin.Forms.Core.json
+++ b/tools/Generator/Xamarin.Forms.Core.json
@@ -1532,7 +1532,7 @@
               "name": "TitleView",
               "inputType": "ViewElement",
               "modelType": "ViewElement",
-              "convToValue": "(fun (elem:ViewElement) -> elem.Create() :?> Xamarin.Forms.View)",
+              "updateCode": "updatePageTitleView",
               "defaultValue": "null"
             }
           ]

--- a/tools/Generator/Xamarin.Forms.Core.json
+++ b/tools/Generator/Xamarin.Forms.Core.json
@@ -1434,13 +1434,6 @@
           "defaultValue": "Unchecked.defaultof<Xamarin.Forms.Thickness>"
         },
         {
-          "name": "TitleView",
-          "inputType": "ViewElement",
-          "modelType": "ViewElement",
-          "updateCode": "updatePageTitleView",
-          "defaultValue": "null"
-        },
-        {
           "name": "ToolbarItems",
           "inputType": "ViewElement list",
           "modelType": "ViewElement[]",
@@ -1533,6 +1526,13 @@
               "inputType": "string",
               "modelType": "string",
               "convToValue": "makeFileImageSource",
+              "defaultValue": "null"
+            },
+            {
+              "name": "TitleView",
+              "inputType": "ViewElement",
+              "modelType": "ViewElement",
+              "convToValue": "(fun (elem:ViewElement) -> elem.Create() :?> Xamarin.Forms.View)",
               "defaultValue": "null"
             }
           ]


### PR DESCRIPTION
Fixes #292 by moving the TitleView property from ```NavigationPage``` to ```Page```.

Hopefully I've put it in the right place - Xamarin.Forms.Core.json looked to be sorted alphabetically with properties first, then events.

I've built and tested the nupkgs locally though I'm afraid I haven't updated the AllControls sample to add a usage of titleView/TitleView.

(This is my first (ever!) PR so please forgive me if I've done something wrong)