### PR TITLE
Added ScrollTo and Scrolled to ScrollView

### DIFF
--- a/docs/views-elements.md
+++ b/docs/views-elements.md
@@ -166,6 +166,40 @@ to automatically move to the visible portion of the screen when the keyboard is 
 View.ScrollView(View.StackLayout(padding=20.0, children= ...) )
 ```
 
+The scroll position can be setted programmatically through the attribute `scrollTo`. This attribute needs the X and Y coordinates to scroll to and an indication whether it should be animated or not. (`Animated`/`NotAnimated`)
+
+Note: Fabulous will try to scroll to these coordinates every time it needs to refresh the UI. Making use of the optional argument is recommended.
+
+You can also subscribe to the event `Scrolled` to be notified when the scrolling is over.
+
+```fsharp
+View.ScrollView(content=(...),
+    ?scrollTo=(if model.ShouldScroll then Some (500.0, 0.0, Animated) else None),
+    scrolled=(fun args -> dispatch Scrolled))
+```
+
+For more complex scenarios, you can directly use the method from Xamarin.Forms [`ScrollView.ScrollToAsync(x, y, animated)`](https://docs.microsoft.com/dotnet/api/xamarin.forms.scrollview.scrolltoasync?view=xamarin-forms)  
+This method offers the advantage of being awaitable until the end of the scrolling.  
+To do this, a reference to the underlying ScrollView is needed.
+
+
+```fsharp
+let scrollViewRef = ViewRef<ScrollView>
+
+View.ScrollView(ref=scrollViewRef, content=(...))
+
+// Some time later (usually in a Cmd)
+let scrollToCoordinates x y animated =
+    async {
+        match scrollViewRef.TryValue with
+        | None ->
+            return None
+        | Some scrollView ->
+            do! scrollView.ScrollToAsync(x, y, animated) |> Async.AwaitTask
+            return (Some Scrolled)
+    } |> Cmd.ofAsyncMsgOption
+```
+
 See also:
 
 * [Xamarin guide to ScrollView](https://docs.microsoft.com/en-us/xamarin/xamarin-forms/user-interface/layouts/scroll-view)

--- a/src/Fabulous.Core/ViewConverters.fs
+++ b/src/Fabulous.Core/ViewConverters.fs
@@ -14,6 +14,11 @@ open Xamarin.Forms.StyleSheets
 module ValueOption = 
     let inline map f x = match x with ValueNone -> ValueNone | ValueSome v -> ValueSome (f v)
 
+/// Defines if the action should be animated or not
+type AnimationKind =
+    | Animated
+    | NotAnimated
+
 /// A custom data element for the ListView view element
 [<AllowNullLiteral>]
 type IListElement = 
@@ -644,6 +649,17 @@ module Converters =
         | ValueSome prevVal, ValueSome newVal when prevVal = newVal -> ()
         | _, ValueNone -> Xamarin.Forms.MenuItem.SetAccelerator(target, null)
         | _, ValueSome newVal -> Xamarin.Forms.MenuItem.SetAccelerator(target, makeAccelerator newVal)
+
+    /// Trigger ScrollView.ScrollToAsync if needed, given the current values
+    let internal triggerScrollToAsync (currValue: (float * float * AnimationKind) voption) (target: Xamarin.Forms.ScrollView) =
+        match currValue with
+        | ValueSome (x, y, animationKind) when x <> target.ScrollX || y <> target.ScrollY ->
+            let animated =
+                match animationKind with
+                | Animated -> true
+                | NotAnimated -> false
+            target.ScrollToAsync(x, y, animated) |> ignore
+        | _ -> ()
 
     /// Check if two LayoutOptions are equal
     let internal equalLayoutOptions (x:Xamarin.Forms.LayoutOptions) (y:Xamarin.Forms.LayoutOptions)  =

--- a/tools/Generator/Xamarin.Forms.Core.json
+++ b/tools/Generator/Xamarin.Forms.Core.json
@@ -380,6 +380,18 @@
         {
           "name": "VerticalScrollBarVisibility",
           "defaultValue": "Xamarin.Forms.ScrollBarVisibility.Default"
+        },
+        {
+          "name": "ScrollTo",
+          "inputType": "float * float * Fabulous.DynamicViews.AnimationKind",
+          "modelType": "float * float * Fabulous.DynamicViews.AnimationKind",
+          "updateCode": "(fun _ curr target -> triggerScrollToAsync curr target)"
+        },
+        {
+          "name": "Scrolled",
+          "defaultValue": "null",
+          "inputType": "Xamarin.Forms.ScrolledEventArgs -> unit",
+          "convToModel": "(fun f -> System.EventHandler<Xamarin.Forms.ScrolledEventArgs>(fun _sender args -> f args))"
         }
       ]
     },


### PR DESCRIPTION
Fixes #311 

Add the missing `Scrolled` event and a new `ScrollTo` property to allow scrolling to a specific position.
This `ScrollTo` property will trigger `ScrollView.ScrollToAsync` of Xamarin.Forms.

I added some examples and a new entry in the docs to specify how to use these new attributes, and why/how to use directly `ScrollView.ScrollToAsync`.