### PR TITLE
Remove redundant condition check

### DIFF
--- a/src/Fabulous.Core/ViewConverters.fs
+++ b/src/Fabulous.Core/ViewConverters.fs
@@ -291,7 +291,7 @@ module Converters =
                 // Adjust the existing targetColl and create the new targetColl
                 for i in 0 .. coll.Length-1 do
                     let newChild = coll.[i]
-                    let prevChildOpt = match prevCollOpt with ValueNone -> ValueNone | ValueSome coll when i < coll.Length && i < n -> ValueSome coll.[i] | _ -> ValueNone
+                    let prevChildOpt = match prevCollOpt with ValueNone -> ValueNone | ValueSome coll when i < n -> ValueSome coll.[i] | _ -> ValueNone
                     let prevChildOpt, targetChild = 
                         if (match prevChildOpt with ValueNone -> true | ValueSome prevChild -> not (identical prevChild newChild)) then
                             let mustCreate = (i >= n || match prevChildOpt with ValueNone -> true | ValueSome prevChild -> not (canReuse prevChild newChild))


### PR DESCRIPTION
`i` is always less than `coll.Length`.