### PR TITLE
Fixed package identifiers for samples

### DIFF
--- a/samples/AllControls/Droid/Properties/AndroidManifest.xml
+++ b/samples/AllControls/Droid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.donsyme.AllControls">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="org.fabulous.AllControls">
 	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="27" />
 	<application android:label="AllControls"></application>
 </manifest>

--- a/samples/AllControls/iOS/Info.plist
+++ b/samples/AllControls/iOS/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleName</key>
 	<string>AllControls</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.donsyme.AllControls</string>
+	<string>org.fabulous.AllControls</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>

--- a/samples/CounterApp/Droid/MainActivity.fs
+++ b/samples/CounterApp/Droid/MainActivity.fs
@@ -12,7 +12,7 @@ open Android.Widget
 open Android.OS
 open Xamarin.Forms.Platform.Android
 
-[<Activity (Label = "Droid", Icon = "@drawable/icon", MainLauncher = true, ConfigurationChanges = (ConfigChanges.ScreenSize ||| ConfigChanges.Orientation))>]
+[<Activity (Label = "CounterApp.Droid", Icon = "@drawable/icon", MainLauncher = true, ConfigurationChanges = (ConfigChanges.ScreenSize ||| ConfigChanges.Orientation))>]
 type MainActivity() =
     inherit FormsApplicationActivity()
     override this.OnCreate (bundle: Bundle) =

--- a/samples/CounterApp/Droid/Properties/AndroidManifest.xml
+++ b/samples/CounterApp/Droid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.companyname.CounterApp">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="org.fabulous.CounterApp">
 	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="27" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/samples/CounterApp/iOS/Info.plist
+++ b/samples/CounterApp/iOS/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDisplayName</key>
 	<string>CounterApp</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.donsyme.AllControls</string>
+	<string>org.fabulous.CounterApp</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>

--- a/samples/StaticView/StaticViewCounterApp/Droid/MainActivity.fs
+++ b/samples/StaticView/StaticViewCounterApp/Droid/MainActivity.fs
@@ -11,7 +11,7 @@ open Android.Views
 open Android.Widget
 open Android.OS
 
-[<Activity (Label = "Droid", Icon = "@drawable/icon", MainLauncher = true, ConfigurationChanges = (ConfigChanges.ScreenSize ||| ConfigChanges.Orientation))>]
+[<Activity (Label = "StaticViewCounterApp.Droid", Icon = "@drawable/icon", MainLauncher = true, ConfigurationChanges = (ConfigChanges.ScreenSize ||| ConfigChanges.Orientation))>]
 type MainActivity() =
     inherit Xamarin.Forms.Platform.Android.FormsApplicationActivity()
     override this.OnCreate (bundle: Bundle) =

--- a/samples/StaticView/StaticViewCounterApp/Droid/Properties/AndroidManifest.xml
+++ b/samples/StaticView/StaticViewCounterApp/Droid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.donsyme.StaticViewCounterApp">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="org.fabulous.StaticViewCounterApp">
 	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="27" />
 	<application android:label="StaticViewCounterApp"></application>
 </manifest>

--- a/samples/StaticView/StaticViewCounterApp/iOS/Info.plist
+++ b/samples/StaticView/StaticViewCounterApp/iOS/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleName</key>
 	<string>StaticViewCounterApp</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.donsyme.AllControls</string>
+	<string>org.fabulous.StaticViewCounterApp</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>

--- a/samples/TicTacToe/Droid/Properties/AndroidManifest.xml
+++ b/samples/TicTacToe/Droid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.companyname.TicTacToe">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="org.fabulous.TicTacToe">
 	<uses-sdk android:minSdkVersion="19" />
 	<application android:label="TicTacToe"></application>
 </manifest>

--- a/samples/TicTacToe/iOS/Info.plist
+++ b/samples/TicTacToe/iOS/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleName</key>
 	<string>TicTacToe</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.donsyme.AllControls</string>
+	<string>org.fabulous.TicTacToe</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
Streamlined all samples to use package identifier `org.fabulous.*`