### PR TITLE
Upgrade to .NET Core 3.1.101 and XCode 11.3.1/Mono 6.6.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,7 +23,7 @@
     <!-- Support for arbitrary value in AssemblyInformationalVersionAttribute https://github.com/Microsoft/visualfsharp/issues/4822 -->
     <NoWarn>FS2003</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework) == 'netstandard2.0' OR $(TargetFramework) == 'netcoreapp2.2'">
+  <PropertyGroup Condition="$(TargetFramework) == 'netstandard2.0' OR $(TargetFramework) == 'netcoreapp2.2' OR $(TargetFramework) == 'netcoreapp3.1'">
     <OtherFlags>/warnon:1182</OtherFlags>
   </PropertyGroup>
   <PropertyGroup Condition="($(IsPackable) == '' OR $(IsPackable) == 'true') AND $(Configuration) == 'Release'">

--- a/Fabulous.CodeGen/tests/Fabulous.CodeGen.Tests/Fabulous.CodeGen.Tests.fsproj
+++ b/Fabulous.CodeGen/tests/Fabulous.CodeGen.Tests/Fabulous.CodeGen.Tests.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
     <DefineConstants>$(DefineConstants);NETSTANDARD2_0;TEST</DefineConstants>

--- a/Fabulous.XamarinForms/samples/CounterApp/CounterApp.Tests/CounterApp.Tests.fsproj
+++ b/Fabulous.XamarinForms/samples/CounterApp/CounterApp.Tests/CounterApp.Tests.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Fabulous.XamarinForms/tests/FSharpDaemon.Driver.Tests/FSharpDaemon.Driver.Tests.fsproj
+++ b/Fabulous.XamarinForms/tests/FSharpDaemon.Driver.Tests/FSharpDaemon.Driver.Tests.fsproj
@@ -35,6 +35,8 @@
     <PackageReference Include="System.Reflection.Emit.Lightweight" />
   </ItemGroup>
   <Import Project="..\..\..\Packages.targets" />
+
+  <!-- Fix these packages to a specific version, independently of Packages.target, to match the versions used by PortaCode tests -->
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.5.2" />
     <PackageReference Update="NETStandard.Library" Version="2.0.3" />

--- a/Fabulous.XamarinForms/tests/FSharpDaemon.Driver.Tests/FSharpDaemon.Driver.Tests.fsproj
+++ b/Fabulous.XamarinForms/tests/FSharpDaemon.Driver.Tests/FSharpDaemon.Driver.Tests.fsproj
@@ -20,7 +20,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Dotnet.ProjInfo" />
-    <PackageReference Include="FSharp.Core" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="FSharp.Compiler.Service" />
     <PackageReference Include="Newtonsoft.Json" />
@@ -29,10 +28,15 @@
     <PackageReference Include="NUnit3TestAdapter" />
   
     <!-- References used indirectly by FCS when compiling tests -->
+    <PackageReference Include="FSharp.Core" />
     <PackageReference Include="Microsoft.CSharp" />
     <PackageReference Include="NETStandard.Library" />
     <PackageReference Include="System.Reflection.Emit.ILGeneration" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" />
   </ItemGroup>
   <Import Project="..\..\..\Packages.targets" />
+  <ItemGroup>
+    <PackageReference Update="FSharp.Core" Version="4.5.2" />
+    <PackageReference Update="NETStandard.Library" Version="2.0.3" />
+  </ItemGroup>
 </Project>

--- a/Fabulous.XamarinForms/tests/FSharpDaemon.Driver.Tests/FSharpDaemon.Driver.Tests.fsproj
+++ b/Fabulous.XamarinForms/tests/FSharpDaemon.Driver.Tests/FSharpDaemon.Driver.Tests.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
     <DefineConstants>$(DefineConstants);NETSTANDARD2_0;TEST</DefineConstants>

--- a/Fabulous.XamarinForms/tests/Fabulous.XamarinForms.Generator.Tests/Fabulous.XamarinForms.Generator.Tests.fsproj
+++ b/Fabulous.XamarinForms/tests/Fabulous.XamarinForms.Generator.Tests/Fabulous.XamarinForms.Generator.Tests.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
     <DefineConstants>$(DefineConstants);NETSTANDARD2_0;TEST</DefineConstants>

--- a/Fabulous.XamarinForms/tests/Fabulous.XamarinForms.Tests/Fabulous.XamarinForms.Tests.fsproj
+++ b/Fabulous.XamarinForms/tests/Fabulous.XamarinForms.Tests/Fabulous.XamarinForms.Tests.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
     <DefineConstants>$(DefineConstants);NETSTANDARD2_0;TEST</DefineConstants>

--- a/Fabulous.XamarinForms/tools/Fabulous.XamarinForms.Generator/Fabulous.XamarinForms.Generator.fsproj
+++ b/Fabulous.XamarinForms/tools/Fabulous.XamarinForms.Generator/Fabulous.XamarinForms.Generator.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFrameworks>netcoreapp2.2;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" />

