### PR TITLE
Fix TicTacToe Sample for Mac

### DIFF
--- a/Fabulous.XamarinForms/samples/TicTacToe/TicTacToe/TicTacToe.fs
+++ b/Fabulous.XamarinForms/samples/TicTacToe/TicTacToe/TicTacToe.fs
@@ -1,4 +1,4 @@
-// Copyright 2018-2019 Fabulous contributors. See LICENSE.md for license.
+﻿// Copyright 2018-2019 Fabulous contributors. See LICENSE.md for license.
 namespace TicTacToe
 
 open Fabulous
@@ -147,8 +147,14 @@ module App =
     /// of the Xaml resource for the image for a player
     let imageForPos cell =
         match cell with
-        | Full X -> "Cross.png"
-        | Full O -> "Nought.png"
+        | Full X -> 
+            match Device.RuntimePlatform with
+            | Device.macOS -> "Cross"
+            | _ -> "Cross.png"
+        | Full O -> 
+            match Device.RuntimePlatform with
+            | Device.macOS -> "Nought"
+            | _ -> "Nought.png"
         | Empty -> ""
 
     /// A helper to get the suffix used in the Xaml for a position on the board.
@@ -178,7 +184,9 @@ module App =
                                 if canPlay model model.Board.[pos] then 
                                     View.Button(command=(fun () -> dispatch (Play pos)), backgroundColor=Color.LightBlue)
                                 else
-                                    View.Image(source=imageForPos model.Board.[pos], margin=10.0, horizontalOptions=LayoutOptions.Center, verticalOptions=LayoutOptions.Center)
+                                    View.Image(source=imageForPos model.Board.[pos],
+                                     margin=10.0, horizontalOptions=LayoutOptions.Center,
+                                     verticalOptions=LayoutOptions.Center)
                             item.GridRow(row*2).GridColumn(col*2) ],
 
                     rowSpacing=0.0,


### PR DESCRIPTION
This PR fix #464 

The problem was that Mac does not work with ".png" ending it only should be the name.
"Restart" works again - I think this was due to a bug in XF but not anymore.