### PR TITLE
Downgrade to Oxyplot 1.0.0

### DIFF
--- a/.nuget/NuGet.config
+++ b/.nuget/NuGet.config
@@ -2,7 +2,6 @@
 <configuration>
     <packageSources>
        <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
-       <add key="myget.org" value="https://www.myget.org/F/oxyplot"  />
    </packageSources>
 </configuration>
 

--- a/Packages.targets
+++ b/Packages.targets
@@ -8,8 +8,7 @@
         <PackageReference Update="Newtonsoft.Json" Version="11.0.2" />
         <PackageReference Update="FSharp.Compiler.Service" Version="25.0.1" />
         <PackageReference Update="Dotnet.ProjInfo" Version="0.9.0" />
-        <PackageReference Update="OxyPlot.Core" Version="2.0.0-unstable0956" />
-        <PackageReference Update="OxyPlot.Xamarin.Forms" Version="1.1.0-unstable0013" />
+        <PackageReference Update="OxyPlot.Xamarin.Forms" Version="1.0.0" />
         <PackageReference Update="SkiaSharp" Version="1.60.3" />
         <PackageReference Update="SkiaSharp.Views.Forms" Version="1.60.3" />
         <PackageReference Update="Mono.Cecil" Version="0.10.0" />
@@ -27,7 +26,6 @@
         <RestoreSources>
             $(RestoreSources);
             https://api.nuget.org/v3/index.json;
-            https://www.myget.org/F/oxyplot;
         </RestoreSources>
     </PropertyGroup>
 </Project>

--- a/extensions/OxyPlot/Fabulous.OxyPlot.fsproj
+++ b/extensions/OxyPlot/Fabulous.OxyPlot.fsproj
@@ -15,7 +15,6 @@
     <ItemGroup>
         <PackageReference Include="FSharp.Core" />
         <PackageReference Include="Xamarin.Forms" />
-        <PackageReference Include="OxyPlot.Core" />
         <PackageReference Include="OxyPlot.Xamarin.Forms" />
     </ItemGroup>
     <ItemGroup>

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -2,7 +2,6 @@
 group neutral
   framework: netstandard2.0
   source https://api.nuget.org/v3/index.json
-  source https://www.myget.org/F/oxyplot
   github fsprojects/FSharp.Compiler.PortaCode:master src/ProjectCracker.fs
   github fsprojects/FSharp.Compiler.PortaCode:master src/CodeModel.fs
   github fsprojects/FSharp.Compiler.PortaCode:master src/Interpreter.fs
@@ -15,8 +14,7 @@ group neutral
   nuget Xamarin.Forms.Maps 3.4.0.1009999
   nuget SkiaSharp
   nuget SkiaSharp.Views.Forms
-  nuget OxyPlot.Core 2.0.0-unstable0956 # version matching last updated version of OxyPlot.Xamarin.Forms
-  nuget OxyPlot.Xamarin.Forms 1.1.0-unstable0013 # last version seen on myget
+  nuget OxyPlot.Xamarin.Forms 1.0.0
   nuget Newtonsoft.Json 11.0.2
 
 # Dependencies used when compiling and running Android samples. We can normally use the latest FSharp.Core and 

--- a/paket.lock
+++ b/paket.lock
@@ -545,7 +545,10 @@ NUGET
   remote: https://api.nuget.org/v3/index.json
     FSharp.Core (4.5.2)
     Newtonsoft.Json (11.0.2)
-    OxyPlot.Core (2.0.0-unstable0956)
+    OxyPlot.Core (1.0)
+    OxyPlot.Xamarin.Forms (1.0)
+      OxyPlot.Core (>= 1.0)
+      Xamarin.Forms (>= 2.3.3.180)
     SkiaSharp (1.68)
     SkiaSharp.Views.Forms (1.68)
       SkiaSharp (>= 1.68)
@@ -553,10 +556,6 @@ NUGET
     Xamarin.Forms (3.4.0.1009999)
     Xamarin.Forms.Maps (3.4.0.1009999)
       Xamarin.Forms (>= 3.4.0.1009999)
-  remote: https://www.myget.org/F/oxyplot
-    OxyPlot.Xamarin.Forms (1.1.0-unstable0013)
-      OxyPlot.Core (>= 2.0.0-unstable0956)
-      Xamarin.Forms (>= 2.3.3.180)
 GITHUB
   remote: fsprojects/FSharp.Compiler.PortaCode
     src/CodeModel.fs (0c6686bcc518246d879bb3d0e3cd4cdbbc72d5ad)


### PR DESCRIPTION
Fix #370

As pointed by #370, Fabulous relies on a non stable version of Oxyplot only available on myget.org

This might confuse people as the version used in not available on nuget.org (though the previous version is)
Also it forces people to add a new source for their NuGet packages, which is not really common to do.

So to avoid these issues and as there doesn't seem to be any benefit from using the latest unstable version (more than 2 years old already), I downgraded to the latest stable version available on nuget.org.