--- a/Fabulous.XamarinForms/tools/Fabulous.XamarinForms.Generator/Fabulous.XamarinForms.Generator.fsproj
+++ b/Fabulous.XamarinForms/tools/Fabulous.XamarinForms.Generator/Fabulous.XamarinForms.Generator.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" />

--- a/azure-pipeline-osx-setup.sh
+++ b/azure-pipeline-osx-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-MONO_VERSION=5_18_1
-XCODE_VERSION=10.3
+MONO_VERSION=6_6_0
+XCODE_VERSION=11.3.1
 
 echo "Switch to the latest Xamarin SDK"
 sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh $MONO_VERSION

--- a/azure-pipelines-full.yml
+++ b/azure-pipelines-full.yml
@@ -13,7 +13,7 @@ jobs:
   - task: UseDotNet@2
     displayName: Stick with .NET Core SDK version compatible to Mono toolchain
     inputs:
-      version: 2.2.301  # See also: https://github.com/mono/mono/issues/13537
+      version: 3.1.101
   - script: ./build.sh Test
   - task: CopyFiles@1
     inputs:
@@ -36,7 +36,7 @@ jobs:
   steps:
   - task: UseDotNet@2
     inputs:
-      version: 2.2.105
+      version: 3.1.101
   - script: ./azure-pipeline-osx-setup.sh
   - script: ./build.sh Test
   - task: CopyFiles@1
@@ -60,7 +60,7 @@ jobs:
   steps:
   - task: UseDotNet@2
     inputs:
-      version: 2.2.105
+      version: 3.1.101
   - script: choco install gtksharp
 
   # Run Build with Test target when not merging a release branch into master

--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -10,7 +10,7 @@ jobs:
   steps:
   - task: UseDotNet@2
     inputs:
-      version: 2.2.105
+      version: 3.1.101
   - script: .\build.cmd
   - task: PublishTestResults@2
     inputs:
@@ -24,7 +24,7 @@ jobs:
   steps:
   - task: UseDotNet@2
     inputs:
-      version: 2.2.105
+      version: 3.1.101
   - script: ./azure-pipeline-osx-setup.sh
   - script: ./build.sh Test
   - task: PublishTestResults@2

--- a/build.cmd
+++ b/build.cmd
@@ -1,4 +1,8 @@
 @echo off
 cls
+
+REM Allow FAKE to run on .NET Core 3.x
+set DOTNET_ROLL_FORWARD=Major 
+
 dotnet restore build.proj
 if "%~1"=="" (dotnet fake build) else (dotnet fake run build.fsx -t %*)

--- a/build.cmd
+++ b/build.cmd
@@ -2,7 +2,7 @@
 cls
 
 REM Allow FAKE to run on .NET Core 3.x
-set DOTNET_ROLL_FORWARD=Major 
+set DOTNET_ROLL_FORWARD=Major
 
 dotnet restore build.proj
 if "%~1"=="" (dotnet fake build) else (dotnet fake run build.fsx -t %*)

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Allow FAKE to run on .NET Core 3.x
+export DOTNET_ROLL_FORWARD=Major
+
 dotnet restore build.proj
 if [ $# -eq 0 ]; then
     dotnet fake build

--- a/src/Fabulous.Cli/Fabulous.Cli.fsproj
+++ b/src/Fabulous.Cli/Fabulous.Cli.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <DefineConstants>$(DefineConstants);NETSTANDARD2_0</DefineConstants>
     <PackAsTool>True</PackAsTool>
     <ToolCommandName>fabulous</ToolCommandName>

--- a/src/Fabulous.Cli/Fabulous.Cli.fsproj
+++ b/src/Fabulous.Cli/Fabulous.Cli.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFrameworks>netcoreapp2.2;netcoreapp3.1</TargetFrameworks>
     <DefineConstants>$(DefineConstants);NETSTANDARD2_0</DefineConstants>
     <PackAsTool>True</PackAsTool>
     <ToolCommandName>fabulous</ToolCommandName>

--- a/tests/Fabulous.Tests/Fabulous.Tests.fsproj
+++ b/tests/Fabulous.Tests/Fabulous.Tests.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
     <DefineConstants>$(DefineConstants);NETSTANDARD2_0;TEST</DefineConstants>


### PR DESCRIPTION
Closes #657 

FAKE is currently built for .NET Core 2.x, but since .NET Core 3.x is backward-compatible, setting the environment variable `DOTNET_ROLL_FORWARD` to `Major` allows it to run on .NET Core 3.x.

Test projects have been moved to .NET Core 3.x only.
Tool projects (Generator, fabulous-cli) now support .NET Core 3.x via multi-targetting.

I tried to update the .NET Core version used by Azure DevOps too, but it depends if XCode can compile it.