### PR TITLE
Set the license for the Templates NuGet package

### DIFF
--- a/templates/Fabulous.Templates.nuspec
+++ b/templates/Fabulous.Templates.nuspec
@@ -7,6 +7,7 @@
         <authors>Fabulous contributors</authors>
         <description>Templates for building apps with Fabulous.</description>
         <projectUrl>https://fsprojects.github.io/Fabulous/</projectUrl>
+        <license type="expression">Apache-2.0</license>
         <iconUrl>http://xamarin.com/content/images/nuget/xamarin.png</iconUrl>
         <copyright>Copyright 2018</copyright>
         <packageTypes>


### PR DESCRIPTION
The Templates package is missing the Apache 2.0 license in the nuspec file.