### PR TITLE
Add support for Xamarin.Forms 4.3

### DIFF
--- a/Fabulous.CodeGen/src/Fabulous.CodeGen/AssemblyReader/Converters.fs
+++ b/Fabulous.CodeGen/src/Fabulous.CodeGen/AssemblyReader/Converters.fs
@@ -2,6 +2,7 @@
 namespace Fabulous.CodeGen.AssemblyReader
 
 open System
+open System.Globalization
 
 module Converters =
     /// Converts the type name to another type name (e.g. System.Boolean => bool)
@@ -26,8 +27,8 @@ module Converters =
         | "System.Collections.IList" -> "obj list"
         | _ -> typeName
         
-    let inline numberWithDecimalsToString literal v =
-        let str = v.ToString()
+    let inline numberWithDecimalsToString literal (v: 'T when 'T :> IConvertible) =
+        let str = v.ToString(CultureInfo.InvariantCulture)
         let separator = if not (str.Contains(".")) then "." else ""
         str + separator + literal
         
@@ -37,15 +38,15 @@ module Converters =
         | null -> Some "null"
         | :? bool as b when b = true -> Some "true"
         | :? bool as b when b = false -> Some "false"
-        | :? sbyte as sbyte -> Some (sbyte.ToString() + "y")
-        | :? byte as byte -> Some (byte.ToString() + "uy")
-        | :? int16 as int16 -> Some (int16.ToString() + "s")
-        | :? uint16 as uint16 -> Some (uint16.ToString() + "us")
-        | :? int as int -> Some (int.ToString())
-        | :? uint32 as uint32 -> Some (uint32.ToString() + "u")
-        | :? int64 as int64 -> Some (int64.ToString() + "L")
-        | :? uint64 as uint64 -> Some (uint64.ToString() + "UL")
-        | :? bigint as bigint -> Some (bigint.ToString() + "I")
+        | :? sbyte as sbyte -> Some (sbyte.ToString(CultureInfo.InvariantCulture) + "y")
+        | :? byte as byte -> Some (byte.ToString(CultureInfo.InvariantCulture) + "uy")
+        | :? int16 as int16 -> Some (int16.ToString(CultureInfo.InvariantCulture) + "s")
+        | :? uint16 as uint16 -> Some (uint16.ToString(CultureInfo.InvariantCulture) + "us")
+        | :? int as int -> Some (int.ToString(CultureInfo.InvariantCulture))
+        | :? uint32 as uint32 -> Some (uint32.ToString(CultureInfo.InvariantCulture) + "u")
+        | :? int64 as int64 -> Some (int64.ToString(CultureInfo.InvariantCulture) + "L")
+        | :? uint64 as uint64 -> Some (uint64.ToString(CultureInfo.InvariantCulture) + "UL")
+        | :? bigint as bigint -> Some (bigint.ToString(CultureInfo.InvariantCulture) + "I")
         | :? float as float when Double.IsNaN(float) -> Some "System.Double.NaN"
         | :? double as double when Double.IsNaN(double) -> Some "System.Double.NaN"
         | :? float32 as float32 when Single.IsNaN(float32) -> Some "System.Single.NaN"

