### PR TITLE
Fix FormattedString and Span

### DIFF
--- a/samples/AllControls/AllControls/AllControls.fs
+++ b/samples/AllControls/AllControls/AllControls.fs
@@ -622,9 +622,9 @@ module App =
                            items = [ 
                                for i in 0 .. 10 do 
                                    yield View.Label "Ionide"
-                                   yield View.Label(formattedText=View.FormattedString([|View.Span(text="Visual ", backgroundColor=Color.Green); View.Span(text="Studio ", fontSize = 10)|]))
+                                   yield View.Label(formattedText=View.FormattedString([View.Span(text="Visual ", backgroundColor=Color.Green); View.Span(text="Studio ", fontSize = 10)]))
                                    yield View.Label "Emacs"
-                                   yield View.Label(formattedText=View.FormattedString([|View.Span(text="Visual ", fontAttributes=FontAttributes.Bold); View.Span(text="Studio ", fontAttributes=FontAttributes.Italic); View.Span(text="Code", foregroundColor = Color.Blue)|]))
+                                   yield View.Label(formattedText=View.FormattedString([View.Span(text="Visual ", fontAttributes=FontAttributes.Bold); View.Span(text="Studio ", fontAttributes=FontAttributes.Italic); View.Span(text="Code", foregroundColor = Color.Blue)]))
                                    yield View.Label "Rider"], 
                            horizontalOptions=LayoutOptions.CenterAndExpand, 
                            itemSelected=(fun idx -> dispatch (ListViewSelectedItemChanged idx)))

--- a/tools/Generator/Xamarin.Forms.Core.json
+++ b/tools/Generator/Xamarin.Forms.Core.json
@@ -1393,6 +1393,10 @@
       "name": "Xamarin.Forms.Span",
       "members": [
         {
+          "name": "Text",
+          "defaultValue": "null"
+        },
+        {
           "name": "FontFamily",
           "defaultValue": "null"
         },
@@ -1415,8 +1419,8 @@
           "defaultValue": "Xamarin.Forms.Color.Default"
         },
         {
-          "name": "Text",
-          "defaultValue": "null"
+          "name": "TextColor",
+          "defaultValue": "Xamarin.Forms.Color.Default"
         },
         {
           "name": "PropertyChanged",
@@ -1440,8 +1444,9 @@
         {
           "name": "Spans",
           "defaultValue": "null",
-          "inputType": "ViewElement[]",
-          "modelType": "ViewElement[]"
+          "inputType": "ViewElement list",
+          "modelType": "ViewElement array",
+          "convToModel": "Array.ofList"
         }
       ]
     },


### PR DESCRIPTION
FormattedString now accepts a list of ViewElement instead of an array. It's easier to write
```fsharp
View.FormattedString([|
    View.Span()
|])

vs

View.FormattedString([
    View.Span()
])
```

Added the missing property `TextColor` to Span, also changed `Text` to be the first property when writing `View.Span(`.
This allows to implicitly set the text. 

Before it was confusing, as you could write an implicit string that was set to `FontFamily`, which was oddly not crashing, just displaying nothing instead.

```fsharp
View.Span(text="Some text")

vs

View.Span("Some text")
```