### PR TITLE
Install fabulous-cli locally as part of template

### DIFF
--- a/Fabulous.XamarinForms/templates/content/blank/.config/dotnet-tools.json
+++ b/Fabulous.XamarinForms/templates/content/blank/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fabulous-cli": {
+      "version": "0.54.1",
+      "commands": [
+        "fabulous"
+      ]
+    }
+  }
+}

--- a/Fabulous.XamarinForms/templates/content/blank/.template.config/template.json
+++ b/Fabulous.XamarinForms/templates/content/blank/.template.config/template.json
@@ -47,6 +47,22 @@
   ],
   "defaultName": "App",
   "preferNameDirectory": "true",
+  "postActions": [
+    {
+      "actionId": "3A7C4B45-1F5D-4A30-959A-51B88E82B5D2",
+      "args": {
+        "executable": "dotnet",
+        "args": "tool restore"
+      },
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet tool restore' to install fabulous-cli"
+        }
+      ],
+      "continueOnError": false,
+      "description ": "Restore the fabulous-cli dotnet tool"
+    }
+  ],
   "guids": [
     "99E19497-29A6-4B77-B773-BEC55F9B55DC",
     "8D9F8CF0-E178-402D-8D40-A88B7B5F3D42",

--- a/build.fsx
+++ b/build.fsx
@@ -296,7 +296,7 @@ Target.create "TestTemplatesNuGet" (fun _ ->
         elif Environment.isLinux then " --Android=false --iOS=false"
         else ""
         
-    DotNet.exec id "new fabulous-xf-app" (sprintf "-n %s -lang F# --GTK%s" testAppName extraArgs) |> ignore
+    DotNet.exec id "new fabulous-xf-app" (sprintf "-n %s -lang F# --allow-scripts yes --GTK%s" testAppName extraArgs) |> ignore
 
     // Restore NuGet packages
     let pkgs = Path.GetFullPath(buildDir)


### PR DESCRIPTION
After running `dotnet new fabulous-xf-app`, dotnet will automatically propose to run `dotnet tool restore` so the `dotnet fabulous` is available immediately.