### PR TITLE
Updated the validation example

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -8,36 +8,30 @@ Models
 
 ### Messages and Validation
 
-Validation is generally done on updates to the model, storing error messages from validation logic in the model
-so they can be correctly and simply displayed to the user.  Here is an example of a typical pattern.
+Validation is generally done on updates to the model storing error messages from validation logic in the model so they can be correctly and simply displayed to the user. Here is an example of a typical pattern noting that you likely need to store the original input value as well as an error message:
 
 ```fsharp
+    type Temperature = DegC of float
+    type InputString = InputString of string
+    type ValidationError = ValidationError of string
+    type Model = { Temperature : Result<Temperature,InputString * ValidationError> }
+    type Msg = SetTemp of string
 
-    type Temperature = 
-       | Value of double
-       | ParseError of string  
-       
-    type Model = 
-        { TempF: Temperature
-          TempC: Temperature }
-
-    /// Validate a temperature in Farenheit, can be shared between client/server
-    let validateF text =  ... // return a Result
-
-    /// Validate a temperature in celcius, can be shared between client/server
-    let validateC text = // return a Result 
+    /// Validate a temperature - can be shared between client/server
+    let validate temperatureStr =
+        match Double.TryParse temperatureStr with
+        | true, temp -> Ok (DegC temp)
+        | false, _ -> Error (InputString temperatureStr, ValidationError "Could not parse temperature string" )
 
     let update msg model =
         match msg with
-        | SetF textF -> 
-            match validateF textF with
-            | Ok newF -> { model with TempF = Value newF }
-            | Error msg -> { model with TempF = ParseError msg }
-            
-        | SetC textC -> 
-            match validateC textC with
-            | Ok newC -> { model with TempC = Value newC }
-            | Error msg -> { model with TempC = ParseError msg }
+        | SetTemp tempStr -> { model with Temperature = validate tempStr }, Cmd.none
+
+    let view model dispatch =
+        match model.Temperature with
+        | Ok validTemp -> ... // View render logic for when the temperature is valid
+        | Error (invalidTempStr, error) -> ... // View render logic for when the temperature is invalid
+
 ```
 
 Note that the same validation logic can be used in both your app and a service back-end.
@@ -47,21 +41,21 @@ Note that the same validation logic can be used in both your app and a service b
 Application state is very simple to save by serializing the model into `app.Properties`. For example, you can store as JSON as follows using `Json.NET`:
 ```fsharp
 
-type Application() = 
+type Application() =
     ....
     let modelId = "model"
-    override __.OnSleep() = 
+    override __.OnSleep() =
 
         let json = Newtonsoft.Json.JsonConvert.SerializeObject(runner.CurrentModel)
         Debug.WriteLine("OnSleep: saving model into app.Properties, json = {0}", json)
 
         app.Properties.[modelId] <- json
 
-    override __.OnResume() = 
+    override __.OnResume() =
         Debug.WriteLine "OnResume: checking for model in app.Properties"
-        try 
+        try
             match app.Properties.TryGetValue modelId with
-            | true, (:? string as json) -> 
+            | true, (:? string as json) ->
 
                 Debug.WriteLine("OnResume: restoring model from app.Properties, json = {0}", json)
                 let model = Newtonsoft.Json.JsonConvert.DeserializeObject<App.Model>(json)
@@ -70,10 +64,10 @@ type Application() =
                 runner.SetCurrentModel (model, Cmd.none)
 
             | _ -> ()
-        with ex -> 
+        with ex ->
             App.program.onError("Error while restoring model found in app.Properties", ex)
 
-    override this.OnStart() = 
+    override this.OnStart() =
         Debug.WriteLine "OnStart: using same logic as OnResume()"
         this.OnResume()
 ```

--- a/docs/models.md
+++ b/docs/models.md
@@ -8,30 +8,89 @@ Models
 
 ### Messages and Validation
 
