### PR TITLE
Fixed crash when using ShellContent

### DIFF
--- a/src/Fabulous.Core/ViewConverters.fs
+++ b/src/Fabulous.Core/ViewConverters.fs
@@ -761,40 +761,32 @@ module Converters =
         | _, ValueSome newVal -> Xamarin.Forms.MenuItem.SetAccelerator(target, makeAccelerator newVal)
 
     /// Update the items of a Shell, given previous and current view elements
-    let internal updateShellItems (prevCollOpt: seq<'T> voption) (collOpt: seq<'T> voption) (target: Xamarin.Forms.Shell) =
+    let internal updateShellItems (prevCollOpt: ViewElement array voption) (collOpt: ViewElement array voption) (target: Xamarin.Forms.Shell) =
         let create (desc: ViewElement) =
             desc.Create() :?> Xamarin.Forms.ShellItem
 
-        let prevArray = ValueOption.map seqToArray prevCollOpt
-        let currArray = ValueOption.map seqToArray collOpt
-        updateCollectionGeneric prevArray currArray target.Items create (fun _ _ _ -> ()) (fun _ _ -> true) updateChild
+        updateCollectionGeneric prevCollOpt collOpt target.Items create (fun _ _ _ -> ()) (fun _ _ -> true) updateChild
         
     /// Update the menu items of a ShellContent, given previous and current view elements
-    let internal updateMenuItemsShellContent (prevCollOpt: seq<'T> voption) (collOpt: seq<'T> voption) (target: Xamarin.Forms.ShellContent) =
+    let internal updateMenuItemsShellContent (prevCollOpt: ViewElement array voption) (collOpt: ViewElement array voption) (target: Xamarin.Forms.ShellContent) =
         let create (desc: ViewElement) =
             desc.Create() :?> Xamarin.Forms.MenuItem
 
-        let prevArray = ValueOption.map seqToArray prevCollOpt
-        let currArray = ValueOption.map seqToArray collOpt
-        updateCollectionGeneric prevArray currArray target.MenuItems create (fun _ _ _ -> ()) (fun _ _ -> true) updateChild
+        updateCollectionGeneric prevCollOpt collOpt target.MenuItems create (fun _ _ _ -> ()) (fun _ _ -> true) updateChild
 
     /// Update the items of a ShellItem, given previous and current view elements
-    let internal updateShellItemItems (prevCollOpt: seq<'T> voption) (collOpt: seq<'T> voption) (target: Xamarin.Forms.ShellItem) =
+    let internal updateShellItemItems (prevCollOpt: ViewElement array voption) (collOpt: ViewElement array voption) (target: Xamarin.Forms.ShellItem) =
         let create (desc: ViewElement) =
             desc.Create() :?> Xamarin.Forms.ShellSection
 
-        let prevArray = ValueOption.map seqToArray prevCollOpt
-        let currArray = ValueOption.map seqToArray collOpt
-        updateCollectionGeneric prevArray currArray target.Items create (fun _ _ _ -> ()) (fun _ _ -> true) updateChild
+        updateCollectionGeneric prevCollOpt collOpt target.Items create (fun _ _ _ -> ()) (fun _ _ -> true) updateChild
 
     /// Update the items of a ShellSection, given previous and current view elements
-    let internal updateShellSectionItems (prevCollOpt: seq<'T> voption) (collOpt: seq<'T> voption) (target: Xamarin.Forms.ShellSection) =
+    let internal updateShellSectionItems (prevCollOpt: ViewElement array voption) (collOpt: ViewElement array voption) (target: Xamarin.Forms.ShellSection) =
         let create (desc: ViewElement) =
             desc.Create() :?> Xamarin.Forms.ShellContent
 
-        let prevArray = ValueOption.map seqToArray prevCollOpt
-        let currArray = ValueOption.map seqToArray collOpt
-        updateCollectionGeneric prevArray currArray target.Items create (fun _ _ _ -> ()) (fun _ _ -> true) updateChild
+        updateCollectionGeneric prevCollOpt collOpt target.Items create (fun _ _ _ -> ()) (fun _ _ -> true) updateChild
 
     /// Update the IsFocusedProperty of a SearchHandler, given previous and current IsFocused
     let internal updateIsFocused prevValue currValue (target: Xamarin.Forms.SearchHandler) =

--- a/tests/Fabulous.Cli.Tests/Fabulous.Cli.Tests.fsproj
+++ b/tests/Fabulous.Cli.Tests/Fabulous.Cli.Tests.fsproj
@@ -14,6 +14,7 @@
         <Compile Include="..\..\paket-files\neutral\fsprojects\FSharp.Compiler.PortaCode\tests\PortaCodeTests.fs" />
         <Compile Include="..\..\src\Fabulous.Cli\fscd.fs" Link="fscd.fs" />
         <Compile Include="Tests.fs" />
+        <Compile Include="Program.fs" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Dotnet.ProjInfo" />

--- a/tests/Fabulous.Cli.Tests/Program.fs
+++ b/tests/Fabulous.Cli.Tests/Program.fs
@@ -1,0 +1,7 @@
+﻿// Copyright 2018 Fabulous contributors. See LICENSE.md for license.
+namespace Fabulous.Cli.Tests
+
+module Program =
+    [<EntryPoint>]
+    let main (argv: string[]) =
+        0

--- a/tools/Generator/Xamarin.Forms.Core.json
+++ b/tools/Generator/Xamarin.Forms.Core.json
@@ -2444,8 +2444,8 @@
         {
           "name": "Items",
           "defaultValue": "null",
-          "inputType": "seq<ViewElement>",
-          "modelType": "seq<ViewElement>",
+          "inputType": "ViewElement list",
+          "modelType": "ViewElement array",
           "updateCode": "updateShellItems"
         },
         {
@@ -2554,14 +2554,18 @@
       "members": [
         {
           "name": "Content",
+          "uniqueName": "ShellContent",
           "defaultValue": "null",
-          "inputType": "ViewElement"
+          "inputType": "ViewElement",
+          "modelType": "ViewElement",
+          "updateCode": "(fun prev (curr: ViewElement voption) (target: Xamarin.Forms.ShellContent) -> target.Content <- match curr with ValueSome c -> c.Create() | ValueNone -> null)"
         },
         {
           "name": "MenuItems",
           "defaultValue": "null",
-          "inputType": "seq<ViewElement>",
-          "modelType": "seq<ViewElement>",
+          "inputType": "ViewElement list",
+          "modelType": "ViewElement array",
+          "convToModel": "Array.ofList",
           "updateCode": "updateMenuItemsShellContent"
         }
       ]
@@ -2577,9 +2581,11 @@
         },
         {
           "name": "Items",
+          "uniqueName": "ShellItemItems",
           "defaultValue": "null",
-          "inputType": "seq<ViewElement>",
-          "modelType": "seq<ViewElement>",
+          "inputType": "ViewElement list",
+          "modelType": "ViewElement array",
+          "convToModel": "Array.ofList",
           "updateCode": "updateShellItemItems"
         }
       ]
@@ -2593,9 +2599,11 @@
         },
         {
           "name": "Items",
+          "uniqueName": "ShellSectionItems",
           "defaultValue": "null",
-          "inputType": "seq<ViewElement>",
-          "modelType": "seq<ViewElement>",
+          "inputType": "ViewElement list",
+          "modelType": "ViewElement array",
+          "convToModel": "Array.ofList",
           "updateCode": "updateShellSectionItems"
         }
       ]


### PR DESCRIPTION
Fixes #427

This is the first pass to make Shell usable.
ShellContent was not correctly creating its content (ViewElement).
This is now the case.