### PR TITLE
Remove reflection from ViewConverters

### DIFF
--- a/src/Fabulous.Core/ViewConverters.fs
+++ b/src/Fabulous.Core/ViewConverters.fs
@@ -364,7 +364,7 @@ module Converters =
         updateCollectionGeneric (ValueSome prevColl) (ValueSome currColl) target ListElementData (fun _ _ _ -> ()) canReuseChild (fun _ curr target -> target.Key <- curr) 
 
     /// Update the items in a GroupedListView control, given previous and current view elements
-    let internal updateListViewGroupedItems (prevCollOpt: (string * 'T * 'T[])[] voption) (collOpt: (string * 'T * 'T[])[] voption) (target: Xamarin.Forms.ListView) = 
+    let internal updateListViewGroupedItems (prevCollOpt: (string * ViewElement * ViewElement[])[] voption) (collOpt: (string * ViewElement * ViewElement[])[] voption) (target: Xamarin.Forms.ListView) = 
         let targetColl = 
             match target.ItemsSource with 
             | :? ObservableCollection<ListGroupData> as oc -> oc

--- a/src/Fabulous.Core/ViewConverters.fs
+++ b/src/Fabulous.Core/ViewConverters.fs
@@ -5,7 +5,6 @@ namespace Fabulous.DynamicViews
 open System
 open System.Collections.Generic
 open System.ComponentModel
-open System.Reflection
 open System.IO
 open System.Windows.Input
 open Xamarin.Forms
@@ -23,16 +22,16 @@ type AnimationKind =
 [<AllowNullLiteral>]
 type IListElement = 
     inherit INotifyPropertyChanged
-    abstract Key : obj
+    abstract Key : ViewElement
 
 /// A custom data element for the ListView view element
 [<AllowNullLiteral>]
-type ListElementData<'T>(key:'T) = 
+type ListElementData(key) = 
     let ev = new Event<_,_>()
     let mutable data = key
     
     interface IListElement with
-        member x.Key = box data
+        member x.Key = data
         [<CLIEvent>] member x.PropertyChanged = ev.Publish
         
     member x.Key
@@ -43,15 +42,15 @@ type ListElementData<'T>(key:'T) =
 
 /// A custom data element for the GroupedListView view element
 [<AllowNullLiteral>]
-type ListGroupData<'T>(shortName: string, key:'T, coll: 'T[]) = 
-    inherit System.Collections.ObjectModel.ObservableCollection<ListElementData<'T>>(Seq.map ListElementData coll)
+type ListGroupData(shortName: string, key, coll: ViewElement[]) = 
+    inherit System.Collections.ObjectModel.ObservableCollection<ListElementData>(Seq.map ListElementData coll)
     
     let ev = new Event<_,_>()
     let mutable shortNameData = shortName
     let mutable keyData = key
     
     interface IListElement with
-        member x.Key = box keyData
+        member x.Key = keyData
         [<CLIEvent>] member x.PropertyChanged = ev.Publish
         
     member x.Key
@@ -73,24 +72,17 @@ type ViewElementCell() =
     inherit ViewCell()
 
     let mutable listElementOpt : IListElement option = None
-    let mutable modelOpt : obj option = None
+    let mutable modelOpt : ViewElement option = None
     
-    let createView newModel =
-        let ty = newModel.GetType()
-        let res = ty.InvokeMember("Create",(BindingFlags.InvokeMethod ||| BindingFlags.Public ||| BindingFlags.Instance), null, newModel, [| |] )
-        match res with 
+    let createView (newModel: ViewElement) =
+        match newModel.Create () with 
         | :? View as v -> v
-        | _ -> failwithf "The cells of a ListView must each be some kind of 'View' and not a '%A'" (res.GetType())
+        | x -> failwithf "The cells of a ListView must each be some kind of 'View' and not a '%A'" (x.GetType())
 
-    let updateIncremental view prevModel newModel =
-        let ty = newModel.GetType()
-        let res = ty.InvokeMember("UpdateIncremental",(BindingFlags.InvokeMethod ||| BindingFlags.Public ||| BindingFlags.Instance), null, newModel, [| prevModel; box view |] )
-        ignore res
-    
     member x.OnDataPropertyChanged = PropertyChangedEventHandler(fun _ args ->
         match args.PropertyName, listElementOpt, modelOpt with
         | "Key", Some curr, Some prevModel ->
-            updateIncremental x.View prevModel curr.Key
+            curr.Key.UpdateIncremental (prevModel, x.View)
             modelOpt <- Some curr.Key
         | _ -> ()
     )
@@ -104,7 +96,7 @@ type ViewElementCell() =
             | Some prev ->
                 prev.PropertyChanged.RemoveHandler x.OnDataPropertyChanged
                 curr.PropertyChanged.AddHandler x.OnDataPropertyChanged
-                updateIncremental x.View prev.Key newModel
+                newModel.UpdateIncremental (prev.Key, x.View)
             | None -> 
                 curr.PropertyChanged.AddHandler x.OnDataPropertyChanged
                 x.View <- createView newModel
