### PR TITLE
Fix reuse liveupdate

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,10 +1,10 @@
 <Project>
   <!-- NuGet Specs -->
   <PropertyGroup>
-    <Version>0.53.1</Version>
+    <Version>0.53.2</Version>
     <Authors>Fabulous Contributors</Authors>
-    <PackageVersion>0.53.1</PackageVersion>
-    <PackageReleaseNotes>[All] Added a new Fabulous icons to the repository and the samples (https://github.com/fsprojects/Fabulous/pull/714)</PackageReleaseNotes>
+    <PackageVersion>0.53.2</PackageVersion>
+    <PackageReleaseNotes>[Fabulous.XamarinForms] Use `XamarinFormsProgram.mkProgram` and similar to correctly support LiveUpdate (https://github.com/fsprojects/Fabulous/pull/716)</PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/fsprojects/Fabulous</PackageProjectUrl>

--- a/Fabulous.XamarinForms/samples/FabulousWeather/FabulousWeather/App.fs
+++ b/Fabulous.XamarinForms/samples/FabulousWeather/FabulousWeather/App.fs
@@ -174,5 +174,5 @@ type App () as app =
     let runner = App.program |> XamarinFormsProgram.run app
 
 #if DEBUG
-    do runner.EnableLiveUpdate ()
+    //do runner.EnableLiveUpdate ()
 #endif

--- a/Fabulous.XamarinForms/samples/Shell/Fabimals/Fabimals/App.fs
+++ b/Fabulous.XamarinForms/samples/Shell/Fabimals/Fabimals/App.fs
@@ -235,7 +235,7 @@ type FabimalsApp () as app =
 #if DEBUG
     // Run LiveUpdate using: 
     //    
-    do runner.EnableLiveUpdate ()
+    //do runner.EnableLiveUpdate ()
 #endif
 
 

--- a/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/Program.fs
+++ b/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/Program.fs
@@ -28,14 +28,33 @@ module XamarinFormsProgram =
     let private syncAction (fn: unit -> unit) =
         fun () ->
             Device.BeginInvokeOnMainThread (fun () -> fn())
+            
+    let private setXamarinFormsHandlers program =
+        program
+        |> Program.withCanReuseView ViewHelpers.canReuseView
+        |> Program.withSyncDispatch syncDispatch
+        |> Program.withSyncAction syncAction
+
+    /// Typical program, new commands are produced by `init` and `update` along with the new state.
+    let mkProgram (init : 'arg -> 'model * Cmd<'msg>) (update : 'msg -> 'model -> 'model * Cmd<'msg>) (view : 'model -> Dispatch<'msg> -> ViewElement) =
+        Fabulous.Program.mkProgram init update view
+        |> setXamarinFormsHandlers
+
+    /// Simple program that produces only new state with `init` and `update`.
+    let mkSimple (init : 'arg -> 'model) (update : 'msg -> 'model -> 'model) (view : 'model -> Dispatch<'msg> -> ViewElement) = 
+        Fabulous.Program.mkSimple init update view
+        |> setXamarinFormsHandlers
+
+    /// Typical program, new commands are produced discriminated unions returned by `init` and `update` along with the new state.
+    let mkProgramWithCmdMsg (init: 'arg -> 'model * 'cmdMsg list) (update: 'msg -> 'model -> 'model * 'cmdMsg list) (view: 'model -> Dispatch<'msg> -> ViewElement) (mapToCmd: 'cmdMsg -> Cmd<'msg>) =
+        Fabulous.Program.mkProgramWithCmdMsg init update view mapToCmd
+        |> setXamarinFormsHandlers
 
     let runWith app arg program =
         let host = XamarinFormsHost(app)
 
         program
-        |> Program.withCanReuseView ViewHelpers.canReuseView
-        |> Program.withSyncDispatch syncDispatch
-        |> Program.withSyncAction syncAction
+        |> setXamarinFormsHandlers // TODO: Kept for not breaking existing apps. Need to be removed later
         |> Program.runWithFabulous host arg
         
     let run app program =

--- a/Fabulous.XamarinForms/templates/content/blank/.template.config/template.json
+++ b/Fabulous.XamarinForms/templates/content/blank/.template.config/template.json
@@ -7,7 +7,7 @@
     "Elmish",
     "Cross-platform"
   ],
-  "name": "Fabulous Xamarin.Forms App v0.53.1",
+  "name": "Fabulous Xamarin.Forms App v0.53.2",
   "groupIdentity": "Fabulous.XamarinForms.App",
   "identity": "Fabulous.XamarinForms.FSharp",
   "shortName": "fabulous-xf-app",
@@ -162,7 +162,7 @@
       "type": "parameter",
       "dataType": "string",
       "replaces": "FabulousPkgsVersion",
-      "defaultValue": "0.53.1"
+      "defaultValue": "0.53.2"
     },
     "NewtonsoftJsonPkg": {
       "type": "parameter",

--- a/Fabulous.XamarinForms/templates/content/blank/NewApp/NewApp.fs
+++ b/Fabulous.XamarinForms/templates/content/blank/NewApp/NewApp.fs
@@ -58,7 +58,7 @@ module App =
             ]))
 
     // Note, this declaration is needed if you enable LiveUpdate
-    let program = Program.mkProgram init update view
+    let program = XamarinFormsProgram.mkProgram init update view
 
 type App () as app = 
     inherit Application ()

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 0.53.2
+
+* [Fabulous.XamarinForms] Use `XamarinFormsProgram.mkProgram` and similar to correctly support LiveUpdate (https://github.com/fsprojects/Fabulous/pull/716)
+
 #### 0.53.1
 
 * [All] Added a new Fabulous icons to the repository and the samples (https://github.com/fsprojects/Fabulous/pull/714)


### PR DESCRIPTION
Noticed just now, that when using LiveUpdate, controls weren't reused as expected.
It's because we set the Fabulous.XamarinForms' `canReuseView` handler too late (only when calling `XamarinFormsProgram.run`).

But LiveUpdate does not re-execute that part, it ends up with the default Fabulous `canReuseView` handler... returning `false` always...

So, I had to provide specific `XamarinFormsProgram.mkSimple`/`mkProgram` to set this canReuseView early so LiveUpdate has access to it.