### PR TITLE
Set JavaSdkDirectory to workaround issue with the Windows build agent

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -206,7 +206,9 @@ Target.create "TestTemplatesNuGet" (fun _ ->
     for c in ["Debug"; "Release"] do 
         for p in ["Any CPU"; "iPhoneSimulator"] do
             let sln = sprintf "%s/%s.sln" testAppName testAppName
-            let properties = [("RestorePackages", "True"); ("Platform", p); ("Configuration", c); ("PackageSources", sprintf "https://api.nuget.org/v3/index.json;%s" pkgs)]
+            // JavaSdkDirectory is a temporary fix for the Windows 2019 build agent
+            // It's currently failing to build Xamarin.Android : https://github.com/Microsoft/azure-pipelines-image-generation/blob/master/images/win/Vs2019-Server2019-Readme.md
+            let properties = [("RestorePackages", "True"); ("Platform", p); ("Configuration", c); ("PackageSources", sprintf "https://api.nuget.org/v3/index.json;%s" pkgs); ("JavaSdkDirectory", "$(JAVA_HOME_8_X64)")]
             MSBuild.run id "" "Build" properties [sln] |> Trace.logItems ("Build-Output: ")
 )
 

--- a/build.fsx
+++ b/build.fsx
@@ -62,9 +62,16 @@ let getOutputDir basePath proj =
     let folderName = Path.GetFileNameWithoutExtension(proj)
     sprintf "%s/%s/" basePath folderName
 
+// JavaSdkDirectory is a temporary fix for the Windows 2019 build agent
+// It's currently failing to build Xamarin.Android : https://github.com/Microsoft/azure-pipelines-image-generation/blob/master/images/win/Vs2019-Server2019-Readme.md
+let addJDK properties =
+    match Environment.environVarOrDefault "JAVA_HOME_8_X64" "" with
+    | javaHome when not (System.String.IsNullOrWhiteSpace javaHome && Environment.isWindows) -> ("JavaSdkDirectory", javaHome) :: properties
+    | _ -> properties
+
 let msbuild (buildType: BuildType) (definition: ProjectDefinition) =
     let configuration = match buildType with Debug -> "Debug" | Release -> "Release"
-    let properties = [ ("Configuration", configuration) ] 
+    let properties = [ ("Configuration", configuration) ] |> addJDK
 
     for project in definition.Path do
         let outputDir = getOutputDir definition.OutputPath project
@@ -201,13 +208,6 @@ Target.create "TestTemplatesNuGet" (fun _ ->
     if Environment.isWindows then
         restorePackageDotnetCli testAppName (testAppName + ".WPF") "fsproj" pkgs
         restorePackageDotnetCli testAppName (testAppName + ".UWP") "csproj" pkgs
-
-    // JavaSdkDirectory is a temporary fix for the Windows 2019 build agent
-    // It's currently failing to build Xamarin.Android : https://github.com/Microsoft/azure-pipelines-image-generation/blob/master/images/win/Vs2019-Server2019-Readme.md
-    let addJDK properties =
-        match Environment.environVarOrDefault "JAVA_HOME_8_X64" "" with
-        | javaHome when not (System.String.IsNullOrWhiteSpace javaHome && Environment.isWindows) -> ("JavaSdkDirectory", javaHome) :: properties
-        | _ -> properties
 
     // Build for all combinations
     for c in ["Debug"; "Release"] do 


### PR DESCRIPTION
Since yesterday, the Windows build agent on Azure DevOps is failing to compile the Android test project.
It fails to find the Java SDK directory.

Apparently it's a known issue (https://github.com/Microsoft/azure-pipelines-image-generation/blob/master/images/win/Vs2019-Server2019-Readme.md) so I applied the workaround until it is resolved