### PR TITLE
Fix an issue in BindableHelpers.onBindingContextChanged

### DIFF
--- a/Fabulous.CodeGen/src/Fabulous.CodeGen/Generator/CodeGenerator.fs
+++ b/Fabulous.CodeGen/src/Fabulous.CodeGen/Generator/CodeGenerator.fs
@@ -108,12 +108,10 @@ module CodeGenerator =
                 // Check if the property is a collection
                 match p.CollectionDataElementType with 
                 | Some collectionDataElementType when not hasApply ->
-                    w.printfn "        ViewUpdaters.updateCollectionGeneric prev%sOpt curr%sOpt target.%s" p.UniqueName p.UniqueName p.Name
-                    w.printfn "            (fun (x: ViewElement) -> x.Create() :?> %s)" collectionDataElementType
+                    w.printfn "        ChildrenUpdaters.updateChildren prev%sOpt curr%sOpt target.%s" p.UniqueName p.UniqueName p.Name
+                    w.printfn "            (fun x -> x.Create() :?> %s)" collectionDataElementType
+                    w.printfn "            ChildrenUpdaters.updateChild"
                     w.printfn "            (match registry.TryGetValue(%s.KeyValue) with true, func -> func | false, _ -> (fun _ _ _ -> ()))" attributeKey
-                    w.printfn "            ViewHelpers.canReuseView"
-                    w.printfn "            ViewHelpers.tryGetKey"
-                    w.printfn "            ViewUpdaters.updateChild"
                     
                 | Some _ when hasApply ->
                     w.printfn "        %s prev%sOpt curr%sOpt target" p.UpdateCode p.UniqueName p.UniqueName

--- a/Fabulous.XamarinForms/extensions/Maps/ViewUpdaters.fs
+++ b/Fabulous.XamarinForms/extensions/Maps/ViewUpdaters.fs
@@ -1,6 +1,7 @@
 namespace Fabulous.XamarinForms.Maps
 
 open Fabulous.XamarinForms
+open Xamarin.Forms.Maps
 
 module ViewUpdaters =
     let updateMapRequestedRegion (prevOpt: Xamarin.Forms.Maps.MapSpan voption) (currOpt: Xamarin.Forms.Maps.MapSpan voption) (target: Xamarin.Forms.Maps.Map) =
@@ -9,18 +10,18 @@ module ViewUpdaters =
         | ValueSome prev, ValueSome curr when prev <> curr -> target.MoveToRegion(curr)
         | _ -> ()
 
-    let updatePolygonGeopath (prevCollOpt: Xamarin.Forms.Maps.Position array voption) (currCollOpt: Xamarin.Forms.Maps.Position array voption) (target: Xamarin.Forms.Maps.Polygon) _ =
-        ViewUpdaters.updateCollectionGeneric prevCollOpt currCollOpt target.Geopath
+    let updatePolygonGeopath (prevCollOpt: Position array voption) (currCollOpt: Xamarin.Forms.Maps.Position array voption) (target: Xamarin.Forms.Maps.Polygon) _ =
+        ItemsUpdaters.updateItems prevCollOpt currCollOpt target.Geopath
+            (fun _ -> ValueNone)
+            (fun prev curr -> prev = curr)
             id
             (fun _ _ _ -> ())
-            (fun prev curr -> prev = curr)
-            (fun _ -> ValueNone)
             (fun _ _ _ -> ())
 
     let updatePolylineGeopath (prevCollOpt: Xamarin.Forms.Maps.Position array voption) (currCollOpt: Xamarin.Forms.Maps.Position array voption) (target: Xamarin.Forms.Maps.Polyline) _ =
-        ViewUpdaters.updateCollectionGeneric prevCollOpt currCollOpt target.Geopath
+        ItemsUpdaters.updateItems prevCollOpt currCollOpt target.Geopath
+            (fun _ -> ValueNone)
+            (fun prev curr -> prev = curr)
             id
             (fun _ _ _ -> ())
-            (fun prev curr -> prev = curr)
-            (fun _ -> ValueNone)
             (fun _ _ _ -> ())

