### PR TITLE
Fix issue with ListViewCachingStrategy.RecycleElement

### DIFF
--- a/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/CustomControls.fs
+++ b/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/CustomControls.fs
@@ -140,10 +140,10 @@ type CustomEntryCell() as self =
 /////////////////
 
 type CustomListView() =
-    inherit ListView(ListViewCachingStrategy.RecycleElement, ItemTemplate = ViewElementDataTemplateSelector())
+    inherit ListView(ItemTemplate = ViewElementDataTemplateSelector())
     
 type CustomGroupListView() = 
-    inherit ListView(ListViewCachingStrategy.RecycleElement, IsGroupingEnabled = true, ItemTemplate = ViewElementDataTemplateSelector(), GroupHeaderTemplate = ViewElementDataTemplateSelector())
+    inherit ListView(IsGroupingEnabled = true, ItemTemplate = ViewElementDataTemplateSelector(), GroupHeaderTemplate = ViewElementDataTemplateSelector())
 
 type CustomCollectionView() = 
     inherit CollectionView(ItemTemplate = ViewElementDataTemplateSelector())


### PR DESCRIPTION
Fixes #603

`ListViewCachingStrategy.RecycleElement` is not compatible with the way Fabulous.XamarinForms handle DataTemplate.

Contrary to Xamarin.Forms, we cache the DataTemplates by their root type (e.g. ViewCell, TextCell, etc.) irrelative to the actual content. So setting an AutomationId on the cell will trigger an exception when the cell is reused.