### PR TITLE
Fix extensions dependencies on NuGet

### DIFF
--- a/Fabulous.XamarinForms/extensions/Maps/Fabulous.XamarinForms.Maps.nuspec
+++ b/Fabulous.XamarinForms/extensions/Maps/Fabulous.XamarinForms.Maps.nuspec
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>Fabulous.XamarinForms.Maps</id>
+    <title>Fabulous.XamarinForms.Maps</title>
+    <version>0.0.1</version>
+    <authors>Fabulous contributors</authors>
+    <description>Fabulous extension for Xamarin.Forms.Maps</description>
+    <projectUrl>https://fsprojects.github.io/Fabulous/</projectUrl>
+    <repository type="git" url="https://github.com/fsprojects/Fabulous" />
+    <license type="expression">Apache-2.0</license>
+    <copyright>Copyright 2018</copyright>
+    <tags>Maps;Xamarin.Forms;Fabulous;F#;Elmish;Elm</tags>
+    <dependencies>
+      <dependency id="Fabulous.XamarinForms" version="0.40.0" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="..\..\..\build_output\Fabulous.XamarinForms\Extensions\Fabulous.XamarinForms.Maps\Fabulous.XamarinForms.Maps.dll" target="lib\netstandard2.0\Fabulous.XamarinForms.Maps.dll" />
+    <file src="..\..\..\build_output\Fabulous.XamarinForms\Extensions\Fabulous.XamarinForms.Maps\Fabulous.XamarinForms.Maps.pdb" target="lib\netstandard2.0\Fabulous.XamarinForms.Maps.pdb" />
+  </files>
+</package>

--- a/Fabulous.XamarinForms/extensions/OxyPlot/Fabulous.XamarinForms.OxyPlot.nuspec
+++ b/Fabulous.XamarinForms/extensions/OxyPlot/Fabulous.XamarinForms.OxyPlot.nuspec
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>Fabulous.XamarinForms.OxyPlot</id>
+    <title>Fabulous.XamarinForms.OxyPlot</title>
+    <version>0.0.1</version>
+    <authors>Fabulous contributors</authors>
+    <description>Fabulous extension for OxyPlot</description>
+    <projectUrl>https://fsprojects.github.io/Fabulous/</projectUrl>
+    <repository type="git" url="https://github.com/fsprojects/Fabulous" />
+    <license type="expression">Apache-2.0</license>
+    <copyright>Copyright 2018</copyright>
+    <tags>OxyPlot;Charting;2D;Xamarin.Forms;Fabulous;F#;Elmish;Elm</tags>
+    <dependencies>
+      <dependency id="Fabulous.XamarinForms" version="0.40.0" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="..\..\..\build_output\Fabulous.XamarinForms\Extensions\Fabulous.XamarinForms.OxyPlot\Fabulous.XamarinForms.OxyPlot.dll" target="lib\netstandard2.0\Fabulous.XamarinForms.OxyPlot.dll" />
+    <file src="..\..\..\build_output\Fabulous.XamarinForms\Extensions\Fabulous.XamarinForms.OxyPlot\Fabulous.XamarinForms.OxyPlot.pdb" target="lib\netstandard2.0\Fabulous.XamarinForms.OxyPlot.pdb" />
+  </files>
+</package>

--- a/Fabulous.XamarinForms/extensions/SkiaSharp/Fabulous.XamarinForms.SkiaSharp.nuspec
+++ b/Fabulous.XamarinForms/extensions/SkiaSharp/Fabulous.XamarinForms.SkiaSharp.nuspec
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>Fabulous.XamarinForms.SkiaSharp</id>
+    <title>Fabulous.XamarinForms.SkiaSharp</title>
+    <version>0.0.1</version>
+    <authors>Fabulous contributors</authors>
+    <description>Fabulous extension for SkiaSharp</description>
+    <projectUrl>https://fsprojects.github.io/Fabulous/</projectUrl>
+    <repository type="git" url="https://github.com/fsprojects/Fabulous" />
+    <license type="expression">Apache-2.0</license>
+    <copyright>Copyright 2018</copyright>
+    <tags>SkiaSharp;Drawing;2D;Xamarin.Forms;Fabulous;F#;Elmish;Elm</tags>
+    <dependencies>
+      <dependency id="Fabulous.XamarinForms" version="0.40.0" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="..\..\..\build_output\Fabulous.XamarinForms\Extensions\Fabulous.XamarinForms.SkiaSharp\Fabulous.XamarinForms.SkiaSharp.dll" target="lib\netstandard2.0\Fabulous.XamarinForms.SkiaSharp.dll" />
+    <file src="..\..\..\build_output\Fabulous.XamarinForms\Extensions\Fabulous.XamarinForms.SkiaSharp\Fabulous.XamarinForms.SkiaSharp.pdb" target="lib\netstandard2.0\Fabulous.XamarinForms.SkiaSharp.pdb" />
+  </files>
+</package>

--- a/Fabulous.XamarinForms/extensions/VideoManager/Fabulous.XamarinForms.VideoManager.nuspec
+++ b/Fabulous.XamarinForms/extensions/VideoManager/Fabulous.XamarinForms.VideoManager.nuspec
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>Fabulous.XamarinForms.VideoManager</id>
+    <title>Fabulous.XamarinForms.VideoManager</title>
+    <version>0.0.1</version>
+    <authors>Fabulous contributors</authors>
+    <description>Fabulous extension for VideoManager</description>
+    <projectUrl>https://fsprojects.github.io/Fabulous/</projectUrl>
+    <repository type="git" url="https://github.com/fsprojects/Fabulous" />
+    <license type="expression">Apache-2.0</license>
+    <copyright>Copyright 2018</copyright>
+    <tags>VideoManager;Audio;Video;Player;Xamarin.Forms;Fabulous;F#;Elmish;Elm</tags>
+    <dependencies>
+      <dependency id="Fabulous.XamarinForms" version="0.40.0" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="..\..\..\build_output\Fabulous.XamarinForms\Extensions\Fabulous.XamarinForms.VideoManager\Fabulous.XamarinForms.VideoManager.dll" target="lib\netstandard2.0\Fabulous.XamarinForms.VideoManager.dll" />
+    <file src="..\..\..\build_output\Fabulous.XamarinForms\Extensions\Fabulous.XamarinForms.VideoManager\Fabulous.XamarinForms.VideoManager.pdb" target="lib\netstandard2.0\Fabulous.XamarinForms.VideoManager.pdb" />
+  </files>
+</package>


### PR DESCRIPTION
In the release 0.40.0, Fabulous.XamarinForms extensions have a wrong dependency on Fabulous.XamarinForms.Controls instead of Fabulous.XamarinForms.

This PR fixes it