### PR TITLE
Make sure slider minimum is always strictly less than maximum

### DIFF
--- a/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/ViewUpdaters.fs
+++ b/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/ViewUpdaters.fs
@@ -376,7 +376,7 @@ module ViewUpdaters =
         let control = target :?> Xamarin.Forms.Slider
         let defaultValue = (0.0, 1.0)
         let updateFunc (_, prevMaximum) (newMinimum, newMaximum) =
-            if newMinimum > prevMaximum then
+            if newMinimum >= prevMaximum then
                 control.Maximum <- newMaximum
                 control.Minimum <- newMinimum
             else


### PR DESCRIPTION
Should fix issue #639 which errors out when giving the value 1.0 as minimum.