--- a/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/ChildrenUpdaters.fs
+++ b/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/ChildrenUpdaters.fs
@@ -1,0 +1,229 @@
+namespace Fabulous.XamarinForms
+
+open Fabulous
+open System.Collections.Generic
+open Xamarin.Forms
+
+module ChildrenUpdaters =    
+    /// Incremental list maintenance: given a collection, and a previous version of that collection, perform
+    /// a reduced number of clear/move/create/update/remove operations
+    ///
+    /// The algorithm will try in priority to update elements sharing the same instance (usually achieved with dependsOn)
+    /// or sharing the same key. All other elements will try to reuse previous elements where possible.
+    /// If no reuse is possible, the element will create a new control.
+    let updateChildrenInternal
+            (prevCollOpt: 'T[] voption)
+            (collOpt: 'T[] voption)
+            (keyOf: 'T -> string voption)
+            (canReuse: 'T -> 'T -> bool)
+            (clear: unit -> unit)
+            (create: int -> 'T -> unit)
+            (update: int -> 'T -> 'T -> unit)
+            (move: int -> int -> unit)
+            (remove: int -> unit)
+        =
+        
+        match prevCollOpt, collOpt with
+        | ValueNone, ValueNone -> ()
+        | ValueSome prevColl, ValueSome newColl when identical prevColl newColl -> ()
+        | ValueSome prevColl, ValueSome newColl when prevColl <> null && newColl <> null && prevColl.Length = 0 && newColl.Length = 0 -> ()
+        | ValueSome _, ValueNone -> clear ()
+        | ValueSome _, ValueSome coll when (coll = null || coll.Length = 0) -> clear ()
+        | _, ValueSome coll ->
+            let currentState = match prevCollOpt with ValueSome x -> List(x) | _ -> List()
+                
+            let create newIndex newChild =
+                currentState.Insert(newIndex, newChild)
+                create newIndex newChild
+                
+            let move prevIndex newIndex =
+                let child = currentState.[prevIndex]
+                currentState.RemoveAt(prevIndex)
+                currentState.Insert(newIndex, child)
+                move prevIndex newIndex
+                
+            let remove index =
+                currentState.RemoveAt(index)
+                remove index
+            
+            // Separate the previous elements into 3 lists
+            // The ones whose instances have been reused (dependsOn)
+            // The ones whose keys have been reused
+            // The rest which can be reused by any other element
+            let identicalElements = HashSet<'T>()
+            let keyedElements = Dictionary<string, 'T>()
+            let reusableElements = ResizeArray<'T>()
+            if prevCollOpt.IsSome then
+                for prevChild in prevCollOpt.Value do
+                    if coll |> Array.exists (identical prevChild) then
+                        identicalElements.Add(prevChild) |> ignore
+                    else
+                        let canReuseChildOf key =
+                            coll
+                            |> Array.exists (fun newChild ->
+                                keyOf newChild = ValueSome key
+                                && canReuse prevChild newChild
+                            )
+                        
+                        match keyOf prevChild with
+                        | ValueSome key when canReuseChildOf key ->
+                            keyedElements.Add(key, prevChild)
+                        | _ ->
+                            reusableElements.Add(prevChild)
+            
+            // Reuse the first element from reusableElements that returns true to canReuse
+            // Otherwise create a new element
+            let reuseOrCreate newIndex newChild =
+                match reusableElements |> Seq.tryFind(fun c -> canReuse c newChild) with
+                | Some prevChild ->
+                    reusableElements.Remove prevChild |> ignore
+                    
+                    let prevIndex = currentState.IndexOf(prevChild)
+                    update prevIndex prevChild newChild
+                            
+                    if prevIndex <> newIndex then
+                        move prevIndex newIndex
+                        
+                | None ->
+                    create newIndex newChild
+            
+            for i in 0 .. coll.Length - 1 do
+                let newChild = coll.[i]
+                
+                // Check if the same instance was reused (dependsOn), if so just move the element to the correct index
+                if identicalElements.Contains(newChild) then
+                    let prevIndex = currentState.IndexOf(newChild)
+                    if prevIndex <> i then
+                        move prevIndex i
+                else
+                    // If the key existed previously, reuse the previous element
+                    match keyOf newChild with
+                    | ValueSome key when keyedElements.ContainsKey(key) -> 
+                        let prevChild = keyedElements.[key]
+                        let prevIndex = currentState.IndexOf(prevChild)
+                        update prevIndex prevChild newChild
+                        
+                        if prevIndex <> i then
+                            move prevIndex i
+                    
+                    // Otherwise, reuse an old element if possible or create a new one
+                    | _ ->
+                        reuseOrCreate i newChild
+            
+            // If we still have old elements that were not reused, delete them
+            if reusableElements.Count > 0 then
+                for remainingElement in reusableElements do
+                    let prevIndex = currentState.IndexOf(remainingElement)
+                    remove prevIndex
+
+    /// Incremental list maintenance: given a collection, and a previous version of that collection, perform
+    /// a reduced number of clear/add/remove/insert operations
+    let updateChildren
+           (prevCollOpt: ViewElement[] voption) 
+           (collOpt: ViewElement[] voption) 
+           (targetColl: IList<'TargetT>) 
+           (create: ViewElement -> 'TargetT)
+           (update: ViewElement -> ViewElement -> 'TargetT -> unit) // Incremental element-wise update, only if element reuse is allowed
+           (attach: ViewElement voption -> ViewElement -> 'TargetT -> unit) // adjust attached properties
+        =
+        
+        let create index child =
+            let targetChild = create child
+            attach ValueNone child targetChild
+            targetColl.Insert(index, targetChild)
+            
+        let update index prevChild newChild =
+            let targetChild = targetColl.[index]
+            update prevChild newChild targetChild
+            attach (ValueSome prevChild) newChild targetChild
+            
+        let move prevIndex newIndex =
+            let targetChild = targetColl.[prevIndex]
+            targetColl.RemoveAt(prevIndex)
+            targetColl.Insert(newIndex, targetChild)
+        
+        updateChildrenInternal
+            prevCollOpt collOpt ViewHelpers.tryGetKey ViewHelpers.canReuseView
+            (fun () -> targetColl.Clear())
+            create update move
+            (fun index -> targetColl.RemoveAt(index))
+
+    /// Update a control given the previous and new view elements
+    let inline updateChild (prevChild: ViewElement) (newChild: ViewElement) targetChild = 
+        newChild.UpdateIncremental(prevChild, targetChild)
+        
+    /// Update the items of a TableSectionBase<'T> control, given previous and current view elements
+    let inline updateTableSectionBaseOfTItems<'T when 'T :> BindableObject> prevCollOpt collOpt (target: TableSectionBase<'T>) attach =
+        updateChildren prevCollOpt collOpt target (fun c -> c.Create() :?> 'T) updateChild attach
+
+    /// Update the items of a Shell, given previous and current view elements
+    let inline updateShellItems prevCollOpt collOpt (target: Shell) attach =
+        let createChild (desc: ViewElement) =
+            match desc.Create() with
+            | :? ShellContent as shellContent -> ShellItem.op_Implicit shellContent
+            | :? TemplatedPage as templatedPage -> ShellItem.op_Implicit templatedPage
+            | :? ShellSection as shellSection -> ShellItem.op_Implicit shellSection
+            | :? MenuItem as menuItem -> ShellItem.op_Implicit menuItem
+            | :? ShellItem as shellItem -> shellItem
+            | child -> failwithf "%s is not compatible with the type ShellItem" (child.GetType().Name)
+
+        let updateChild prevViewElement (currViewElement: ViewElement) (target: ShellItem) =
+            let realTarget =
+                match currViewElement.TargetType with
+                | t when t = typeof<ShellContent> -> target.Items.[0].Items.[0] :> Element
+                | t when t = typeof<TemplatedPage> -> target.Items.[0].Items.[0] :> Element
+                | t when t = typeof<ShellSection> -> target.Items.[0] :> Element
+                | t when t = typeof<MenuItem> -> target.GetType().GetProperty("MenuItem").GetValue(target) :?> Element // MenuShellItem is marked as internal
+                | _ -> target :> Element
+            updateChild prevViewElement currViewElement realTarget
+
+        updateChildren prevCollOpt collOpt target.Items createChild updateChild attach
+        
+    /// Update the menu items of a ShellContent, given previous and current view elements
+    let inline updateShellContentMenuItems prevCollOpt collOpt (target: ShellContent) =
+        updateChildren prevCollOpt collOpt target.MenuItems (fun c -> c.Create() :?> MenuItem) updateChild (fun _ _ _ -> ())
+
+    /// Update the items of a ShellItem, given previous and current view elements
+    let inline updateShellItemItems prevCollOpt collOpt (target: ShellItem) attach =
+        let createChild (desc: ViewElement) =
+            match desc.Create() with
+            | :? ShellContent as shellContent -> ShellSection.op_Implicit shellContent
+            | :? TemplatedPage as templatedPage -> ShellSection.op_Implicit templatedPage
+            | :? ShellSection as shellSection -> shellSection
+            | child -> failwithf "%s is not compatible with the type ShellSection" (child.GetType().Name)
+
+        let updateChild prevViewElement (currViewElement: ViewElement) (target: ShellSection) =
+            let realTarget =
+                match currViewElement.TargetType with
+                | t when t = typeof<ShellContent> -> target.Items.[0] :> BaseShellItem
+                | t when t = typeof<TemplatedPage> -> target.Items.[0] :> BaseShellItem
+                | _ -> target :> BaseShellItem
+            updateChild prevViewElement currViewElement realTarget
+
+        updateChildren prevCollOpt collOpt target.Items createChild updateChild attach
+
+    /// Update the items of a ShellSection, given previous and current view elements
+    let inline updateShellSectionItems prevCollOpt collOpt (target: ShellSection) attach =
+        updateChildren prevCollOpt collOpt target.Items (fun c -> c.Create() :?> ShellContent) updateChild attach
+
+    /// Update the items of a SwipeItems, given previous and current view elements
+    let inline updateSwipeItems prevCollOpt collOpt (target: SwipeItems) =
+        updateChildren prevCollOpt collOpt target (fun c -> c.Create() :?> ISwipeItem) updateChild (fun _ _ _ -> ())
+            
+    /// Update the children of a Menu, given previous and current view elements
+    let inline updateMenuChildren prevCollOpt collOpt (target: Menu) attach =
+        updateChildren prevCollOpt collOpt target (fun c -> c.Create() :?> Menu) updateChild attach
+        
+    /// Update the effects of an Element, given previous and current view elements
+    let inline updateElementEffects prevCollOpt collOpt (target: Element) attach =
+        let createChild (desc: ViewElement) =
+            match desc.Create() with
+            | :? CustomEffect as customEffect -> Effect.Resolve(customEffect.Name)
+            | effect -> effect :?> Effect
+            
+        updateChildren prevCollOpt collOpt target.Effects createChild updateChild attach
+        
+    /// Update the toolbar items of a Page, given previous and current view elements
+    let inline updatePageToolbarItems prevCollOpt collOpt (target: Page) attach =
+        updateChildren prevCollOpt collOpt target.ToolbarItems (fun c -> c.Create() :?> ToolbarItem) updateChild attach
+

--- a/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/ChildrenUpdaters.fs
+++ b/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/ChildrenUpdaters.fs
@@ -4,6 +4,7 @@ open Fabulous
 open System.Collections.Generic
 open Xamarin.Forms
 
+/// This module contains the update logic for the controls with children
 module ChildrenUpdaters =    
     /// Incremental list maintenance: given a collection, and a previous version of that collection, perform
     /// a reduced number of clear/move/create/update/remove operations

--- a/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/CustomControls.fs
+++ b/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/CustomControls.fs
@@ -82,9 +82,7 @@ module BindableHelpers =
                 newHolder.ViewElement.UpdateInherited(prevModelOpt, newHolder.ViewElement, bindableObject)
                 holderOpt <- ValueSome newHolder
                 prevModelOpt <- ValueSome newHolder.ViewElement
-            | _ ->
-                holderOpt <- ValueNone
-                prevModelOpt <- ValueNone
+            | _ -> ()
             
         onBindingContextChanged
         

--- a/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/CustomControls.fs
+++ b/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/CustomControls.fs
@@ -82,7 +82,11 @@ module BindableHelpers =
                 newHolder.ViewElement.UpdateInherited(prevModelOpt, newHolder.ViewElement, bindableObject)
                 holderOpt <- ValueSome newHolder
                 prevModelOpt <- ValueSome newHolder.ViewElement
-            | _ -> ()
+            | _ ->
+                // Only remove the previous holder reference since we don't need it anymore
+                // prevModelOpt on the other hand needs to be kept, since Xamarin.Forms will first
+                // set BindingContext to null before setting a new item
+                holderOpt <- ValueNone
             
         onBindingContextChanged
         

--- a/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/Fabulous.XamarinForms.Core.fsproj
+++ b/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/Fabulous.XamarinForms.Core.fsproj
@@ -11,6 +11,8 @@
     <Compile Include="Program.fs" />
     <Compile Include="ViewConverters.fs" />
     <Compile Include="ViewUpdaters.fs" />
+    <Compile Include="ChildrenUpdaters.fs" />
+    <Compile Include="ItemsUpdaters.fs" />
     <Compile Include="ViewExtensions.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/ItemsUpdaters.fs
+++ b/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/ItemsUpdaters.fs
@@ -1,0 +1,199 @@
+namespace Fabulous.XamarinForms
+
+open Fabulous
+open System.Collections
+open System.Collections.Generic
+open System.Collections.ObjectModel
+open Xamarin.Forms
+
+module ItemsUpdaters =    
+    /// Incremental list maintenance: given a collection, and a previous version of that collection, perform
+    /// a reduced number of clear/move/create/update/remove operations
+    ///
+    /// The algorithm will try in priority to update elements sharing the same instance (usually achieved with dependsOn)
+    /// or sharing the same key. All other elements will try to reuse previous elements where possible.
+    /// If no reuse is possible, the element will create a new control.
+    let updateItemsInternal
+            (prevCollOpt: 'T[] voption)
+            (collOpt: 'T[] voption)
+            (keyOf: 'T -> string voption)
+            (canReuse: 'T -> 'T -> bool)
+            (clear: unit -> unit)
+            (create: int -> 'T -> unit)
+            (update: int -> 'T -> 'T -> unit)
+            (move: int -> int -> unit)
+            (remove: int -> unit)
+        =
+        
+        match prevCollOpt, collOpt with
+        | ValueNone, ValueNone -> ()
+        | ValueSome prevColl, ValueSome newColl when identical prevColl newColl -> ()
+        | ValueSome prevColl, ValueSome newColl when prevColl <> null && newColl <> null && prevColl.Length = 0 && newColl.Length = 0 -> ()
+        | ValueSome _, ValueNone -> clear ()
+        | ValueSome _, ValueSome coll when (coll = null || coll.Length = 0) -> clear ()
+        | _, ValueSome coll ->
+            let currentState = match prevCollOpt with ValueSome x -> List(x) | _ -> List()
+                
+            let create newIndex newChild =
+                currentState.Insert(newIndex, newChild)
+                create newIndex newChild
+                
+            let move prevIndex newIndex =
+                let child = currentState.[prevIndex]
+                currentState.RemoveAt(prevIndex)
+                currentState.Insert(newIndex, child)
+                move prevIndex newIndex
+                
+            let remove index =
+                currentState.RemoveAt(index)
+                remove index
+            
+            // Separate the previous elements into 2 lists
+            // The ones whose instances have been reused (dependsOn)
+            // The ones whose keys have been reused
+            let identicalElements = HashSet<'T>()
+            let keyedElements = Dictionary<string, 'T>()
+            if prevCollOpt.IsSome then
+                for prevChild in prevCollOpt.Value do
+                    if coll |> Array.exists (identical prevChild) then
+                        identicalElements.Add(prevChild) |> ignore
+                    else
+                        let canReuseChildOf key =
+                            coll
+                            |> Array.exists (fun newChild ->
+                                keyOf newChild = ValueSome key
+                                && canReuse prevChild newChild
+                            )
+                        
+                        match keyOf prevChild with
+                        | ValueSome key when canReuseChildOf key ->
+                            keyedElements.Add(key, prevChild)
+                        | _ -> ()
+            
+            // Reuse the element from the same index if possible (not already reused and reusable)
+            // Otherwise create a new element
+            let reuseOrCreate index newChild =
+                if prevCollOpt.IsSome && prevCollOpt.Value.Length > index then
+                    let prevChild = prevCollOpt.Value.[index]
+                    let key = keyOf prevChild
+                    
+                    if not (identicalElements.Contains(prevChild))
+                       && (key.IsNone || not (keyedElements.ContainsKey(key.Value)))
+                       && (canReuse prevChild newChild) then
+                           update index prevChild newChild
+                        
+                    else
+                        create index newChild
+                else
+                    create index newChild
+            
+            for i in 0 .. coll.Length - 1 do
+                let newChild = coll.[i]
+                
+                // Check if the same instance was reused (dependsOn), if so just move the element to the correct index
+                if identicalElements.Contains(newChild) then
+                    let prevIndex = currentState.IndexOf(newChild)
+                    if prevIndex <> i then
+                        move prevIndex i
+                else
+                    // If the key existed previously, reuse the previous element
+                    match keyOf newChild with
+                    | ValueSome key when keyedElements.ContainsKey(key) ->
+                        let prevChild = keyedElements.[key]
+                        let prevIndex = currentState.IndexOf(prevChild)
+                        update prevIndex prevChild newChild
+                        
+                        if prevIndex <> i then
+                            move prevIndex i
+                    
+                    // Otherwise, reuse an old element if possible or create a new one
+                    | _ ->
+                        reuseOrCreate i newChild
+            
+            // Remove all the excess elements
+            if prevCollOpt.IsSome && prevCollOpt.Value.Length > coll.Length then
+                while currentState.Count > coll.Length do
+                    remove (currentState.Count - 1)
+                    
+    let updateItems
+           (prevCollOpt: 'T[] voption)
+           (collOpt: 'T[] voption)
+           (targetColl: IList<'TargetT>)
+           (keyOf: 'T -> string voption)
+           (canReuse: 'T -> 'T -> bool)
+           (create: 'T -> 'TargetT)
+           (update: 'T -> 'T -> 'TargetT -> unit)
+           (attach: 'T voption -> 'T -> 'TargetT -> unit) // adjust attached properties
+        =
+        
+        let create index child =
+            let targetChild = create child
+            attach ValueNone child targetChild
+            targetColl.Insert(index, targetChild)
+            
+        let update index prevChild newChild =
+            let targetChild = targetColl.[index]
+            update prevChild newChild targetChild
+            attach (ValueSome prevChild) newChild targetChild
+            
+        let move prevIndex newIndex =
+            let targetChild = targetColl.[prevIndex]
+            targetColl.RemoveAt(prevIndex)
+            targetColl.Insert(newIndex, targetChild)
+        
+        updateItemsInternal
+            prevCollOpt collOpt keyOf canReuse
+            (fun () -> targetColl.Clear())
+            create update move
+            (fun index -> targetColl.RemoveAt(index))
+    
+    let inline updateViewElementHolderItems (prevCollOpt: ViewElement[] voption) (collOpt: ViewElement[] voption) (targetColl: ObservableCollection<ViewElementHolder>) =
+        updateItems prevCollOpt collOpt targetColl
+            ViewHelpers.tryGetKey ViewHelpers.canReuseView
+            ViewElementHolder (fun _ curr holder -> holder.ViewElement <- curr)
+    
+    let inline getCollection<'T> (coll: IEnumerable) (set: ObservableCollection<'T> -> unit) =
+        match coll with 
+        | :? ObservableCollection<'T> as oc -> oc
+        | _ -> let oc = ObservableCollection<'T>() in set oc; oc
+    
+    /// Update the items in a ItemsView control, given previous and current view elements
+    let inline updateItemsViewItems prevCollOpt collOpt (target: ItemsView) =
+        let targetColl = getCollection<ViewElementHolder> target.ItemsSource (fun oc -> target.ItemsSource <- oc)
+        updateViewElementHolderItems prevCollOpt collOpt targetColl (fun _ _ _ -> ())
+                    
+    /// Update the items in a ItemsView<'T> control, given previous and current view elements
+    let inline updateItemsViewOfTItems<'T when 'T :> BindableObject> prevCollOpt collOpt (target: ItemsView<'T>) = 
+        let targetColl = getCollection<ViewElementHolder> target.ItemsSource (fun oc -> target.ItemsSource <- oc)
+        updateViewElementHolderItems prevCollOpt collOpt targetColl (fun _ _ _ -> ())
+        
+    /// Update the items in a SearchHandler control, given previous and current view elements
+    let inline updateSearchHandlerItems prevCollOpt collOpt (target: SearchHandler) = 
+        let targetColl = getCollection<ViewElementHolder> target.ItemsSource (fun oc -> target.ItemsSource <- oc)
+        updateViewElementHolderItems prevCollOpt collOpt targetColl (fun _ _ _ -> ())
+
+    /// Update the items in a GroupedListView control, given previous and current view elements
+    let inline updateListViewGroupedItems (prevCollOpt: (string * ViewElement * ViewElement[])[] voption) (collOpt: (string * ViewElement * ViewElement[])[] voption) (target: ListView) =
+        let updateViewElementHolderGroup (_prevShortName: string, _prevKey, prevColl: ViewElement[]) (currShortName: string, currKey, currColl: ViewElement[]) (target: ViewElementHolderGroup) =
+            target.ShortName <- currShortName
+            target.ViewElement <- currKey
+            updateViewElementHolderItems (ValueSome prevColl) (ValueSome currColl) target (fun _ _ _ -> ())
+                
+        let targetColl = getCollection<ViewElementHolderGroup> target.ItemsSource (fun oc -> target.ItemsSource <- oc)
+        updateItems prevCollOpt collOpt targetColl
+            (fun (key, _, _) -> ValueSome key)
+            (fun (_, prevHeader, _) (_, currHeader, _) -> ViewHelpers.canReuseView prevHeader currHeader)
+            ViewElementHolderGroup updateViewElementHolderGroup
+            (fun _ _ _ -> ())
+                    
+    /// Update the selected items in a SelectableItemsView control, given previous and current indexes
+    let inline updateSelectableItemsViewSelectedItems (prevCollOptOpt: int[] option voption) (collOptOpt: int[] option voption) (target: SelectableItemsView) = 
+        let prevCollOpt = match prevCollOptOpt with ValueNone | ValueSome None -> ValueNone | ValueSome (Some x) -> ValueSome x
+        let collOpt = match collOptOpt with ValueNone | ValueSome None -> ValueNone | ValueSome (Some x) -> ValueSome x
+        let targetColl = getCollection<obj> target.SelectedItems (fun oc -> target.SelectedItems <- oc)
+        
+        let findItem idx =
+            let itemsSource = target.ItemsSource :?> IList<ViewElementHolder>
+            itemsSource.[idx] :> obj
+        
+        updateItems prevCollOpt collOpt targetColl (fun _ -> ValueNone) (fun x y -> x = y) findItem (fun _ _ _ -> ()) (fun _ _ _ -> ())

--- a/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/ViewExtensions.fs
+++ b/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/ViewExtensions.fs
@@ -58,8 +58,6 @@ module ViewExtensions =
             let prevCollOpt = match prevOpt with ValueNone -> ValueNone | ValueSome prev -> prev.TryGetAttributeKeyed<_>(attribKey)
             let collOpt = source.TryGetAttributeKeyed<_>(attribKey)
             
-            updateCollectionGeneric
+            ChildrenUpdaters.updateChildren
                 (ValueOption.map Seq.toArray prevCollOpt) (ValueOption.map Seq.toArray collOpt) targetCollection 
-                (fun x -> x.Create() :?> 'T) (fun _ _ _ -> ()) ViewHelpers.canReuseView ViewHelpers.tryGetKey
-                updateChild
-
+                (fun x -> x.Create() :?> 'T) ChildrenUpdaters.updateChild (fun _ _ _ -> ())

--- a/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/ViewUpdaters.fs
+++ b/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/ViewUpdaters.fs
@@ -9,7 +9,7 @@ open Xamarin.Forms
 open Xamarin.Forms.StyleSheets
 open System.Windows.Input
 
-[<AutoOpen>]
+/// This module contains custom update logic for all kind of properties
 module ViewUpdaters =        
     // Update a DataTemplate property taking a direct ViewElement
     let private updateDirectViewElementDataTemplate setValue clearValue getTarget prevValueOpt currValueOpt =

--- a/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/ViewUpdaters.fs
+++ b/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/ViewUpdaters.fs
@@ -5,17 +5,12 @@ open System
 open Fabulous
 open System.Collections.ObjectModel
 open System.Collections.Generic
-open System.Diagnostics
 open Xamarin.Forms
 open Xamarin.Forms.StyleSheets
 open System.Windows.Input
 
 [<AutoOpen>]
-module ViewUpdaters =
-    /// Update a control given the previous and new view elements
-    let inline updateChild (prevChild:ViewElement) (newChild:ViewElement) targetChild = 
-        newChild.UpdateIncremental(prevChild, targetChild)
-        
+module ViewUpdaters =        
     // Update a DataTemplate property taking a direct ViewElement
     let private updateDirectViewElementDataTemplate setValue clearValue getTarget prevValueOpt currValueOpt =
         match prevValueOpt, currValueOpt with
@@ -29,250 +24,6 @@ module ViewUpdaters =
             if target <> null then currValue.UpdateIncremental(prevValue, target)            
         | ValueSome _, ValueNone ->
             clearValue ()
-           
-    /// Incremental list maintenance: given a collection, and a previous version of that collection, perform
-    /// a reduced number of clear/move/create/update/remove operations
-    ///
-    /// The algorithm will try in priority to update elements sharing the same instance (usually achieved with dependsOn)
-    /// or sharing the same key. All other elements will try to reuse previous elements where possible.
-    /// If no reuse is possible, the element will create a new control.
-    let updateCollectionGenericInternal
-            (prevCollOpt: 'T[] voption)
-            (collOpt: 'T[] voption)
-            (keyOf: 'T -> string voption)
-            (canReuse: 'T -> 'T -> bool)
-            (clear: unit -> unit)
-            (create: int -> 'T -> unit)
-            (update: int -> 'T -> 'T -> unit)
-            (move: int -> int -> unit)
-            (remove: int -> unit) =
-        
-        match prevCollOpt, collOpt with
-        | ValueNone, ValueNone -> ()
-        | ValueSome prevColl, ValueSome newColl when identical prevColl newColl -> ()
-        | ValueSome prevColl, ValueSome newColl when prevColl <> null && newColl <> null && prevColl.Length = 0 && newColl.Length = 0 -> ()
-        | ValueSome _, ValueNone -> clear ()
-        | ValueSome _, ValueSome coll when (coll = null || coll.Length = 0) -> clear ()
-        | _, ValueSome coll ->
-            let currentState = match prevCollOpt with ValueSome x -> List(x) | _ -> List()
-                
-            let create newIndex newChild =
-                currentState.Insert(newIndex, newChild)
-                create newIndex newChild
-                
-            let move prevIndex newIndex =
-                let child = currentState.[prevIndex]
-                currentState.RemoveAt(prevIndex)
-                currentState.Insert(newIndex, child)
-                move prevIndex newIndex
-                
-            let remove index =
-                currentState.RemoveAt(index)
-                remove index
-            
-            // Separate the previous elements into 3 lists
-            // The ones whose instances have been reused (dependsOn)
-            // The ones whose keys have been reused
-            // The rest which can be reused by any other element
-            let identicalElements = HashSet<'T>()
-            let keyedElements = Dictionary<string, 'T>()
-            let reusableElements = ResizeArray<'T>()
-            if prevCollOpt.IsSome then
-                for prevChild in prevCollOpt.Value do
-                    if coll |> Array.exists (identical prevChild) then
-                        identicalElements.Add(prevChild) |> ignore
-                    else
-                        let canReuseChildOf key =
-                            coll
-                            |> Array.exists (fun newChild ->
-                                keyOf newChild = ValueSome key
-                                && canReuse prevChild newChild
-                            )
-                        
-                        match keyOf prevChild with
-                        | ValueSome key when canReuseChildOf key ->
-                            keyedElements.Add(key, prevChild)
-                        | _ ->
-                            reusableElements.Add(prevChild)
-            
-            // Reuse the first element from reusableElements that returns true to canReuse
-            // Otherwise create a new element
-            let reuseOrCreate newIndex newChild =
-                match reusableElements |> Seq.tryFind(fun c -> canReuse c newChild) with
-                | Some prevChild ->
-                    reusableElements.Remove prevChild |> ignore
-                    
-                    let prevIndex = currentState.IndexOf(prevChild)
-                    update prevIndex prevChild newChild
-                            
-                    if prevIndex <> newIndex then
-                        move prevIndex newIndex
-                        
-                | None ->
-                    create newIndex newChild
-            
-            for i in 0 .. coll.Length - 1 do
-                let newChild = coll.[i]
-                
-                // Check if the same instance was reused (dependsOn), if so just move the element to the correct index
-                if identicalElements.Contains(newChild) then
-                    let prevIndex = currentState.IndexOf(newChild)
-                    if prevIndex <> i then
-                        move prevIndex i
-                else
-                    match keyOf newChild with
-                    | ValueSome key ->
-                        // If the key existed previously, reuse the previous element
-                        if keyedElements.ContainsKey(key) then 
-                            let prevChild = keyedElements.[key]
-                            let prevIndex = currentState.IndexOf(prevChild)
-                            update prevIndex prevChild newChild
-                            
-                            if prevIndex <> i then
-                                move prevIndex i
-                        
-                        // Otherwise reuse an old element if possible or create a new one
-                        else
-                            reuseOrCreate i newChild
-                    
-                    | ValueNone ->
-                        // Reuse an old element if possible, otherwise create a new one
-                        reuseOrCreate i newChild
-            
-            // If we still have old elements that were not reused, delete them
-            if reusableElements.Count > 0 then
-                for remainingElement in reusableElements do
-                    let prevIndex = currentState.IndexOf(remainingElement)
-                    remove prevIndex
-
-    /// Incremental list maintenance: given a collection, and a previous version of that collection, perform
-    /// a reduced number of clear/add/remove/insert operations
-    let updateCollectionGeneric
-           (prevCollOpt: 'T[] voption) 
-           (collOpt: 'T[] voption) 
-           (targetColl: IList<'TargetT>) 
-           (create: 'T -> 'TargetT)
-           (attach: 'T voption -> 'T -> 'TargetT -> unit) // adjust attached properties
-           (canReuse : 'T -> 'T -> bool) // Used to check if reuse is possible
-           (keyOf:'T -> string voption)
-           (update: 'T -> 'T -> 'TargetT -> unit) // Incremental element-wise update, only if element reuse is allowed
-        =
-        
-        let create index child =
-            let targetChild = create child
-            attach ValueNone child targetChild
-            targetColl.Insert(index, targetChild)
-            
-        let update index prevChild newChild =
-            let targetChild = targetColl.[index]
-            update prevChild newChild targetChild
-            attach (ValueSome prevChild) newChild targetChild
-            
-        let move prevIndex newIndex =
-            let targetChild = targetColl.[prevIndex]
-            targetColl.RemoveAt(prevIndex)
-            targetColl.Insert(newIndex, targetChild)
-        
-        updateCollectionGenericInternal
-            prevCollOpt
-            collOpt
-            keyOf
-            canReuse
-            (fun () -> targetColl.Clear())
-            create
-            update
-            move
-            (fun index -> targetColl.RemoveAt(index))
-                    
-    /// Update the items in a ItemsView control, given previous and current view elements
-    let updateItemsViewItems (prevCollOpt: ViewElement array voption) (collOpt: ViewElement array voption) (target: Xamarin.Forms.ItemsView) = 
-        let targetColl = 
-            match target.ItemsSource with 
-            | :? ObservableCollection<ViewElementHolder> as oc -> oc
-            | _ -> 
-                let oc = ObservableCollection<ViewElementHolder>()
-                target.ItemsSource <- oc
-                oc
-        updateCollectionGeneric
-            prevCollOpt collOpt targetColl
-            ViewElementHolder (fun _ _ _ -> ()) ViewHelpers.canReuseView ViewHelpers.tryGetKey
-            (fun _ curr holder -> holder.ViewElement <- curr)
-                    
-    /// Update the items in a ItemsView<'T> control, given previous and current view elements
-    let updateItemsViewOfTItems<'T when 'T :> Xamarin.Forms.BindableObject> (prevCollOpt: ViewElement array voption) (collOpt: ViewElement array voption) (target: Xamarin.Forms.ItemsView<'T>) = 
-        let targetColl = 
-            match target.ItemsSource with 
-            | :? ObservableCollection<ViewElementHolder> as oc -> oc
-            | _ -> 
-                let oc = ObservableCollection<ViewElementHolder>()
-                target.ItemsSource <- oc
-                oc
-        updateCollectionGeneric
-            prevCollOpt collOpt targetColl
-            ViewElementHolder (fun _ _ _ -> ()) ViewHelpers.canReuseView ViewHelpers.tryGetKey
-            (fun _ curr holder -> holder.ViewElement <- curr)
-                    
-    /// Update the selected items in a SelectableItemsView control, given previous and current indexes
-    let updateSelectableItemsViewSelectedItems (prevCollOptOpt: int array option voption) (collOptOpt: int array option voption) (target: Xamarin.Forms.SelectableItemsView) = 
-        let targetColl = 
-            match target.SelectedItems with 
-            | :? ObservableCollection<obj> as oc -> oc
-            | _ -> 
-                let oc = ObservableCollection<obj>()
-                target.SelectedItems <- oc
-                oc
-                
-        let convert = ValueOption.bind (function None -> ValueNone | Some x -> ValueSome x)
-        let prevCollOpt = convert prevCollOptOpt
-        let collOpt = convert collOptOpt
-        
-        let findItem idx =
-            let itemsSource = target.ItemsSource :?> System.Collections.Generic.IList<ViewElementHolder>
-            itemsSource.[idx] :> obj
-        
-        updateCollectionGeneric
-            prevCollOpt collOpt targetColl
-            findItem (fun _ _ _ -> ()) (fun x y -> x = y) (fun _ -> ValueNone)
-            (fun _ _ _ -> ())
-        
-    /// Update the items in a SearchHandler control, given previous and current view elements
-    let updateSearchHandlerItems (prevCollOpt: ViewElement array voption) (collOpt: ViewElement array voption) (target: Xamarin.Forms.SearchHandler) = 
-        let targetColl = 
-            match target.ItemsSource with 
-            | :? ObservableCollection<ViewElementHolder> as oc -> oc
-            | _ -> 
-                let oc = ObservableCollection<ViewElementHolder>()
-                target.ItemsSource <- oc
-                oc
-
-        updateCollectionGeneric
-            prevCollOpt collOpt targetColl
-            ViewElementHolder (fun _ _ _ -> ()) ViewHelpers.canReuseView ViewHelpers.tryGetKey
-            (fun _ curr holder -> holder.ViewElement <- curr)
-        
-    let private updateViewElementHolderGroup (_prevShortName: string, _prevKey, prevColl: ViewElement[]) (currShortName: string, currKey, currColl: ViewElement[]) (target: ViewElementHolderGroup) =
-        target.ShortName <- currShortName
-        target.ViewElement <- currKey
-
-        updateCollectionGeneric
-            (ValueSome prevColl) (ValueSome currColl) target
-            ViewElementHolder (fun _ _ _ -> ()) ViewHelpers.canReuseView ViewHelpers.tryGetKey
-            (fun _ curr target -> target.ViewElement <- curr) 
-
-    /// Update the items in a GroupedListView control, given previous and current view elements
-    let updateListViewGroupedItems (prevCollOpt: (string * ViewElement * ViewElement[])[] voption) (collOpt: (string * ViewElement * ViewElement[])[] voption) (target: Xamarin.Forms.ListView) = 
-        let targetColl = 
-            match target.ItemsSource with 
-            | :? ObservableCollection<ViewElementHolderGroup> as oc -> oc
-            | _ -> 
-                let oc = ObservableCollection<ViewElementHolderGroup>()
-                target.ItemsSource <- oc
-                oc
-                
-        updateCollectionGeneric
-            prevCollOpt collOpt targetColl
-            ViewElementHolderGroup (fun _ _ _ -> ()) (fun (_, prevKey, _) (_, currKey, _) -> ViewHelpers.canReuseView prevKey currKey) (fun _-> ValueNone)
-            updateViewElementHolderGroup
 
     /// Update the ShowJumpList property of a GroupedListView control, given previous and current view elements
     let updateListViewGroupedShowJumpList (prevOpt: bool voption) (currOpt: bool voption) (target: Xamarin.Forms.ListView) =
@@ -284,16 +35,6 @@ module ViewUpdaters =
         | ValueSome prev, ValueSome curr when prev <> curr -> updateTarget curr
         | ValueSome _, ValueNone -> target.GroupShortNameBinding <- null
         | _, _ -> ()
-
-    /// Update the items of a TableSectionBase<'T> control, given previous and current view elements
-    let updateTableSectionBaseOfTItems<'T when 'T :> Xamarin.Forms.BindableObject> (prevCollOpt: ViewElement array voption) (collOpt: ViewElement array voption) (target: Xamarin.Forms.TableSectionBase<'T>) _ =
-        let create (desc: ViewElement) =
-            desc.Create() :?> 'T
-        
-        updateCollectionGeneric
-            prevCollOpt collOpt target
-            create (fun _ _ _ -> ()) ViewHelpers.canReuseView ViewHelpers.tryGetKey
-            updateChild
 
     /// Update the resources of a control, given previous and current view elements describing the resources
     let updateResources (prevCollOpt: (string * obj) array voption) (collOpt: (string * obj) array voption) (target: Xamarin.Forms.VisualElement) = 
@@ -437,7 +178,7 @@ module ViewUpdaters =
                             else
                                 printfn "Adjust page number %d" i
                                 let targetChild = target.Pages |> Seq.item i
-                                updateChild prevChildOpt.Value newChild targetChild
+                                newChild.UpdateIncremental(prevChildOpt.Value, targetChild)
                                 prevChildOpt, targetChild
                         else
                             //printfn "Skipping child %d" i
@@ -536,73 +277,6 @@ module ViewUpdaters =
         | ValueSome prevVal, ValueSome newVal when prevVal = newVal -> ()
         | _, ValueNone -> target.ClearValue Xamarin.Forms.MenuItem.AcceleratorProperty
         | _, ValueSome newVal -> Xamarin.Forms.MenuItem.SetAccelerator(target, Xamarin.Forms.Accelerator.FromString newVal)
-
-    /// Update the items of a Shell, given previous and current view elements
-    let updateShellItems (prevCollOpt: ViewElement array voption) (collOpt: ViewElement array voption) (target: Xamarin.Forms.Shell) _ =
-        let create (desc: ViewElement) =
-            match desc.Create() with
-            | :? ShellContent as shellContent -> ShellItem.op_Implicit shellContent
-            | :? TemplatedPage as templatedPage -> ShellItem.op_Implicit templatedPage
-            | :? ShellSection as shellSection -> ShellItem.op_Implicit shellSection
-            | :? MenuItem as menuItem -> ShellItem.op_Implicit menuItem
-            | :? ShellItem as shellItem -> shellItem
-            | child -> failwithf "%s is not compatible with the type ShellItem" (child.GetType().Name)
-
-        let update prevViewElement (currViewElement: ViewElement) (target: ShellItem) =
-            let realTarget =
-                match currViewElement.TargetType with
-                | t when t = typeof<ShellContent> -> target.Items.[0].Items.[0] :> Element
-                | t when t = typeof<TemplatedPage> -> target.Items.[0].Items.[0] :> Element
-                | t when t = typeof<ShellSection> -> target.Items.[0] :> Element
-                | t when t = typeof<MenuItem> -> target.GetType().GetProperty("MenuItem").GetValue(target) :?> Element // MenuShellItem is marked as internal
-                | _ -> target :> Element
-            updateChild prevViewElement currViewElement realTarget
-
-        updateCollectionGeneric
-            prevCollOpt collOpt target.Items
-            create (fun _ _ _ -> ()) (fun _ _ -> true) ViewHelpers.tryGetKey
-            update
-        
-    /// Update the menu items of a ShellContent, given previous and current view elements
-    let updateShellContentMenuItems (prevCollOpt: ViewElement array voption) (collOpt: ViewElement array voption) (target: Xamarin.Forms.ShellContent) =
-        let create (desc: ViewElement) =
-            desc.Create() :?> Xamarin.Forms.MenuItem
-
-        updateCollectionGeneric
-            prevCollOpt collOpt target.MenuItems
-            create (fun _ _ _ -> ()) (fun _ _ -> true) ViewHelpers.tryGetKey
-            updateChild
-
-    /// Update the items of a ShellItem, given previous and current view elements
-    let updateShellItemItems (prevCollOpt: ViewElement array voption) (collOpt: ViewElement array voption) (target: Xamarin.Forms.ShellItem) _ =
-        let create (desc: ViewElement) =
-            match desc.Create() with
-            | :? ShellContent as shellContent -> ShellSection.op_Implicit shellContent
-            | :? TemplatedPage as templatedPage -> ShellSection.op_Implicit templatedPage
-            | :? ShellSection as shellSection -> shellSection
-            | child -> failwithf "%s is not compatible with the type ShellSection" (child.GetType().Name)
-
-        let update prevViewElement (currViewElement: ViewElement) (target: ShellSection) =
-            let realTarget =
-                match currViewElement.TargetType with
-                | t when t = typeof<ShellContent> -> target.Items.[0] :> BaseShellItem
-                | t when t = typeof<TemplatedPage> -> target.Items.[0] :> BaseShellItem
-                | _ -> target :> BaseShellItem
-            updateChild prevViewElement currViewElement realTarget
-
-        updateCollectionGeneric
-            prevCollOpt collOpt target.Items create (fun _ _ _ -> ()) (fun _ _ -> true) ViewHelpers.tryGetKey
-            update
-
-    /// Update the items of a ShellSection, given previous and current view elements
-    let updateShellSectionItems (prevCollOpt: ViewElement array voption) (collOpt: ViewElement array voption) (target: Xamarin.Forms.ShellSection) _ =
-        let create (desc: ViewElement) =
-            desc.Create() :?> Xamarin.Forms.ShellContent
-
-        updateCollectionGeneric
-            prevCollOpt collOpt target.Items
-            create (fun _ _ _ -> ()) (fun _ _ -> true) ViewHelpers.tryGetKey
-            updateChild
 
     /// Trigger ScrollView.ScrollToAsync if needed, given the current values
     let triggerScrollToAsync _ (currValue: (float * float * AnimationKind) voption) (target: Xamarin.Forms.ScrollView) =
@@ -838,32 +512,6 @@ module ViewUpdaters =
         | ValueNone, ValueNone -> ()
         | _, ValueSome value -> target.SelectionLength <- value
         | ValueSome _, ValueNone -> target.ClearValue Entry.SelectionLengthProperty
-        
-    let updateMenuChildren (prevCollOpt: ViewElement array voption) (currCollOpt: ViewElement array voption) (target: Xamarin.Forms.Menu) _ =
-        updateCollectionGeneric
-            prevCollOpt currCollOpt target
-            (fun _ -> target) (fun _ _ _ -> ()) (fun _ _ -> true) ViewHelpers.tryGetKey
-            updateChild
-        
-    let updateElementEffects (prevCollOpt: ViewElement array voption) (collOpt: ViewElement array voption) (target: Xamarin.Forms.Element) _ =
-        let create (viewElement: ViewElement) =
-            match viewElement.Create() with
-            | :? CustomEffect as customEffect -> Effect.Resolve(customEffect.Name)
-            | effect -> effect :?> Xamarin.Forms.Effect
-
-        updateCollectionGeneric
-            prevCollOpt collOpt target.Effects
-            create (fun _ _ _ -> ()) ViewHelpers.canReuseView ViewHelpers.tryGetKey
-            updateChild
-        
-    let updatePageToolbarItems (prevCollOpt: ViewElement array voption) (collOpt: ViewElement array voption) (target: Xamarin.Forms.Page) _ =
-        let create (viewElement: ViewElement) =
-            viewElement.Create() :?> Xamarin.Forms.ToolbarItem
-        
-        updateCollectionGeneric
-            prevCollOpt collOpt target.ToolbarItems
-            create (fun _ _ _ -> ()) ViewHelpers.canReuseView ViewHelpers.tryGetKey
-            updateChild
 
     let updateElementMenu prevValueOpt (currValueOpt: ViewElement voption) target =
         match prevValueOpt, currValueOpt with
@@ -931,16 +579,7 @@ module ViewUpdaters =
             let handler = getHandler()
             prevValue.ValueChanged.RemoveHandler(handler)
             currValue.ValueChanged.AddHandler(handler)
-            tryLinkIndicatorViewToCarouselView target currValue            
-
-    let updateSwipeItems (prevCollOpt: ViewElement array voption) (collOpt: ViewElement array voption) (target: Xamarin.Forms.SwipeItems) =
-        let create (desc: ViewElement) =
-            desc.Create() :?> Xamarin.Forms.ISwipeItem
-
-        updateCollectionGeneric
-            prevCollOpt collOpt target
-            create (fun _ _ _ -> ()) (fun _ _ -> true) ViewHelpers.tryGetKey
-            updateChild
+            tryLinkIndicatorViewToCarouselView target currValue     
 
     // This function could be automatically generated by CodeGen, but the BindingProperty field StepperPositionProperty is currently marked private, preventing that.
     // See https://github.com/xamarin/Xamarin.Forms/issues/10148

--- a/Fabulous.XamarinForms/src/Fabulous.XamarinForms/Fabulous.XamarinForms.fsproj
+++ b/Fabulous.XamarinForms/src/Fabulous.XamarinForms/Fabulous.XamarinForms.fsproj
@@ -13,6 +13,8 @@
     <Compile Include="..\Fabulous.XamarinForms.Core\Program.fs" />
     <Compile Include="..\Fabulous.XamarinForms.Core\ViewConverters.fs" />
     <Compile Include="..\Fabulous.XamarinForms.Core\ViewUpdaters.fs" />
+    <Compile Include="..\Fabulous.XamarinForms.Core\ChildrenUpdaters.fs" />
+    <Compile Include="..\Fabulous.XamarinForms.Core\ItemsUpdaters.fs" />
     <Compile Include="..\Fabulous.XamarinForms.Core\ViewExtensions.fs" />
     <Compile Include="Xamarin.Forms.Core.fs" />
     <None Include="Xamarin.Forms.Core.json" />

--- a/Fabulous.XamarinForms/src/Fabulous.XamarinForms/Xamarin.Forms.Core.json
+++ b/Fabulous.XamarinForms/src/Fabulous.XamarinForms/Xamarin.Forms.Core.json
@@ -92,7 +92,7 @@
         },
         {
           "source": "Effects",
-          "updateCode": "ViewUpdaters.updateElementEffects",
+          "updateCode": "ChildrenUpdaters.updateElementEffects",
           "collection": {
             "elementType": "Xamarin.Forms.Effect"
           }
@@ -122,7 +122,7 @@
           "source": null,
           "name": "Children",
           "inputType": "ViewElement list",
-          "updateCode": "ViewUpdaters.updateMenuChildren",
+          "updateCode": "ChildrenUpdaters.updateMenuChildren",
           "collection": {
             "elementType": "Xamarin.Forms.Menu"
           }
@@ -665,7 +665,7 @@
         {
           "name": "MenuItems",
           "inputType": "ViewElement list",
-          "updateCode": "ViewUpdaters.updateShellContentMenuItems"
+          "updateCode": "ChildrenUpdaters.updateShellContentMenuItems"
         }
       ],
       "primaryConstructorMembers": [
@@ -690,7 +690,7 @@
         {
           "source": "Items",
           "inputType": "ViewElement list",
-          "updateCode": "ViewUpdaters.updateShellItemItems"
+          "updateCode": "ChildrenUpdaters.updateShellItemItems"
         }
       ],
       "primaryConstructorMembers": [
@@ -718,7 +718,7 @@
         {
           "source": "Items",
           "inputType": "ViewElement list",
-          "updateCode": "ViewUpdaters.updateShellSectionItems"
+          "updateCode": "ChildrenUpdaters.updateShellSectionItems"
         }
       ],
       "primaryConstructorMembers": [
@@ -867,7 +867,7 @@
           "source": null,
           "name": "ToolbarItems",
           "inputType": "ViewElement list",
-          "updateCode": "ViewUpdaters.updatePageToolbarItems",
+          "updateCode": "ChildrenUpdaters.updatePageToolbarItems",
           "collection": {
             "elementType": "Xamarin.Forms.ToolbarItem"
           }
@@ -1108,7 +1108,7 @@
           "source": null,
           "name": "Items",
           "inputType": "ViewElement list",
-          "updateCode": "ViewUpdaters.updateShellItems",
+          "updateCode": "ChildrenUpdaters.updateShellItems",
           "collection": {
             "elementType": "Xamarin.Forms.ShellItem"
           }
@@ -1574,7 +1574,7 @@
           "source": "ItemsSource",
           "shortName": "items",
           "inputType": "ViewElement list",
-          "updateCode": "ViewUpdaters.updateItemsViewItems"
+          "updateCode": "ItemsUpdaters.updateItemsViewItems"
         },
         {
           "source": "RemainingItemsThreshold"
@@ -1691,7 +1691,7 @@
           "inputType": "int list option",
           "modelType": "int array option",
           "convertInputToModel": "(Option.map Array.ofList)",
-          "updateCode": "ViewUpdaters.updateSelectableItemsViewSelectedItems"
+          "updateCode": "ItemsUpdaters.updateSelectableItemsViewSelectedItems"
         },
         {
           "source": "SelectionMode"
@@ -1741,7 +1741,7 @@
           "source": null,
           "name": "Items",
           "inputType": "ViewElement list",
-          "updateCode": "ViewUpdaters.updateItemsViewOfTItems<'T>"
+          "updateCode": "ItemsUpdaters.updateItemsViewOfTItems<'T>"
         }
       ]
     },
@@ -1860,7 +1860,7 @@
           "inputType": "(string * ViewElement * ViewElement list) list",
           "modelType": "(string * ViewElement * ViewElement[])[]",
           "convertInputToModel": "(fun es -> es |> Array.ofList |> Array.map (fun (g, e, l) -> (g, e, Array.ofList l)))",
-          "updateCode": "ViewUpdaters.updateListViewGroupedItems"
+          "updateCode": "ItemsUpdaters.updateListViewGroupedItems"
         },
         {
           "source": null,
@@ -2663,7 +2663,7 @@
           "source": "ItemsSource",
           "shortName": "items",
           "inputType": "ViewElement list",
-          "updateCode": "ViewUpdaters.updateSearchHandlerItems"
+          "updateCode": "ItemsUpdaters.updateSearchHandlerItems"
         },
         {
           "source": "Keyboard"
@@ -2750,7 +2750,7 @@
           "source": null,
           "name": "Items",
           "inputType": "ViewElement list",
-          "updateCode": "ViewUpdaters.updateTableSectionBaseOfTItems<'T>",
+          "updateCode": "ChildrenUpdaters.updateTableSectionBaseOfTItems<'T>",
           "collection": {
             "elementType": "'T"
           }
@@ -2844,7 +2844,7 @@
           "source": null,
           "name": "Items",
           "inputType": "ViewElement list",
-          "updateCode": "ViewUpdaters.updateSwipeItems"
+          "updateCode": "ChildrenUpdaters.updateSwipeItems"
         }
       ],
       "events": [

--- a/Fabulous.XamarinForms/tests/Fabulous.XamarinForms.Tests/ChildrenUpdaters/UpdateChildrenInternalTests.fs
+++ b/Fabulous.XamarinForms/tests/Fabulous.XamarinForms.Tests/ChildrenUpdaters/UpdateChildrenInternalTests.fs
@@ -1,4 +1,4 @@
-namespace Fabulous.XamarinForms.Tests.ViewUpdaters
+namespace Fabulous.XamarinForms.Tests.ChildrenUpdaters
 
 open Fabulous
 open System.Collections.Generic
@@ -9,7 +9,7 @@ open FsUnit
 // 1 & 1' means its the same ViewElement (same property values), except it's not the same .NET reference
 // Tx & Ty means its 2 different ViewElement types that can't be reused between themselves (e.g. Label vs Button)
 // 1k/Txk means its a ViewElement with a key value 
-module UpdateCollectionGenericInternalTests =    
+module UpdateChildrenInternalTests =    
     type Operation =
         | Clear
         | Create of index: int * newChild: ViewElement
@@ -36,7 +36,7 @@ module UpdateCollectionGenericInternalTests =
         let mockRemove index =
             operations.Add(Remove index)
        
-        do updateCollectionGenericInternal
+        do ChildrenUpdaters.updateChildrenInternal
                (previousCollection |> ValueOption.map List.toArray)
                (newCollection |> ValueOption.map List.toArray)
                ViewHelpers.tryGetKey

--- a/Fabulous.XamarinForms/tests/Fabulous.XamarinForms.Tests/Fabulous.XamarinForms.Tests.fsproj
+++ b/Fabulous.XamarinForms/tests/Fabulous.XamarinForms.Tests/Fabulous.XamarinForms.Tests.fsproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <Compile Include="ViewHelpersTests.fs" />
     <Compile Include="ViewConvertersTests.fs" />
-    <Compile Include="ViewUpdaters\UpdateCollectionGenericInternalTests.fs" />
+    <Compile Include="ChildrenUpdaters\UpdateChildrenInternalTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" />


### PR DESCRIPTION
Potential fix for #733 
Fixed an issue in `BindableHelpers.onBindingContextChanged` and also separated the collection diffing algorithm into 2 kinds: Children/Items.

The diffing algorithm for Items is less aggressive on reuse to avoid unwanted reordering animation, and will only reorder for same instance or same key, otherwise it only tries to reuse on the same index.

The diffing algorithm for Children will try to reuse all elements, even if the indexes are not matching.