-Validation is generally done on updates to the model storing error messages from validation logic in the model so they can be correctly and simply displayed to the user. Here is an example of a typical pattern noting that you likely need to store the original input value as well as an error message:
+Validation is generally done on updates to the model storing error messages from validation logic in the model so they can be correctly and simply displayed to the user. Here is a very basic example:
 
 ```fsharp
-    type Temperature = DegC of float
-    type InputString = InputString of string
-    type ValidationError = ValidationError of string
-    type Model = { Temperature : Result<Temperature,InputString * ValidationError> }
-    type Msg = SetTemp of string
+type Animal =
+    | ValidAnimal of string
+    | InvalidAnimal of string
 
-    /// Validate a temperature - can be shared between client/server
-    let validate temperatureStr =
-        match Double.TryParse temperatureStr with
-        | true, temp -> Ok (DegC temp)
-        | false, _ -> Error (InputString temperatureStr, ValidationError "Could not parse temperature string" )
+type Model = { AnimalName : Animal }
 
-    let update msg model =
-        match msg with
-        | SetTemp tempStr -> { model with Temperature = validate tempStr }, Cmd.none
+type Msg = UpdateAnimal of string
 
-    let view model dispatch =
-        match model.Temperature with
-        | Ok validTemp -> ... // View render logic for when the temperature is valid
-        | Error (invalidTempStr, error) -> ... // View render logic for when the temperature is invalid
+let validAnimalNames = [ "Emu"; "Kangaroo"; "Platypus"; "Wombat" ]
 
+let validateAnimal (animalName : string) =
+    if List.contains animalName validAnimalNames
+    then ValidAnimal animalName
+    else InvalidAnimal animalName
+
+let update msg model =
+    match msg with
+    | UpdateAnimal animalName -> { model with AnimalName = validateAnimal animalName }
+
+let view (model: Model) dispatch : ViewElement =
+    let makeEntryCell text = View.Entry(text = text, textChanged = fun textArgs -> UpdateAnimal textArgs.NewTextValue |> dispatch)
+    View.ContentPage(
+        content =
+        View.StackLayout(
+            children =
+                match model.AnimalName with
+                | ValidAnimal validName -> [ makeEntryCell validName ]
+                | InvalidAnimal invalidName ->
+                    [ makeEntryCell invalidName
+                      View.Label(text = sprintf "%s is not a valid animal name. Try %A" invalidName validAnimalNames) ]))
+
+let init () = { AnimalName = validateAnimal "Emu" }
+```
+A more advanced validation might use the `Result<'T,'TError>` type to wrap parts of the model that require validation: in the previous example the `Result` type has somewhat been reinvented. Using `Result` provides a consistient way of knowing which parts of the model are in a valid state, use of the standard `Result` functions like `map` and `bind` to peform branching logic, and more comprehensive error messaging. One thing to note is that `'TError` will usually need to carry the original input value so it can be displayed back to the user.
+
+```fSharp
+type Animal = Animal of string
+
+type ErrorMessage =
+    | InvalidName of InputString : string
+    | BlankName
+
+type Model = { AnimalName : Result<Animal,ErrorMessage> }
+
+type Msg = UpdateAnimal of string
+
+let validAnimalNames = [ "Emu"; "Kangaroo"; "Platypus"; "Wombat" ]
+
+let validateAnimal (animalName : string) =
+    if animalName = ""
+    then Error BlankName
+    else
+        if List.contains animalName validAnimalNames
+        then Ok (Animal animalName)
+        else Error (InvalidName animalName)
+
+let update msg model =
+    match msg with
+    | UpdateAnimal animalName -> { model with AnimalName = validateAnimal animalName }
+
+let view (model: Model) dispatch : ViewElement =
+    let makeEntryCell text = View.Entry(text = text, textChanged = fun textArgs -> UpdateAnimal textArgs.NewTextValue |> dispatch)
+    let makeErrorMsg err =
+        match err with
+        | InvalidName invalidName ->
+            [ makeEntryCell invalidName
+              View.Label(text = sprintf "%s is not a valid animal name. Try %A" invalidName validAnimalNames) ]
+        | BlankName ->
+            [ makeEntryCell ""
+              View.Label(text = sprintf "You must input a name") ]
+
+    View.ContentPage(
+        content =
+        View.StackLayout(
+            children =
+                match model.AnimalName with
+                | Ok (Animal validName) -> [ makeEntryCell validName ]
+                | Error errorMsg -> makeErrorMsg errorMsg))
+
+let init () = { AnimalName = validateAnimal "Emu" }
 ```
 
 Note that the same validation logic can be used in both your app and a service back-end.

