### PR TITLE
Make path to follow clearer

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,12 +6,6 @@ Never write a ViewModel class again! Conquer the world with clean dynamic UIs!
 
 * [Documentation of Fabulous](https://fsprojects.github.io/Fabulous/Fabulous.XamarinForms/)
 
-Tools
------
-
-* [Documentation of Fabulous StaticView](https://fsprojects.github.io/Fabulous/Fabulous.StaticView/)
-* [Documentation of Fabulous.CodeGen](https://fsprojects.github.io/Fabulous/Fabulous.CodeGen/)
-
 Contributing
 ------
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,14 +4,18 @@
 
 Never write a ViewModel class again! Conquer the world with clean dynamic UIs!
 
-* [Documentation of Fabulous](https://fsprojects.github.io/Fabulous/Fabulous/)
-* [Documentation of Fabulous.CodeGen](https://fsprojects.github.io/Fabulous/Fabulous.CodeGen/)
-* [Documentation of Fabulous for Xamarin.Forms](https://fsprojects.github.io/Fabulous/Fabulous.XamarinForms/)
+* [Documentation of Fabulous](https://fsprojects.github.io/Fabulous/Fabulous.XamarinForms/)
+
+Tools
+-----
+
 * [Documentation of Fabulous StaticView](https://fsprojects.github.io/Fabulous/Fabulous.StaticView/)
+* [Documentation of Fabulous.CodeGen](https://fsprojects.github.io/Fabulous/Fabulous.CodeGen/)
 
 Contributing
 ------
 
 Please contribute to this library through issue reports, pull requests, code reviews and discussion.
 
+* [Github Repo](https://github.com/fsprojects/Fabulous)
 * [Submit a fix to this guide](https://github.com/fsprojects/Fabulous/tree/master/docs)


### PR DESCRIPTION
The Fabulous home page is unclear

* The main "Fabulous" link takes you to unfinished docs

* The "StaticView" is not really supported 

* The "CodeGen" is a tool and is not documented

We really have to make the getting-started path really simple.   I think we should just direct people down the happy path for now and take them straight to the "Fabulous for Xamarin Forms" documentation.  We really don't want anyone to end up anywhere else for now??