### PR TITLE
Fixed inverted assignment in TableView

### DIFF
--- a/src/Fabulous.Core/ViewConverters.fs
+++ b/src/Fabulous.Core/ViewConverters.fs
@@ -389,8 +389,8 @@ module Converters =
         let create (desc: ViewElement) = (desc.Create() :?> Cell)
 
         match prevCollOpt with
-        | ValueNone -> ()
-        | ValueSome _ -> target.Root <- TableRoot()
+        | ValueNone -> target.Root <- TableRoot()
+        | ValueSome _ -> ()
 
         updateCollectionGeneric prevCollOpt collOpt target.Root 
             (fun (s, es) -> let section = TableSection(s) in section.Add(Seq.map create es); section) 


### PR DESCRIPTION
Fixes #363 

In a previous PR, the buggy TableRoot was replaced by a newly instantiated TableRoot. (https://github.com/xamarin/Xamarin.Forms/issues/5197)
But since then, everytime the TableView needed to update, its TableRoot was recreated thus preventing the recycling of the view.
Now the TableRoot is only created when there was no previous item in the TableView.