--- a/docs/models.md
+++ b/docs/models.md
@@ -44,7 +44,7 @@ let view (model: Model) dispatch : ViewElement =
 
 let init () = { AnimalName = validateAnimal "Emu" }
 ```
-A more advanced validation might use the `Result<'T,'TError>` type to wrap parts of the model that require validation: in the previous example the `Result` type has somewhat been reinvented. Using `Result` provides a consistient way of knowing which parts of the model are in a valid state, use of the standard `Result` functions like `map` and `bind` to peform branching logic, and more comprehensive error messaging. One thing to note is that `'TError` will usually need to carry the original input value so it can be displayed back to the user.
+A more advanced validation might use the `Result<'T,'TError>` type to wrap parts of the model that require validation: in the previous example the `Result` type has somewhat been reinvented. Using `Result` provides a consistent way of knowing which parts of the model are in a valid state, use of the standard `Result` functions like `map` and `bind` to perform branching logic, and more comprehensive error messaging. One thing to note is that `'TError` will usually need to carry the original input value so it can be displayed back to the user.
 
 ```fSharp
 type Animal = Animal of string

--- a/docs/models.md
+++ b/docs/models.md
@@ -34,13 +34,13 @@ let view (model: Model) dispatch : ViewElement =
     let makeEntryCell text = View.Entry(text = text, textChanged = fun textArgs -> UpdateAnimal textArgs.NewTextValue |> dispatch)
     View.ContentPage(
         content =
-			View.StackLayout(
-				children =
-					match model.AnimalName with
-					| ValidAnimal validName -> [ makeEntryCell validName ]
-					| InvalidAnimal invalidName ->
-						[ makeEntryCell invalidName
-						  View.Label(text = sprintf "%s is not a valid animal name. Try %A" invalidName validAnimalNames) ]))
+            View.StackLayout(
+                children =
+                    match model.AnimalName with
+                    | ValidAnimal validName -> [ makeEntryCell validName ]
+                    | InvalidAnimal invalidName ->
+                        [ makeEntryCell invalidName
+                          View.Label(text = sprintf "%s is not a valid animal name. Try %A" invalidName validAnimalNames) ]))
 
 let init () = { AnimalName = validateAnimal "Emu" }
 ```

--- a/docs/models.md
+++ b/docs/models.md
@@ -34,13 +34,13 @@ let view (model: Model) dispatch : ViewElement =
     let makeEntryCell text = View.Entry(text = text, textChanged = fun textArgs -> UpdateAnimal textArgs.NewTextValue |> dispatch)
     View.ContentPage(
         content =
-        View.StackLayout(
-            children =
-                match model.AnimalName with
-                | ValidAnimal validName -> [ makeEntryCell validName ]
-                | InvalidAnimal invalidName ->
-                    [ makeEntryCell invalidName
-                      View.Label(text = sprintf "%s is not a valid animal name. Try %A" invalidName validAnimalNames) ]))
+			View.StackLayout(
+				children =
+					match model.AnimalName with
+					| ValidAnimal validName -> [ makeEntryCell validName ]
+					| InvalidAnimal invalidName ->
+						[ makeEntryCell invalidName
+						  View.Label(text = sprintf "%s is not a valid animal name. Try %A" invalidName validAnimalNames) ]))
 
 let init () = { AnimalName = validateAnimal "Emu" }
 ```


### PR DESCRIPTION
While there are many ways to skin a cat when it comes to validation.... I thought the example given here for validation could be improved. Currently it doesn't carry forward the original input value along with the error message (you would likely need both of these); and it also in a way reinvents the result type on the `Temperature` union type rather than wrapping the temperature in a `Result` (which would have advantages when you had a large form of values and you wanted to check if they were all valid). Let me know your thoughts.