### PR TITLE
Add missing namespace opening in templates

### DIFF
--- a/Fabulous.XamarinForms/templates/content/blank/NewApp/NewApp.fs
+++ b/Fabulous.XamarinForms/templates/content/blank/NewApp/NewApp.fs
@@ -4,6 +4,7 @@ namespace NewApp
 open System.Diagnostics
 open Fabulous
 open Fabulous.XamarinForms
+open Fabulous.XamarinForms.LiveUpdate
 open Xamarin.Forms
 
 module App = 


### PR DESCRIPTION
Closes #546 (in combination with #547)

Adds a missing namespace to be able to use LiveUpdate out of the box when creating a new project from the templates