### PR TITLE
Fix build script not running Fabulous.XamarinForms test projects

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -187,8 +187,8 @@ Target.create "BuildFabulousXamarinForms" (fun _ ->
 )
 
 Target.create "RunFabulousXamarinFormsTests" (fun _ ->
-    !! "tests/**/*.fsproj"
-    |> dotnetTest "Fabulous/TestResults"
+    !! "Fabulous.XamarinForms/tests/**/*.fsproj"
+    |> dotnetTest "Fabulous.XamarinForms/TestResults"
 )
 
 Target.create "BuildFabulousXamarinFormsExtensions" (fun _ ->
@@ -237,7 +237,7 @@ Target.create "BuildFabulousXamarinFormsSamples" (fun _ ->
 
 Target.create "RunFabulousXamarinFormsSamplesTests" (fun _ ->
     !! "Fabulous.XamarinForms/samples/**/*.Tests.fsproj"
-    |> dotnetTest "Fabulous.XamarinForms/TestResults"
+    |> dotnetTest "Fabulous.XamarinForms/samples/TestResults"
 )
 
 Target.create "BuildFabulousStaticViewSamples" (fun _ ->


### PR DESCRIPTION
Build scripts were not running Fabulous.XamarinForms test projects.
It is fixed now.