### PR TITLE
Add test reporting on the Azure Pipelines summary for a build

### DIFF
--- a/azure-pipelines-full.yml
+++ b/azure-pipelines-full.yml
@@ -24,6 +24,7 @@ jobs:
     inputs:
       testResultsFormat: 'VSTest'
       testResultsFiles: '**/testresults/*.trx'
+      testRunTitle: '$(Agent.JobName)'
 
 - job: macOS
   pool:
@@ -43,6 +44,7 @@ jobs:
     inputs:
       testResultsFormat: 'VSTest'
       testResultsFiles: '**/testresults/*.trx'
+      testRunTitle: '$(Agent.JobName)'
 
 - job: Windows
   pool:
@@ -64,3 +66,4 @@ jobs:
     inputs:
       testResultsFormat: 'VSTest'
       testResultsFiles: '**/testresults/*.trx'
+      testRunTitle: '$(Agent.JobName)'

--- a/azure-pipelines-full.yml
+++ b/azure-pipelines-full.yml
@@ -20,6 +20,10 @@ jobs:
     inputs:
       pathtoPublish: $(Build.ArtifactStagingDirectory)
       artifactName: Linux
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: 'VSTest'
+      testResultsFiles: '**/testresults/*.trx'
 
 - job: macOS
   pool:
@@ -35,6 +39,10 @@ jobs:
     inputs:
       pathtoPublish: $(Build.ArtifactStagingDirectory)
       artifactName: macOS
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: 'VSTest'
+      testResultsFiles: '**/testresults/*.trx'
 
 - job: Windows
   pool:
@@ -52,3 +60,7 @@ jobs:
     inputs:
       pathtoPublish: $(Build.ArtifactStagingDirectory)
       artifactName: Windows
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: 'VSTest'
+      testResultsFiles: '**/testresults/*.trx'

--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -9,9 +9,17 @@ jobs:
     vmImage: 'windows-2019'
   steps:
   - script: .\build.cmd
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: 'VSTest'
+      testResultsFiles: '**/testresults/*.trx'
 
 - job: macOS
   pool:
     vmImage: 'macOS-10.14'
   steps:
   - script: ./build.sh Test
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: 'VSTest'
+      testResultsFiles: '**/testresults/*.trx'

--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -13,6 +13,7 @@ jobs:
     inputs:
       testResultsFormat: 'VSTest'
       testResultsFiles: '**/testresults/*.trx'
+      testRunTitle: '$(Agent.JobName)'
 
 - job: macOS
   pool:
@@ -23,3 +24,4 @@ jobs:
     inputs:
       testResultsFormat: 'VSTest'
       testResultsFiles: '**/testresults/*.trx'
+      testRunTitle: '$(Agent.JobName)'

--- a/build.fsx
+++ b/build.fsx
@@ -163,7 +163,7 @@ Target.create "BuildSamples" (fun _ ->
 Target.create "RunTests" (fun _ ->
     let testProjects = !! "tests/**/*.fsproj"
     for testProject in testProjects do
-        DotNet.test id testProject
+        DotNet.test (fun opt -> { opt with Logger = Some "trx"; ResultsDirectory = Some (buildDir + "/testresults") }) testProject
 )
 
 Target.create "RunSamplesTests" (fun _ ->

--- a/build.fsx
+++ b/build.fsx
@@ -169,7 +169,7 @@ Target.create "RunTests" (fun _ ->
 Target.create "RunSamplesTests" (fun _ ->
     let testProjects = !! "samples/**/*Tests.fsproj"
     for testProject in testProjects do
-        DotNet.test id testProject
+        DotNet.test (fun opt -> { opt with Logger = Some "trx"; ResultsDirectory = Some (buildDir + "/testresults") }) testProject
 )
 
 Target.create "TestTemplatesNuGet" (fun _ ->


### PR DESCRIPTION
When a build is completed by Azure Pipelines, the results of the unit tests are uploaded to make a dashboard.
It's great to easily monitor what's going on when one or more tests crash.

<img width="817" alt="image" src="https://user-images.githubusercontent.com/6429007/58689959-bd865880-8388-11e9-97b8-ce189f50f4e6.png">