### PR TITLE
Fix url pointing to update page from testing page in docs

### DIFF
--- a/docs/Fabulous.XamarinForms/testing.md
+++ b/docs/Fabulous.XamarinForms/testing.md
@@ -87,7 +87,7 @@ let ``Given the message Reset, Update should reset the state``() =
 Testing `Cmd<'msg>` can be hard, because there's no way of knowing what the functions inside `Cmd` really are before executing them.
 
 The recommended way is to apply the `CmdMsg` pattern.  
-See [Replacing commands with command messages for better testability](https://fsprojects.github.io/Fabulous/update.html#replacing-commands-with-command-messages-for-better-testability)
+See [Replacing commands with command messages for better testability](https://fsprojects.github.io/Fabulous/Fabulous.XamarinForms/update.html#replacing-commands-with-command-messages-for-better-testability)
 
 ### Testing view
 


### PR DESCRIPTION
I noticed a wrong url while reading the docs and fixed it