### PR TITLE
Removed CommandParameter

### DIFF
--- a/src/Fabulous.Core/Xamarin.Forms.Core.fs
+++ b/src/Fabulous.Core/Xamarin.Forms.Core.fs
@@ -85,7 +85,6 @@ module ViewAttributes =
     let ButtonCanExecuteAttribKey : AttributeKey<_> = AttributeKey<_>("ButtonCanExecute")
     let BorderColorAttribKey : AttributeKey<_> = AttributeKey<_>("BorderColor")
     let BorderWidthAttribKey : AttributeKey<_> = AttributeKey<_>("BorderWidth")
-    let CommandParameterAttribKey : AttributeKey<_> = AttributeKey<_>("CommandParameter")
     let ContentLayoutAttribKey : AttributeKey<_> = AttributeKey<_>("ContentLayout")
     let ButtonCornerRadiusAttribKey : AttributeKey<_> = AttributeKey<_>("ButtonCornerRadius")
     let ButtonImageSourceAttribKey : AttributeKey<_> = AttributeKey<_>("ButtonImageSource")
@@ -2907,7 +2906,6 @@ type ViewBuilders() =
                                      ?canExecute: bool,
                                      ?borderColor: Xamarin.Forms.Color,
                                      ?borderWidth: double,
-                                     ?commandParameter: System.Object,
                                      ?contentLayout: Xamarin.Forms.Button.ButtonContentLayout,
                                      ?cornerRadius: int,
                                      ?fontFamily: string,
@@ -2962,7 +2960,6 @@ type ViewBuilders() =
         let attribCount = match canExecute with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match borderColor with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match borderWidth with Some _ -> attribCount + 1 | None -> attribCount
-        let attribCount = match commandParameter with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match contentLayout with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match cornerRadius with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match fontFamily with Some _ -> attribCount + 1 | None -> attribCount
@@ -2978,7 +2975,6 @@ type ViewBuilders() =
         match canExecute with None -> () | Some v -> attribBuilder.Add(ViewAttributes.ButtonCanExecuteAttribKey, (v)) 
         match borderColor with None -> () | Some v -> attribBuilder.Add(ViewAttributes.BorderColorAttribKey, (v)) 
         match borderWidth with None -> () | Some v -> attribBuilder.Add(ViewAttributes.BorderWidthAttribKey, (v)) 
-        match commandParameter with None -> () | Some v -> attribBuilder.Add(ViewAttributes.CommandParameterAttribKey, (v)) 
         match contentLayout with None -> () | Some v -> attribBuilder.Add(ViewAttributes.ContentLayoutAttribKey, (v)) 
         match cornerRadius with None -> () | Some v -> attribBuilder.Add(ViewAttributes.ButtonCornerRadiusAttribKey, (v)) 
         match fontFamily with None -> () | Some v -> attribBuilder.Add(ViewAttributes.FontFamilyAttribKey, (v)) 
@@ -3011,8 +3007,6 @@ type ViewBuilders() =
         let mutable currBorderColorOpt = ValueNone
         let mutable prevBorderWidthOpt = ValueNone
         let mutable currBorderWidthOpt = ValueNone
-        let mutable prevCommandParameterOpt = ValueNone
-        let mutable currCommandParameterOpt = ValueNone
         let mutable prevContentLayoutOpt = ValueNone
         let mutable currContentLayoutOpt = ValueNone
         let mutable prevButtonCornerRadiusOpt = ValueNone
@@ -3040,8 +3034,6 @@ type ViewBuilders() =
                 currBorderColorOpt <- ValueSome (kvp.Value :?> Xamarin.Forms.Color)
             if kvp.Key = ViewAttributes.BorderWidthAttribKey.KeyValue then 
                 currBorderWidthOpt <- ValueSome (kvp.Value :?> double)
-            if kvp.Key = ViewAttributes.CommandParameterAttribKey.KeyValue then 
-                currCommandParameterOpt <- ValueSome (kvp.Value :?> System.Object)
             if kvp.Key = ViewAttributes.ContentLayoutAttribKey.KeyValue then 
                 currContentLayoutOpt <- ValueSome (kvp.Value :?> Xamarin.Forms.Button.ButtonContentLayout)
             if kvp.Key = ViewAttributes.ButtonCornerRadiusAttribKey.KeyValue then 
@@ -3072,8 +3064,6 @@ type ViewBuilders() =
                     prevBorderColorOpt <- ValueSome (kvp.Value :?> Xamarin.Forms.Color)
                 if kvp.Key = ViewAttributes.BorderWidthAttribKey.KeyValue then 
                     prevBorderWidthOpt <- ValueSome (kvp.Value :?> double)
-                if kvp.Key = ViewAttributes.CommandParameterAttribKey.KeyValue then 
-                    prevCommandParameterOpt <- ValueSome (kvp.Value :?> System.Object)
                 if kvp.Key = ViewAttributes.ContentLayoutAttribKey.KeyValue then 
                     prevContentLayoutOpt <- ValueSome (kvp.Value :?> Xamarin.Forms.Button.ButtonContentLayout)
                 if kvp.Key = ViewAttributes.ButtonCornerRadiusAttribKey.KeyValue then 
@@ -3106,11 +3096,6 @@ type ViewBuilders() =
         | ValueSome prevValue, ValueSome currValue when prevValue = currValue -> ()
         | _, ValueSome currValue -> target.BorderWidth <-  currValue
         | ValueSome _, ValueNone -> target.BorderWidth <- -1.0
-        | ValueNone, ValueNone -> ()
-        match prevCommandParameterOpt, currCommandParameterOpt with
-        | ValueSome prevValue, ValueSome currValue when prevValue = currValue -> ()
-        | _, ValueSome currValue -> target.CommandParameter <-  currValue
-        | ValueSome _, ValueNone -> target.CommandParameter <- null
         | ValueNone, ValueNone -> ()
         match prevContentLayoutOpt, currContentLayoutOpt with
         | ValueSome prevValue, ValueSome currValue when prevValue = currValue -> ()
