### PR TITLE
Fixes typo in CmdMsg docs

### DIFF
--- a/docs/update.md
+++ b/docs/update.md
@@ -137,7 +137,7 @@ type Msg =
     | TimerToggled of bool
 
 type CmdMsg =
-    | TickTimer
+    | TimerTick
 
 let init () =
     { TimerOn = false; Count = 0; Step = 1 }, [] // An empty list means no action


### PR DESCRIPTION
Hey there! I was reading through the new `CmdMsg` docs, and I noticed that the types didn't line up between what was defined in the DU (`TickTimer`) and what was being returned from `update` (`TimerTick`). This changes the DU to define `TimerTick`.