### PR TITLE
Add support for implicit converters when using Shell

### DIFF
--- a/src/Fabulous.Core/ViewConverters.fs
+++ b/src/Fabulous.Core/ViewConverters.fs
@@ -763,7 +763,13 @@ module Converters =
     /// Update the items of a Shell, given previous and current view elements
     let internal updateShellItems (prevCollOpt: ViewElement array voption) (collOpt: ViewElement array voption) (target: Xamarin.Forms.Shell) =
         let create (desc: ViewElement) =
-            desc.Create() :?> Xamarin.Forms.ShellItem
+            match desc.Create() with
+            | :? ShellContent as shellContent -> ShellItem.op_Implicit shellContent
+            | :? TemplatedPage as templatedPage -> ShellItem.op_Implicit templatedPage
+            | :? ShellSection as shellSection -> ShellItem.op_Implicit shellSection
+            | :? MenuItem as menuItem -> ShellItem.op_Implicit menuItem
+            | :? ShellItem as shellItem -> shellItem
+            | child -> failwithf "%s is not compatible with the type ShellItem" (child.GetType().Name)
 
         updateCollectionGeneric prevCollOpt collOpt target.Items create (fun _ _ _ -> ()) (fun _ _ -> true) updateChild
         
@@ -777,7 +783,11 @@ module Converters =
     /// Update the items of a ShellItem, given previous and current view elements
     let internal updateShellItemItems (prevCollOpt: ViewElement array voption) (collOpt: ViewElement array voption) (target: Xamarin.Forms.ShellItem) =
         let create (desc: ViewElement) =
-            desc.Create() :?> Xamarin.Forms.ShellSection
+            match desc.Create() with
+            | :? ShellContent as shellContent -> ShellSection.op_Implicit shellContent
+            | :? TemplatedPage as templatedPage -> ShellSection.op_Implicit templatedPage
+            | :? ShellSection as shellSection -> shellSection
+            | child -> failwithf "%s is not compatible with the type ShellSection" (child.GetType().Name)
 
         updateCollectionGeneric prevCollOpt collOpt target.Items create (fun _ _ _ -> ()) (fun _ _ -> true) updateChild
 

--- a/tools/Generator/Xamarin.Forms.Core.json
+++ b/tools/Generator/Xamarin.Forms.Core.json
@@ -2451,6 +2451,10 @@
           "updateCode": "updateShellItems"
         },
         {
+          "name": "CurrentItem",
+          "defaultValue": "null"
+        },
+        {
           "name": "FlyoutBackgroundColor",
           "defaultValue": "Xamarin.Forms.Color.Default"
         },

--- a/tools/Generator/Xamarin.Forms.Core.json
+++ b/tools/Generator/Xamarin.Forms.Core.json
@@ -2443,14 +2443,12 @@
       "members": [
         {
           "name": "Items",
+          "uniqueName": "ShellItems",
           "defaultValue": "null",
           "inputType": "ViewElement list",
           "modelType": "ViewElement array",
+          "convToModel": "Array.ofList",
           "updateCode": "updateShellItems"
-        },
-        {
-          "name": "CurrentItem",
-          "defaultValue": "null"
         },
         {
           "name": "FlyoutBackgroundColor",


### PR DESCRIPTION
Shell heavily relies on implicit operators to convert between the numerous types required to make a good hierarchy.

This PR adds some of them.

I will surely make other PRs when I encounter other cases