@@ -3158,7 +3143,6 @@ type ViewBuilders() =
                                          ?canExecute: bool,
                                          ?borderColor: Xamarin.Forms.Color,
                                          ?borderWidth: double,
-                                         ?commandParameter: System.Object,
                                          ?contentLayout: Xamarin.Forms.Button.ButtonContentLayout,
                                          ?cornerRadius: int,
                                          ?fontFamily: string,
@@ -3214,7 +3198,6 @@ type ViewBuilders() =
                                ?canExecute=canExecute,
                                ?borderColor=borderColor,
                                ?borderWidth=borderWidth,
-                               ?commandParameter=commandParameter,
                                ?contentLayout=contentLayout,
                                ?cornerRadius=cornerRadius,
                                ?fontFamily=fontFamily,
@@ -10659,7 +10642,6 @@ type ViewBuilders() =
     static member inline BuildMenuItem(attribCount: int,
                                        ?text: string,
                                        ?command: unit -> unit,
-                                       ?commandParameter: System.Object,
                                        ?icon: string,
                                        ?accelerator: string,
                                        ?classId: string,
@@ -10670,14 +10652,12 @@ type ViewBuilders() =
 
         let attribCount = match text with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match command with Some _ -> attribCount + 1 | None -> attribCount
-        let attribCount = match commandParameter with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match icon with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match accelerator with Some _ -> attribCount + 1 | None -> attribCount
 
         let attribBuilder = ViewBuilders.BuildElement(attribCount, ?classId=classId, ?styleId=styleId, ?automationId=automationId, ?created=created, ?ref=ref)
         match text with None -> () | Some v -> attribBuilder.Add(ViewAttributes.TextAttribKey, (v)) 
         match command with None -> () | Some v -> attribBuilder.Add(ViewAttributes.CommandAttribKey, makeCommand(v)) 
-        match commandParameter with None -> () | Some v -> attribBuilder.Add(ViewAttributes.CommandParameterAttribKey, (v)) 
         match icon with None -> () | Some v -> attribBuilder.Add(ViewAttributes.IconAttribKey, (v)) 
         match accelerator with None -> () | Some v -> attribBuilder.Add(ViewAttributes.AcceleratorAttribKey, (v)) 
         attribBuilder
@@ -10698,8 +10678,6 @@ type ViewBuilders() =
         let mutable currTextOpt = ValueNone
         let mutable prevCommandOpt = ValueNone
         let mutable currCommandOpt = ValueNone
-        let mutable prevCommandParameterOpt = ValueNone
-        let mutable currCommandParameterOpt = ValueNone
         let mutable prevIconOpt = ValueNone
         let mutable currIconOpt = ValueNone
         let mutable prevAcceleratorOpt = ValueNone
@@ -10709,8 +10687,6 @@ type ViewBuilders() =
                 currTextOpt <- ValueSome (kvp.Value :?> string)
             if kvp.Key = ViewAttributes.CommandAttribKey.KeyValue then 
                 currCommandOpt <- ValueSome (kvp.Value :?> System.Windows.Input.ICommand)
-            if kvp.Key = ViewAttributes.CommandParameterAttribKey.KeyValue then 
-                currCommandParameterOpt <- ValueSome (kvp.Value :?> System.Object)
             if kvp.Key = ViewAttributes.IconAttribKey.KeyValue then 
                 currIconOpt <- ValueSome (kvp.Value :?> string)
             if kvp.Key = ViewAttributes.AcceleratorAttribKey.KeyValue then 
@@ -10723,8 +10699,6 @@ type ViewBuilders() =
                     prevTextOpt <- ValueSome (kvp.Value :?> string)
                 if kvp.Key = ViewAttributes.CommandAttribKey.KeyValue then 
                     prevCommandOpt <- ValueSome (kvp.Value :?> System.Windows.Input.ICommand)
-                if kvp.Key = ViewAttributes.CommandParameterAttribKey.KeyValue then 
-                    prevCommandParameterOpt <- ValueSome (kvp.Value :?> System.Object)
                 if kvp.Key = ViewAttributes.IconAttribKey.KeyValue then 
                     prevIconOpt <- ValueSome (kvp.Value :?> string)
                 if kvp.Key = ViewAttributes.AcceleratorAttribKey.KeyValue then 
@@ -10739,11 +10713,6 @@ type ViewBuilders() =
         | _, ValueSome currValue -> target.Command <-  currValue
         | ValueSome _, ValueNone -> target.Command <- null
         | ValueNone, ValueNone -> ()
-        match prevCommandParameterOpt, currCommandParameterOpt with
-        | ValueSome prevValue, ValueSome currValue when prevValue = currValue -> ()
-        | _, ValueSome currValue -> target.CommandParameter <-  currValue
-        | ValueSome _, ValueNone -> target.CommandParameter <- null
-        | ValueNone, ValueNone -> ()
         match prevIconOpt, currIconOpt with
         | ValueSome prevValue, ValueSome currValue when prevValue = currValue -> ()
         | _, ValueSome currValue -> target.Icon <- makeFileImageSource currValue
@@ -10753,7 +10722,6 @@ type ViewBuilders() =
 
     static member inline ConstructMenuItem(?text: string,
                                            ?command: unit -> unit,
-                                           ?commandParameter: System.Object,
                                            ?icon: string,
                                            ?accelerator: string,
                                            ?classId: string,
@@ -10765,7 +10733,6 @@ type ViewBuilders() =
         let attribBuilder = ViewBuilders.BuildMenuItem(0,
                                ?text=text,
                                ?command=command,
-                               ?commandParameter=commandParameter,
                                ?icon=icon,
                                ?accelerator=accelerator,
                                ?classId=classId,
@@ -10784,7 +10751,6 @@ type ViewBuilders() =
                                        ?detailColor: Xamarin.Forms.Color,
                                        ?command: unit -> unit,
                                        ?canExecute: bool,
-                                       ?commandParameter: System.Object,
                                        ?height: double,
                                        ?isEnabled: bool,
                                        ?classId: string,
@@ -10799,7 +10765,6 @@ type ViewBuilders() =
         let attribCount = match detailColor with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match command with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match canExecute with Some _ -> attribCount + 1 | None -> attribCount
-        let attribCount = match commandParameter with Some _ -> attribCount + 1 | None -> attribCount
 
         let attribBuilder = ViewBuilders.BuildCell(attribCount, ?height=height, ?isEnabled=isEnabled, ?classId=classId, ?styleId=styleId, ?automationId=automationId, ?created=created, ?ref=ref)
         match text with None -> () | Some v -> attribBuilder.Add(ViewAttributes.TextAttribKey, (v)) 
@@ -10808,7 +10773,6 @@ type ViewBuilders() =
         match detailColor with None -> () | Some v -> attribBuilder.Add(ViewAttributes.TextDetailColorAttribKey, (v)) 
         match command with None -> () | Some v -> attribBuilder.Add(ViewAttributes.TextCellCommandAttribKey, (v)) 
         match canExecute with None -> () | Some v -> attribBuilder.Add(ViewAttributes.TextCellCanExecuteAttribKey, (v)) 
-        match commandParameter with None -> () | Some v -> attribBuilder.Add(ViewAttributes.CommandParameterAttribKey, (v)) 
         attribBuilder
 
     static member val CreateFuncTextCell : (unit -> Xamarin.Forms.TextCell) = (fun () -> ViewBuilders.CreateTextCell()) with get, set
@@ -10835,8 +10799,6 @@ type ViewBuilders() =
         let mutable currTextCellCommandOpt = ValueNone
         let mutable prevTextCellCanExecuteOpt = ValueNone
         let mutable currTextCellCanExecuteOpt = ValueNone
-        let mutable prevCommandParameterOpt = ValueNone
-        let mutable currCommandParameterOpt = ValueNone
         for kvp in curr.AttributesKeyed do
             if kvp.Key = ViewAttributes.TextAttribKey.KeyValue then 
                 currTextOpt <- ValueSome (kvp.Value :?> string)
@@ -10850,8 +10812,6 @@ type ViewBuilders() =
                 currTextCellCommandOpt <- ValueSome (kvp.Value :?> unit -> unit)
             if kvp.Key = ViewAttributes.TextCellCanExecuteAttribKey.KeyValue then 
                 currTextCellCanExecuteOpt <- ValueSome (kvp.Value :?> bool)
-            if kvp.Key = ViewAttributes.CommandParameterAttribKey.KeyValue then 
-                currCommandParameterOpt <- ValueSome (kvp.Value :?> System.Object)
         match prevOpt with
         | ValueNone -> ()
         | ValueSome prev ->
@@ -10868,8 +10828,6 @@ type ViewBuilders() =
                     prevTextCellCommandOpt <- ValueSome (kvp.Value :?> unit -> unit)
                 if kvp.Key = ViewAttributes.TextCellCanExecuteAttribKey.KeyValue then 
                     prevTextCellCanExecuteOpt <- ValueSome (kvp.Value :?> bool)
-                if kvp.Key = ViewAttributes.CommandParameterAttribKey.KeyValue then 
-                    prevCommandParameterOpt <- ValueSome (kvp.Value :?> System.Object)
         match prevTextOpt, currTextOpt with
         | ValueSome prevValue, ValueSome currValue when prevValue = currValue -> ()
         | _, ValueSome currValue -> target.Text <-  currValue
@@ -10892,11 +10850,6 @@ type ViewBuilders() =
         | ValueNone, ValueNone -> ()
         (fun _ _ _ -> ()) prevTextCellCommandOpt currTextCellCommandOpt target
         updateCommand prevTextCellCommandOpt currTextCellCommandOpt (fun _target -> ()) (fun (target: Xamarin.Forms.TextCell) cmd -> target.Command <- cmd) prevTextCellCanExecuteOpt currTextCellCanExecuteOpt target
-        match prevCommandParameterOpt, currCommandParameterOpt with
-        | ValueSome prevValue, ValueSome currValue when prevValue = currValue -> ()
-        | _, ValueSome currValue -> target.CommandParameter <-  currValue
-        | ValueSome _, ValueNone -> target.CommandParameter <- null
-        | ValueNone, ValueNone -> ()
 
     static member inline ConstructTextCell(?text: string,
                                            ?detail: string,
@@ -10904,7 +10857,6 @@ type ViewBuilders() =
                                            ?detailColor: Xamarin.Forms.Color,
                                            ?command: unit -> unit,
                                            ?canExecute: bool,
-                                           ?commandParameter: System.Object,
                                            ?height: double,
                                            ?isEnabled: bool,
                                            ?classId: string,
@@ -10920,7 +10872,6 @@ type ViewBuilders() =
                                ?detailColor=detailColor,
                                ?command=command,
                                ?canExecute=canExecute,
-                               ?commandParameter=commandParameter,
                                ?height=height,
                                ?isEnabled=isEnabled,
                                ?classId=classId,
@@ -10937,7 +10888,6 @@ type ViewBuilders() =
                                           ?priority: int,
                                           ?text: string,
                                           ?command: unit -> unit,
-                                          ?commandParameter: System.Object,
                                           ?icon: string,
                                           ?accelerator: string,
                                           ?classId: string,
@@ -10949,7 +10899,7 @@ type ViewBuilders() =
         let attribCount = match order with Some _ -> attribCount + 1 | None -> attribCount
         let attribCount = match priority with Some _ -> attribCount + 1 | None -> attribCount
 
-        let attribBuilder = ViewBuilders.BuildMenuItem(attribCount, ?text=text, ?command=command, ?commandParameter=commandParameter, ?icon=icon, ?accelerator=accelerator, ?classId=classId, ?styleId=styleId, ?automationId=automationId, ?created=created, ?ref=ref)
+        let attribBuilder = ViewBuilders.BuildMenuItem(attribCount, ?text=text, ?command=command, ?icon=icon, ?accelerator=accelerator, ?classId=classId, ?styleId=styleId, ?automationId=automationId, ?created=created, ?ref=ref)
         match order with None -> () | Some v -> attribBuilder.Add(ViewAttributes.OrderAttribKey, (v)) 
         match priority with None -> () | Some v -> attribBuilder.Add(ViewAttributes.PriorityAttribKey, (v)) 
         attribBuilder
@@ -10998,7 +10948,6 @@ type ViewBuilders() =
                                               ?priority: int,
                                               ?text: string,
                                               ?command: unit -> unit,
-                                              ?commandParameter: System.Object,
                                               ?icon: string,
                                               ?accelerator: string,
                                               ?classId: string,
@@ -11012,7 +10961,6 @@ type ViewBuilders() =
                                ?priority=priority,
                                ?text=text,
                                ?command=command,
-                               ?commandParameter=commandParameter,
                                ?icon=icon,
                                ?accelerator=accelerator,
                                ?classId=classId,
@@ -11032,7 +10980,6 @@ type ViewBuilders() =
                                         ?detailColor: Xamarin.Forms.Color,
                                         ?command: unit -> unit,
                                         ?canExecute: bool,
-                                        ?commandParameter: System.Object,
                                         ?height: double,
                                         ?isEnabled: bool,
                                         ?classId: string,
@@ -11043,7 +10990,7 @@ type ViewBuilders() =
 
         let attribCount = match imageSource with Some _ -> attribCount + 1 | None -> attribCount
 
-        let attribBuilder = ViewBuilders.BuildTextCell(attribCount, ?text=text, ?detail=detail, ?textColor=textColor, ?detailColor=detailColor, ?command=command, ?canExecute=canExecute, ?commandParameter=commandParameter, ?height=height, ?isEnabled=isEnabled, ?classId=classId, ?styleId=styleId, ?automationId=automationId, ?created=created, ?ref=ref)
+        let attribBuilder = ViewBuilders.BuildTextCell(attribCount, ?text=text, ?detail=detail, ?textColor=textColor, ?detailColor=detailColor, ?command=command, ?canExecute=canExecute, ?height=height, ?isEnabled=isEnabled, ?classId=classId, ?styleId=styleId, ?automationId=automationId, ?created=created, ?ref=ref)
         match imageSource with None -> () | Some v -> attribBuilder.Add(ViewAttributes.ImageSourceAttribKey, (v)) 
         attribBuilder
 
@@ -11083,7 +11030,6 @@ type ViewBuilders() =
                                             ?detailColor: Xamarin.Forms.Color,
                                             ?command: unit -> unit,
                                             ?canExecute: bool,
-                                            ?commandParameter: System.Object,
                                             ?height: double,
                                             ?isEnabled: bool,
                                             ?classId: string,
@@ -11100,7 +11046,6 @@ type ViewBuilders() =
                                ?detailColor=detailColor,
                                ?command=command,
                                ?canExecute=canExecute,
-                               ?commandParameter=commandParameter,
                                ?height=height,
                                ?isEnabled=isEnabled,
                                ?classId=classId,
@@ -12312,8 +12257,6 @@ type ButtonViewer(element: ViewElement) =
     member this.BorderColor = element.GetAttributeKeyed(ViewAttributes.BorderColorAttribKey)
     /// Get the value of the BorderWidth property
     member this.BorderWidth = element.GetAttributeKeyed(ViewAttributes.BorderWidthAttribKey)
-    /// Get the value of the CommandParameter property
-    member this.CommandParameter = element.GetAttributeKeyed(ViewAttributes.CommandParameterAttribKey)
     /// Get the value of the ContentLayout property
     member this.ContentLayout = element.GetAttributeKeyed(ViewAttributes.ContentLayoutAttribKey)
     /// Get the value of the CornerRadius property
@@ -12836,8 +12779,6 @@ type MenuItemViewer(element: ViewElement) =
     member this.Text = element.GetAttributeKeyed(ViewAttributes.TextAttribKey)
     /// Get the value of the Command property
     member this.Command = element.GetAttributeKeyed(ViewAttributes.CommandAttribKey)
-    /// Get the value of the CommandParameter property
-    member this.CommandParameter = element.GetAttributeKeyed(ViewAttributes.CommandParameterAttribKey)
     /// Get the value of the Icon property
     member this.Icon = element.GetAttributeKeyed(ViewAttributes.IconAttribKey)
     /// Get the value of the Accelerator property
@@ -12859,8 +12800,6 @@ type TextCellViewer(element: ViewElement) =
     member this.Command = element.GetAttributeKeyed(ViewAttributes.TextCellCommandAttribKey)
     /// Get the value of the CanExecute property
     member this.CanExecute = element.GetAttributeKeyed(ViewAttributes.TextCellCanExecuteAttribKey)
-    /// Get the value of the CommandParameter property
-    member this.CommandParameter = element.GetAttributeKeyed(ViewAttributes.CommandParameterAttribKey)
 
 /// Viewer that allows to read the properties of a ViewElement representing a ToolbarItem
 type ToolbarItemViewer(element: ViewElement) =
@@ -13795,7 +13734,6 @@ type View() =
                                 ?canExecute: bool,
                                 ?borderColor: Xamarin.Forms.Color,
                                 ?borderWidth: double,
-                                ?commandParameter: System.Object,
                                 ?contentLayout: Xamarin.Forms.Button.ButtonContentLayout,
                                 ?cornerRadius: int,
                                 ?fontFamily: string,
@@ -13850,7 +13788,6 @@ type View() =
                                ?canExecute=canExecute,
                                ?borderColor=borderColor,
                                ?borderWidth=borderWidth,
-                               ?commandParameter=commandParameter,
                                ?contentLayout=contentLayout,
                                ?cornerRadius=cornerRadius,
                                ?fontFamily=fontFamily,
@@ -16720,7 +16657,6 @@ type View() =
     /// Describes a MenuItem in the view
     static member inline MenuItem(?text: string,
                                   ?command: unit -> unit,
-                                  ?commandParameter: System.Object,
                                   ?icon: string,
                                   ?accelerator: string,
                                   ?classId: string,
@@ -16731,7 +16667,6 @@ type View() =
 
         ViewBuilders.ConstructMenuItem(?text=text,
                                ?command=command,
-                               ?commandParameter=commandParameter,
                                ?icon=icon,
                                ?accelerator=accelerator,
                                ?classId=classId,
@@ -16747,7 +16682,6 @@ type View() =
                                   ?detailColor: Xamarin.Forms.Color,
                                   ?command: unit -> unit,
                                   ?canExecute: bool,
-                                  ?commandParameter: System.Object,
                                   ?height: double,
                                   ?isEnabled: bool,
                                   ?classId: string,
@@ -16762,7 +16696,6 @@ type View() =
                                ?detailColor=detailColor,
                                ?command=command,
                                ?canExecute=canExecute,
-                               ?commandParameter=commandParameter,
                                ?height=height,
                                ?isEnabled=isEnabled,
                                ?classId=classId,
@@ -16776,7 +16709,6 @@ type View() =
                                      ?priority: int,
                                      ?text: string,
                                      ?command: unit -> unit,
-                                     ?commandParameter: System.Object,
                                      ?icon: string,
                                      ?accelerator: string,
                                      ?classId: string,
@@ -16789,7 +16721,6 @@ type View() =
                                ?priority=priority,
                                ?text=text,
                                ?command=command,
-                               ?commandParameter=commandParameter,
                                ?icon=icon,
                                ?accelerator=accelerator,
                                ?classId=classId,
@@ -16806,7 +16737,6 @@ type View() =
                                    ?detailColor: Xamarin.Forms.Color,
                                    ?command: unit -> unit,
                                    ?canExecute: bool,
-                                   ?commandParameter: System.Object,
                                    ?height: double,
                                    ?isEnabled: bool,
                                    ?classId: string,
@@ -16822,7 +16752,6 @@ type View() =
                                ?detailColor=detailColor,
                                ?command=command,
                                ?canExecute=canExecute,
-                               ?commandParameter=commandParameter,
                                ?height=height,
                                ?isEnabled=isEnabled,
                                ?classId=classId,
@@ -17327,9 +17256,6 @@ module ViewElementExtensions =
         /// Adjusts the BorderWidth property in the visual element
         member x.BorderWidth(value: double) = x.WithAttribute(ViewAttributes.BorderWidthAttribKey, (value))
 
-        /// Adjusts the CommandParameter property in the visual element
-        member x.CommandParameter(value: System.Object) = x.WithAttribute(ViewAttributes.CommandParameterAttribKey, (value))
-
         /// Adjusts the ContentLayout property in the visual element
         member x.ContentLayout(value: Xamarin.Forms.Button.ButtonContentLayout) = x.WithAttribute(ViewAttributes.ContentLayoutAttribKey, (value))
 
@@ -17825,39 +17751,39 @@ module ViewElementExtensions =
                       ?scrolled: Xamarin.Forms.ScrolledEventArgs -> unit, ?cancelButtonColor: Xamarin.Forms.Color, ?fontFamily: string, ?fontAttributes: Xamarin.Forms.FontAttributes, ?fontSize: obj, 
                       ?horizontalTextAlignment: Xamarin.Forms.TextAlignment, ?placeholder: string, ?placeholderColor: Xamarin.Forms.Color, ?searchBarCommand: string -> unit, ?searchBarCanExecute: bool, 
                       ?text: string, ?textColor: Xamarin.Forms.Color, ?searchBarTextChanged: Xamarin.Forms.TextChangedEventArgs -> unit, ?buttonCommand: unit -> unit, ?buttonCanExecute: bool, 
-                      ?borderColor: Xamarin.Forms.Color, ?borderWidth: double, ?commandParameter: System.Object, ?contentLayout: Xamarin.Forms.Button.ButtonContentLayout, ?buttonCornerRadius: int, 
-                      ?buttonImageSource: string, ?minimumMaximum: float * float, ?value: double, ?valueChanged: Xamarin.Forms.ValueChangedEventArgs -> unit, ?increment: double, 
-                      ?isToggled: bool, ?toggled: Xamarin.Forms.ToggledEventArgs -> unit, ?onColor: Xamarin.Forms.Color, ?height: double, ?on: bool, 
-                      ?onChanged: Xamarin.Forms.ToggledEventArgs -> unit, ?intent: Xamarin.Forms.TableIntent, ?hasUnevenRows: bool, ?rowHeight: int, ?tableRoot: (string * ViewElement list) list, 
-                      ?rowDefinitionHeight: obj, ?columnDefinitionWidth: obj, ?gridRowDefinitions: obj list, ?gridColumnDefinitions: obj list, ?rowSpacing: double, 
-                      ?columnSpacing: double, ?children: ViewElement list, ?gridRow: int, ?gridRowSpan: int, ?gridColumn: int, 
-                      ?gridColumnSpan: int, ?layoutBounds: Xamarin.Forms.Rectangle, ?layoutFlags: Xamarin.Forms.AbsoluteLayoutFlags, ?boundsConstraint: Xamarin.Forms.BoundsConstraint, ?heightConstraint: Xamarin.Forms.Constraint, 
-                      ?widthConstraint: Xamarin.Forms.Constraint, ?xConstraint: Xamarin.Forms.Constraint, ?yConstraint: Xamarin.Forms.Constraint, ?alignContent: Xamarin.Forms.FlexAlignContent, ?alignItems: Xamarin.Forms.FlexAlignItems, 
-                      ?flexLayoutDirection: Xamarin.Forms.FlexDirection, ?position: Xamarin.Forms.FlexPosition, ?wrap: Xamarin.Forms.FlexWrap, ?justifyContent: Xamarin.Forms.FlexJustify, ?flexAlignSelf: Xamarin.Forms.FlexAlignSelf, 
-                      ?flexOrder: int, ?flexBasis: Xamarin.Forms.FlexBasis, ?flexGrow: double, ?flexShrink: double, ?date: System.DateTime, 
-                      ?format: string, ?minimumDate: System.DateTime, ?maximumDate: System.DateTime, ?dateSelected: Xamarin.Forms.DateChangedEventArgs -> unit, ?pickerItemsSource: seq<'T>, 
-                      ?selectedIndex: int, ?title: string, ?selectedIndexChanged: (int * 'T option) -> unit, ?frameCornerRadius: double, ?hasShadow: bool, 
-                      ?imageSource: obj, ?aspect: Xamarin.Forms.Aspect, ?isOpaque: bool, ?imageButtonCommand: unit -> unit, ?imageButtonCornerRadius: int, 
-                      ?clicked: System.EventArgs -> unit, ?pressed: System.EventArgs -> unit, ?released: System.EventArgs -> unit, ?keyboard: Xamarin.Forms.Keyboard, ?editorCompleted: string -> unit, 
-                      ?textChanged: Xamarin.Forms.TextChangedEventArgs -> unit, ?autoSize: Xamarin.Forms.EditorAutoSizeOption, ?isPassword: bool, ?entryCompleted: string -> unit, ?isTextPredictionEnabled: bool, 
-                      ?returnType: Xamarin.Forms.ReturnType, ?returnCommand: unit -> unit, ?cursorPosition: int, ?selectionLength: int, ?label: string, 
-                      ?entryCellTextChanged: Xamarin.Forms.TextChangedEventArgs -> unit, ?verticalTextAlignment: Xamarin.Forms.TextAlignment, ?formattedText: ViewElement, ?lineBreakMode: Xamarin.Forms.LineBreakMode, ?lineHeight: double, 
-                      ?maxLines: int, ?textDecorations: Xamarin.Forms.TextDecorations, ?stackOrientation: Xamarin.Forms.StackOrientation, ?spacing: double, ?foregroundColor: Xamarin.Forms.Color, 
-                      ?propertyChanged: System.ComponentModel.PropertyChangedEventArgs -> unit, ?spans: ViewElement[], ?time: System.TimeSpan, ?webSource: Xamarin.Forms.WebViewSource, ?reload: bool, 
-                      ?navigated: Xamarin.Forms.WebNavigatedEventArgs -> unit, ?navigating: Xamarin.Forms.WebNavigatingEventArgs -> unit, ?reloadRequested: System.EventArgs -> unit, ?backgroundImage: string, ?icon: string, 
-                      ?isBusy: bool, ?toolbarItems: ViewElement list, ?useSafeArea: bool, ?page_Appearing: unit -> unit, ?page_Disappearing: unit -> unit, 
-                      ?page_LayoutChanged: unit -> unit, ?carouselPage_CurrentPage: int, ?carouselPage_CurrentPageChanged: int option -> unit, ?pages: ViewElement list, ?backButtonTitle: string, 
-                      ?hasBackButton: bool, ?hasNavigationBar: bool, ?titleIcon: string, ?titleView: ViewElement, ?barBackgroundColor: Xamarin.Forms.Color, 
-                      ?barTextColor: Xamarin.Forms.Color, ?popped: Xamarin.Forms.NavigationEventArgs -> unit, ?poppedToRoot: Xamarin.Forms.NavigationEventArgs -> unit, ?pushed: Xamarin.Forms.NavigationEventArgs -> unit, ?tabbedPage_CurrentPage: int, 
-                      ?tabbedPage_CurrentPageChanged: int option -> unit, ?onSizeAllocatedCallback: (double * double) -> unit, ?master: ViewElement, ?detail: ViewElement, ?isGestureEnabled: bool, 
-                      ?isPresented: bool, ?masterBehavior: Xamarin.Forms.MasterBehavior, ?isPresentedChanged: bool -> unit, ?accelerator: string, ?textDetail: string, 
-                      ?textDetailColor: Xamarin.Forms.Color, ?textCellCommand: unit -> unit, ?textCellCanExecute: bool, ?order: Xamarin.Forms.ToolbarItemOrder, ?priority: int, 
-                      ?view: ViewElement, ?listViewItems: seq<ViewElement>, ?footer: System.Object, ?header: System.Object, ?headerTemplate: Xamarin.Forms.DataTemplate, 
-                      ?isGroupingEnabled: bool, ?isPullToRefreshEnabled: bool, ?isRefreshing: bool, ?refreshCommand: unit -> unit, ?listView_SelectedItem: int option, 
-                      ?listView_SeparatorVisibility: Xamarin.Forms.SeparatorVisibility, ?listView_SeparatorColor: Xamarin.Forms.Color, ?listView_ItemAppearing: int -> unit, ?listView_ItemDisappearing: int -> unit, ?listView_ItemSelected: int option -> unit, 
-                      ?listView_ItemTapped: int -> unit, ?listView_Refreshing: unit -> unit, ?selectionMode: Xamarin.Forms.ListViewSelectionMode, ?listViewGrouped_ItemsSource: (string * ViewElement * ViewElement list) list, ?listViewGrouped_ShowJumpList: bool, 
-                      ?listViewGrouped_SelectedItem: (int * int) option, ?separatorVisibility: Xamarin.Forms.SeparatorVisibility, ?separatorColor: Xamarin.Forms.Color, ?listViewGrouped_ItemAppearing: int * int option -> unit, ?listViewGrouped_ItemDisappearing: int * int option -> unit, 
-                      ?listViewGrouped_ItemSelected: (int * int) option -> unit, ?listViewGrouped_ItemTapped: int * int -> unit, ?refreshing: unit -> unit) =
+                      ?borderColor: Xamarin.Forms.Color, ?borderWidth: double, ?contentLayout: Xamarin.Forms.Button.ButtonContentLayout, ?buttonCornerRadius: int, ?buttonImageSource: string, 
+                      ?minimumMaximum: float * float, ?value: double, ?valueChanged: Xamarin.Forms.ValueChangedEventArgs -> unit, ?increment: double, ?isToggled: bool, 
+                      ?toggled: Xamarin.Forms.ToggledEventArgs -> unit, ?onColor: Xamarin.Forms.Color, ?height: double, ?on: bool, ?onChanged: Xamarin.Forms.ToggledEventArgs -> unit, 
+                      ?intent: Xamarin.Forms.TableIntent, ?hasUnevenRows: bool, ?rowHeight: int, ?tableRoot: (string * ViewElement list) list, ?rowDefinitionHeight: obj, 
+                      ?columnDefinitionWidth: obj, ?gridRowDefinitions: obj list, ?gridColumnDefinitions: obj list, ?rowSpacing: double, ?columnSpacing: double, 
+                      ?children: ViewElement list, ?gridRow: int, ?gridRowSpan: int, ?gridColumn: int, ?gridColumnSpan: int, 
+                      ?layoutBounds: Xamarin.Forms.Rectangle, ?layoutFlags: Xamarin.Forms.AbsoluteLayoutFlags, ?boundsConstraint: Xamarin.Forms.BoundsConstraint, ?heightConstraint: Xamarin.Forms.Constraint, ?widthConstraint: Xamarin.Forms.Constraint, 
+                      ?xConstraint: Xamarin.Forms.Constraint, ?yConstraint: Xamarin.Forms.Constraint, ?alignContent: Xamarin.Forms.FlexAlignContent, ?alignItems: Xamarin.Forms.FlexAlignItems, ?flexLayoutDirection: Xamarin.Forms.FlexDirection, 
+                      ?position: Xamarin.Forms.FlexPosition, ?wrap: Xamarin.Forms.FlexWrap, ?justifyContent: Xamarin.Forms.FlexJustify, ?flexAlignSelf: Xamarin.Forms.FlexAlignSelf, ?flexOrder: int, 
+                      ?flexBasis: Xamarin.Forms.FlexBasis, ?flexGrow: double, ?flexShrink: double, ?date: System.DateTime, ?format: string, 
+                      ?minimumDate: System.DateTime, ?maximumDate: System.DateTime, ?dateSelected: Xamarin.Forms.DateChangedEventArgs -> unit, ?pickerItemsSource: seq<'T>, ?selectedIndex: int, 
+                      ?title: string, ?selectedIndexChanged: (int * 'T option) -> unit, ?frameCornerRadius: double, ?hasShadow: bool, ?imageSource: obj, 
+                      ?aspect: Xamarin.Forms.Aspect, ?isOpaque: bool, ?imageButtonCommand: unit -> unit, ?imageButtonCornerRadius: int, ?clicked: System.EventArgs -> unit, 
+                      ?pressed: System.EventArgs -> unit, ?released: System.EventArgs -> unit, ?keyboard: Xamarin.Forms.Keyboard, ?editorCompleted: string -> unit, ?textChanged: Xamarin.Forms.TextChangedEventArgs -> unit, 
+                      ?autoSize: Xamarin.Forms.EditorAutoSizeOption, ?isPassword: bool, ?entryCompleted: string -> unit, ?isTextPredictionEnabled: bool, ?returnType: Xamarin.Forms.ReturnType, 
+                      ?returnCommand: unit -> unit, ?cursorPosition: int, ?selectionLength: int, ?label: string, ?entryCellTextChanged: Xamarin.Forms.TextChangedEventArgs -> unit, 
+                      ?verticalTextAlignment: Xamarin.Forms.TextAlignment, ?formattedText: ViewElement, ?lineBreakMode: Xamarin.Forms.LineBreakMode, ?lineHeight: double, ?maxLines: int, 
+                      ?textDecorations: Xamarin.Forms.TextDecorations, ?stackOrientation: Xamarin.Forms.StackOrientation, ?spacing: double, ?foregroundColor: Xamarin.Forms.Color, ?propertyChanged: System.ComponentModel.PropertyChangedEventArgs -> unit, 
+                      ?spans: ViewElement[], ?time: System.TimeSpan, ?webSource: Xamarin.Forms.WebViewSource, ?reload: bool, ?navigated: Xamarin.Forms.WebNavigatedEventArgs -> unit, 
+                      ?navigating: Xamarin.Forms.WebNavigatingEventArgs -> unit, ?reloadRequested: System.EventArgs -> unit, ?backgroundImage: string, ?icon: string, ?isBusy: bool, 
+                      ?toolbarItems: ViewElement list, ?useSafeArea: bool, ?page_Appearing: unit -> unit, ?page_Disappearing: unit -> unit, ?page_LayoutChanged: unit -> unit, 
+                      ?carouselPage_CurrentPage: int, ?carouselPage_CurrentPageChanged: int option -> unit, ?pages: ViewElement list, ?backButtonTitle: string, ?hasBackButton: bool, 
+                      ?hasNavigationBar: bool, ?titleIcon: string, ?titleView: ViewElement, ?barBackgroundColor: Xamarin.Forms.Color, ?barTextColor: Xamarin.Forms.Color, 
+                      ?popped: Xamarin.Forms.NavigationEventArgs -> unit, ?poppedToRoot: Xamarin.Forms.NavigationEventArgs -> unit, ?pushed: Xamarin.Forms.NavigationEventArgs -> unit, ?tabbedPage_CurrentPage: int, ?tabbedPage_CurrentPageChanged: int option -> unit, 
+                      ?onSizeAllocatedCallback: (double * double) -> unit, ?master: ViewElement, ?detail: ViewElement, ?isGestureEnabled: bool, ?isPresented: bool, 
+                      ?masterBehavior: Xamarin.Forms.MasterBehavior, ?isPresentedChanged: bool -> unit, ?accelerator: string, ?textDetail: string, ?textDetailColor: Xamarin.Forms.Color, 
+                      ?textCellCommand: unit -> unit, ?textCellCanExecute: bool, ?order: Xamarin.Forms.ToolbarItemOrder, ?priority: int, ?view: ViewElement, 
+                      ?listViewItems: seq<ViewElement>, ?footer: System.Object, ?header: System.Object, ?headerTemplate: Xamarin.Forms.DataTemplate, ?isGroupingEnabled: bool, 
+                      ?isPullToRefreshEnabled: bool, ?isRefreshing: bool, ?refreshCommand: unit -> unit, ?listView_SelectedItem: int option, ?listView_SeparatorVisibility: Xamarin.Forms.SeparatorVisibility, 
+                      ?listView_SeparatorColor: Xamarin.Forms.Color, ?listView_ItemAppearing: int -> unit, ?listView_ItemDisappearing: int -> unit, ?listView_ItemSelected: int option -> unit, ?listView_ItemTapped: int -> unit, 
+                      ?listView_Refreshing: unit -> unit, ?selectionMode: Xamarin.Forms.ListViewSelectionMode, ?listViewGrouped_ItemsSource: (string * ViewElement * ViewElement list) list, ?listViewGrouped_ShowJumpList: bool, ?listViewGrouped_SelectedItem: (int * int) option, 
+                      ?separatorVisibility: Xamarin.Forms.SeparatorVisibility, ?separatorColor: Xamarin.Forms.Color, ?listViewGrouped_ItemAppearing: int * int option -> unit, ?listViewGrouped_ItemDisappearing: int * int option -> unit, ?listViewGrouped_ItemSelected: (int * int) option -> unit, 
+                      ?listViewGrouped_ItemTapped: int * int -> unit, ?refreshing: unit -> unit) =
             let x = match classId with None -> x | Some opt -> x.ClassId(opt)
             let x = match styleId with None -> x | Some opt -> x.StyleId(opt)
             let x = match automationId with None -> x | Some opt -> x.AutomationId(opt)
@@ -17935,7 +17861,6 @@ module ViewElementExtensions =
             let x = match buttonCanExecute with None -> x | Some opt -> x.ButtonCanExecute(opt)
             let x = match borderColor with None -> x | Some opt -> x.BorderColor(opt)
             let x = match borderWidth with None -> x | Some opt -> x.BorderWidth(opt)
-            let x = match commandParameter with None -> x | Some opt -> x.CommandParameter(opt)
             let x = match contentLayout with None -> x | Some opt -> x.ContentLayout(opt)
             let x = match buttonCornerRadius with None -> x | Some opt -> x.ButtonCornerRadius(opt)
             let x = match buttonImageSource with None -> x | Some opt -> x.ButtonImageSource(opt)
@@ -18252,8 +18177,6 @@ module ViewElementExtensions =
     let borderColor (value: Xamarin.Forms.Color) (x: ViewElement) = x.BorderColor(value)
     /// Adjusts the BorderWidth property in the visual element
     let borderWidth (value: double) (x: ViewElement) = x.BorderWidth(value)
-    /// Adjusts the CommandParameter property in the visual element
-    let commandParameter (value: System.Object) (x: ViewElement) = x.CommandParameter(value)
     /// Adjusts the ContentLayout property in the visual element
     let contentLayout (value: Xamarin.Forms.Button.ButtonContentLayout) (x: ViewElement) = x.ContentLayout(value)
     /// Adjusts the ButtonCornerRadius property in the visual element

--- a/tools/Generator/Xamarin.Forms.Core.json
+++ b/tools/Generator/Xamarin.Forms.Core.json
@@ -489,10 +489,6 @@
           "defaultValue": "-1.0"
         },
         {
-          "name": "CommandParameter",
-          "defaultValue": "null"
-        },
-        {
           "name": "ContentLayout",
           "defaultValue": "null"
         },
@@ -1705,10 +1701,6 @@
           "convToModel": "makeCommand"
         },
         {
-          "name": "CommandParameter",
-          "defaultValue": "null"
-        },
-        {
           "name": "Icon",
           "inputType": "string",
           "modelType": "string",
@@ -1759,10 +1751,6 @@
           "inputType": "bool",
           "modelType": "bool",
           "updateCode": "updateCommand prevTextCellCommandOpt currTextCellCommandOpt (fun _target -> ()) (fun (target: Xamarin.Forms.TextCell) cmd -> target.Command <- cmd)"
-        },
-        {
-          "name": "CommandParameter",
-          "defaultValue": "null"
         }
       ]
     },


### PR DESCRIPTION
Fix #369

As pointed by the issue, `CommandParameter` is only necessary in a MVVM app.
In MVU apps, it is completely useless because any parameter needed by the command will be provided in other ways.