--- a/Fabulous.XamarinForms/src/Fabulous.XamarinForms/Xamarin.Forms.Core.json
+++ b/Fabulous.XamarinForms/src/Fabulous.XamarinForms/Xamarin.Forms.Core.json
@@ -222,6 +222,9 @@
         },
         {
           "source": "Text"
+        },
+        {
+          "source": "VerticalTextAlignment"
         }
       ],
       "events": [
@@ -361,6 +364,9 @@
     {
       "type": "Xamarin.Forms.Span",
       "properties": [
+        {
+          "source": "CharacterSpacing"
+        },
         {
           "source": "BackgroundColor"
         },
@@ -1228,6 +1234,9 @@
           "source": "BorderWidth"
         },
         {
+          "source": "CharacterSpacing"
+        },
+        {
           "source": "Command"
         },
         {
@@ -1291,6 +1300,9 @@
     {
       "type": "Xamarin.Forms.DatePicker",
       "properties": [
+        {
+          "source": "CharacterSpacing"
+        },
         {
           "source": "Date"
         },
@@ -1415,6 +1427,9 @@
           "source": "AutoSize"
         },
         {
+          "source": "CharacterSpacing"
+        },
+        {
           "source": "FontAttributes"
         },
         {
@@ -1462,6 +1477,12 @@
       "type": "Xamarin.Forms.Entry",
       "properties": [
         {
+          "source": "CharacterSpacing"
+        },
+        {
+          "source": "ClearButtonVisibility"
+        },
+        {
           "source": "CursorPosition",
           "updateCode": "ViewUpdaters.updateEntryCursorPosition"
         },
@@ -1506,6 +1527,9 @@
         },
         {
           "source": "TextColor"
+        },
+        {
+          "source": "VerticalTextAlignment"
         }
       ],
       "events": [
@@ -1530,6 +1554,9 @@
       "properties": [
         {
           "source": "CancelButtonColor"
+        },
+        {
+          "source": "CharacterSpacing"
         },
         {
           "source": "FontAttributes"
@@ -1570,6 +1597,9 @@
         },
         {
           "source": "TextColor"
+        },
+        {
+          "source": "VerticalTextAlignment"
         }
       ],
       "events": [
@@ -1641,7 +1671,47 @@
     {
       "type": "Xamarin.Forms.CarouselView",
       "name": "XFCarouselView",
-      "canBeInstantiated": false
+      "canBeInstantiated": false,
+      "properties": [
+        {
+          "source": "CurrentItem"
+        },
+        {
+          "source": "IsBounceEnabled"
+        },
+        {
+          "source": "IsScrollAnimated"
+        },
+        {
+          "source": "IsSwipeEnabled"
+        },
+        {
+          "source": "ItemsLayout"
+        },
+        {
+          "source": "NumberOfSideItems"
+        },
+        {
+          "source": "PeekAreaInsets"
+        },
+        {
+          "source": "Position"
+        }
+      ],
+      "events": [
+        {
+          "source": "CurrentItemChanged",
+          "relatedProperties": [
+            "CurrentItem"
+          ]
+        },
+        {
+          "source": "PositionChanged",
+          "relatedProperties": [
+            "Position"
+          ]
+        }
+      ]
     },
     {
       "type": "Fabulous.XamarinForms.CustomCarouselView",
@@ -1799,6 +1869,9 @@
         },
         {
           "source": "Refreshing"
+        },
+        {
+          "source": "Scrolled"
         }
       ]
     },
@@ -1868,6 +1941,9 @@
       "type": "Xamarin.Forms.Label",
       "properties": [
         {
+          "source": "CharacterSpacing"
+        },
+        {
           "source": "FontAttributes"
         },
         {
@@ -1894,6 +1970,9 @@
           "source": "MaxLines"
         },
         {
+          "source": "Padding"
+        },
+        {
           "source": "Text"
         },
         {
@@ -1901,6 +1980,9 @@
         },
         {
           "source": "TextDecorations"
+        },
+        {
+          "source": "TextType"
         },
         {
           "source": "VerticalTextAlignment"
@@ -2205,6 +2287,9 @@
       "type": "Xamarin.Forms.Picker",
       "properties": [
         {
+          "source": "CharacterSpacing"
+        },
+        {
           "source": "FontAttributes"
         },
         {
@@ -2391,6 +2476,9 @@
       "canBeInstantiated": false,
       "properties": [
         {
+          "source": "CharacterSpacing"
+        },
+        {
           "source": "FontAttributes"
         },
         {
@@ -2509,6 +2597,9 @@
       "name": "XFSearchHandler",
       "properties": [
         {
+          "source": "CharacterSpacing"
+        },
+        {
           "source": "BackgroundColor"
         },
         {
@@ -2594,6 +2685,9 @@
         },
         {
           "source": "TextColor"
+        },
+        {
+          "source": "VerticalTextAlignment"
         }
       ],
       "events": [
@@ -2667,6 +2761,25 @@
       "baseGenericConstraint": "Xamarin.Forms.Cell",
       "primaryConstructorMembers": [
         "Items"
+      ]
+    },
+    {
+      "type": "Xamarin.Forms.RefreshView",
+      "properties": [
+        {
+          "source": "IsRefreshing"
+        },
+        {
+          "source": "RefreshColor"
+        }
+      ],
+      "events": [
+        {
+          "source": "Refreshing",
+          "relatedProperties": [
+            "IsRefreshing"
+          ]
+        }
       ]
     }
   ]

--- a/Fabulous.XamarinForms/src/Fabulous.XamarinForms/Xamarin.Forms.Core.json
+++ b/Fabulous.XamarinForms/src/Fabulous.XamarinForms/Xamarin.Forms.Core.json
@@ -2289,6 +2289,9 @@
             "IsRefreshing"
           ]
         }
+      ],
+      "primaryConstructorMembers": [
+        "Content"
       ]
     },
     {

--- a/Fabulous.XamarinForms/src/Fabulous.XamarinForms/Xamarin.Forms.Core.json
+++ b/Fabulous.XamarinForms/src/Fabulous.XamarinForms/Xamarin.Forms.Core.json
@@ -2273,6 +2273,25 @@
       ]
     },
     {
+      "type": "Xamarin.Forms.RefreshView",
+      "properties": [
+        {
+          "source": "IsRefreshing"
+        },
+        {
+          "source": "RefreshColor"
+        }
+      ],
+      "events": [
+        {
+          "source": "Refreshing",
+          "relatedProperties": [
+            "IsRefreshing"
+          ]
+        }
+      ]
+    },
+    {
       "type": "Xamarin.Forms.OpenGLView",
       "properties": [
         {
@@ -2761,25 +2780,6 @@
       "baseGenericConstraint": "Xamarin.Forms.Cell",
       "primaryConstructorMembers": [
         "Items"
-      ]
-    },
-    {
-      "type": "Xamarin.Forms.RefreshView",
-      "properties": [
-        {
-          "source": "IsRefreshing"
-        },
-        {
-          "source": "RefreshColor"
-        }
-      ],
-      "events": [
-        {
-          "source": "Refreshing",
-          "relatedProperties": [
-            "IsRefreshing"
-          ]
-        }
       ]
     }
   ]


### PR DESCRIPTION
Some of the changes have already been added to F.XF 0.43 to avoid getting runtime errors when targeting XF 4.3.

This PR contains the remaining controls and properties changes.

~I still need to add a sample to AllControls for the new control RefreshView.~ Done

Link: https://docs.microsoft.com/en-us/xamarin/xamarin-forms/release-notes/4.3/4.3.0-api