@@ -359,14 +351,14 @@ module Converters =
     let internal updateListViewItems (prevCollOpt: seq<'T> voption) (collOpt: seq<'T> voption) (target: Xamarin.Forms.ListView) = 
         let targetColl = 
             match target.ItemsSource with 
-            | :? ObservableCollection<ListElementData<'T>> as oc -> oc
+            | :? ObservableCollection<ListElementData> as oc -> oc
             | _ -> 
-                let oc = ObservableCollection<ListElementData<'T>>()
+                let oc = ObservableCollection<ListElementData>()
                 target.ItemsSource <- oc
                 oc
         updateCollectionGeneric (ValueOption.map seqToArray prevCollOpt) (ValueOption.map seqToArray collOpt) targetColl ListElementData (fun _ _ _ -> ()) canReuseChild (fun _ curr target -> target.Key <- curr) 
 
-    let private updateListGroupData (_prevShortName: string, _prevKey: 'T, prevColl: 'T[]) (currShortName: string, currKey: 'T, currColl: 'T[]) (target: ListGroupData<'T>) =
+    let private updateListGroupData (_prevShortName: string, _prevKey, prevColl: ViewElement[]) (currShortName: string, currKey, currColl: ViewElement[]) (target: ListGroupData) =
         target.ShortName <- currShortName
         target.Key <- currKey
         updateCollectionGeneric (ValueSome prevColl) (ValueSome currColl) target ListElementData (fun _ _ _ -> ()) canReuseChild (fun _ curr target -> target.Key <- curr) 
@@ -375,9 +367,9 @@ module Converters =
     let internal updateListViewGroupedItems (prevCollOpt: (string * 'T * 'T[])[] voption) (collOpt: (string * 'T * 'T[])[] voption) (target: Xamarin.Forms.ListView) = 
         let targetColl = 
             match target.ItemsSource with 
-            | :? ObservableCollection<ListGroupData<'T>> as oc -> oc
+            | :? ObservableCollection<ListGroupData> as oc -> oc
             | _ -> 
-                let oc = ObservableCollection<ListGroupData<'T>>()
+                let oc = ObservableCollection<ListGroupData>()
                 target.ItemsSource <- oc
                 oc
         updateCollectionGeneric prevCollOpt collOpt targetColl ListGroupData (fun _ _ _ -> ()) (fun (_, prevKey, _) (_, currKey, _) -> canReuseChild prevKey currKey) updateListGroupData
@@ -675,13 +667,13 @@ module Converters =
     let tryFindListViewItem (sender: obj) (item: obj) =
         match item with 
         | null -> None
-        | :? ListElementData<ViewElement> as item -> 
-            let items = (sender :?> Xamarin.Forms.ListView).ItemsSource :?> System.Collections.Generic.IList<ListElementData<ViewElement>> 
+        | :? ListElementData as item -> 
+            let items = (sender :?> Xamarin.Forms.ListView).ItemsSource :?> System.Collections.Generic.IList<ListElementData> 
             // POSSIBLE IMPROVEMENT: don't use a linear search
             items |> Seq.tryFindIndex (fun item2 -> identical item.Key item2.Key)
         | _ -> None
 
-    let private tryFindGroupedListViewItemIndex (items: System.Collections.Generic.IList<ListGroupData<ViewElement>>) (item: ListElementData<ViewElement>) =
+    let private tryFindGroupedListViewItemIndex (items: System.Collections.Generic.IList<ListGroupData>) (item: ListElementData) =
         // POSSIBLE IMPROVEMENT: don't use a linear search
         items 
         |> Seq.indexed 
@@ -695,14 +687,14 @@ module Converters =
     let tryFindGroupedListViewItemOrGroupItem (sender: obj) (item: obj) = 
         match item with 
         | null -> None
-        | :? ListGroupData<ViewElement> as item ->
-            let items = (sender :?> Xamarin.Forms.ListView).ItemsSource :?> System.Collections.Generic.IList<ListGroupData<ViewElement>> 
+        | :? ListGroupData as item ->
+            let items = (sender :?> Xamarin.Forms.ListView).ItemsSource :?> System.Collections.Generic.IList<ListGroupData> 
             // POSSIBLE IMPROVEMENT: don't use a linear search
             items 
             |> Seq.indexed 
             |> Seq.tryPick (fun (i, item2) -> if identical item.Key item2.Key then Some (i, None) else None)
-        | :? ListElementData<ViewElement> as item ->
-            let items = (sender :?> Xamarin.Forms.ListView).ItemsSource :?> System.Collections.Generic.IList<ListGroupData<ViewElement>> 
+        | :? ListElementData as item ->
+            let items = (sender :?> Xamarin.Forms.ListView).ItemsSource :?> System.Collections.Generic.IList<ListGroupData> 
             tryFindGroupedListViewItemIndex items item
             |> (function
                 | None -> None
@@ -713,7 +705,7 @@ module Converters =
     let tryFindGroupedListViewItem (sender: obj) (item: obj) =
         match item with 
         | null -> None
-        | :? ListElementData<ViewElement> as item ->
-            let items = (sender :?> Xamarin.Forms.ListView).ItemsSource :?> System.Collections.Generic.IList<ListGroupData<ViewElement>> 
+        | :? ListElementData as item ->
+            let items = (sender :?> Xamarin.Forms.ListView).ItemsSource :?> System.Collections.Generic.IList<ListGroupData> 
             tryFindGroupedListViewItemIndex items item
         | _ -> None

--- a/src/Fabulous.Core/Xamarin.Forms.Core.fs
+++ b/src/Fabulous.Core/Xamarin.Forms.Core.fs
@@ -11466,7 +11466,7 @@ type ViewBuilders() =
         | ValueNone, ValueNone -> ()
         match prevListView_SelectedItemOpt, currListView_SelectedItemOpt with
         | ValueSome prevValue, ValueSome currValue when prevValue = currValue -> ()
-        | _, ValueSome currValue -> target.SelectedItem <- (function None -> null | Some i -> let items = target.ItemsSource :?> System.Collections.Generic.IList<ListElementData<ViewElement>> in if i >= 0 && i < items.Count then items.[i] else null) currValue
+        | _, ValueSome currValue -> target.SelectedItem <- (function None -> null | Some i -> let items = target.ItemsSource :?> System.Collections.Generic.IList<ListElementData> in if i >= 0 && i < items.Count then items.[i] else null) currValue
         | ValueSome _, ValueNone -> target.SelectedItem <- null
         | ValueNone, ValueNone -> ()
         match prevListView_SeparatorVisibilityOpt, currListView_SeparatorVisibilityOpt with
@@ -11903,7 +11903,7 @@ type ViewBuilders() =
         | ValueNone, ValueNone -> ()
         match prevListViewGrouped_SelectedItemOpt, currListViewGrouped_SelectedItemOpt with
         | ValueSome prevValue, ValueSome currValue when prevValue = currValue -> ()
-        | _, ValueSome currValue -> target.SelectedItem <- (function None -> null | Some (i,j) -> let items = target.ItemsSource :?> System.Collections.Generic.IList<ListGroupData<ViewElement>> in (if i >= 0 && i < items.Count then (let items2 = items.[i] in if j >= 0 && j < items2.Count then items2.[j] else null) else null)) currValue
+        | _, ValueSome currValue -> target.SelectedItem <- (function None -> null | Some (i,j) -> let items = target.ItemsSource :?> System.Collections.Generic.IList<ListGroupData> in (if i >= 0 && i < items.Count then (let items2 = items.[i] in if j >= 0 && j < items2.Count then items2.[j] else null) else null)) currValue
         | ValueSome _, ValueNone -> target.SelectedItem <- null
         | ValueNone, ValueNone -> ()
         match prevSeparatorVisibilityOpt, currSeparatorVisibilityOpt with

--- a/tools/Generator/Xamarin.Forms.Core.json
+++ b/tools/Generator/Xamarin.Forms.Core.json
@@ -1855,7 +1855,7 @@
           "uniqueName": "ListView_SelectedItem",
           "defaultValue": "null",
           "modelType": "int option",
-          "convToValue": "(function None -> null | Some i -> let items = target.ItemsSource :?> System.Collections.Generic.IList<ListElementData<ViewElement>> in if i >= 0 && i < items.Count then items.[i] else null)"
+          "convToValue": "(function None -> null | Some i -> let items = target.ItemsSource :?> System.Collections.Generic.IList<ListElementData> in if i >= 0 && i < items.Count then items.[i] else null)"
         },
         {
           "name": "SeparatorVisibility",
@@ -1965,7 +1965,7 @@
           "uniqueName": "ListViewGrouped_SelectedItem",
           "defaultValue": "null",
           "modelType": "(int * int) option",
-          "convToValue": "(function None -> null | Some (i,j) -> let items = target.ItemsSource :?> System.Collections.Generic.IList<ListGroupData<ViewElement>> in (if i >= 0 && i < items.Count then (let items2 = items.[i] in if j >= 0 && j < items2.Count then items2.[j] else null) else null))"
+          "convToValue": "(function None -> null | Some (i,j) -> let items = target.ItemsSource :?> System.Collections.Generic.IList<ListGroupData> in (if i >= 0 && i < items.Count then (let items2 = items.[i] in if j >= 0 && j < items2.Count then items2.[j] else null) else null))"
         },
         {
           "name": "SeparatorVisibility",


### PR DESCRIPTION
I was looking at `updateIncremental` and wondered whether the reflection is necessary at all. If we're always looking for an `UpdateIncremental` member, why not simply constrain the parameter to be a subtype of `ViewElement`? Having done this, a bunch of generic type parameters have become unnecessary as well. As a result, view updates should be a tiny bit faster.

Feel free to close this if I am overlooking something and the reflection is there for a reason.