### PR TITLE
Fix attached properties

### DIFF
--- a/Fabulous.CodeGen/src/Fabulous.CodeGen/Generator/CodeGenerator.fs
+++ b/Fabulous.CodeGen/src/Fabulous.CodeGen/Generator/CodeGenerator.fs
@@ -151,7 +151,8 @@ module CodeGenerator =
         // Attached properties updaters
         if data.PropertiesWithAttachedProperties.Length > 0 then
             for p in data.PropertiesWithAttachedProperties do
-                w.printfn "        let update%sAttachedProperties overrideFunc (prevChildOpt: ViewElement voption) (newChild: ViewElement) (targetChild: Xamarin.Forms.BindableObject) =" p.UniqueName
+                let targetChildType = p.CollectionDataElementType |> Option.defaultValue "obj"
+                w.printfn "        let update%sAttachedProperties overrideFunc (prevChildOpt: ViewElement voption) (newChild: ViewElement) (targetChild: %s) =" p.UniqueName targetChildType
                 for ap in p.AttachedProperties do
                     let hasApply = not (System.String.IsNullOrWhiteSpace(ap.ConvertModelToValue)) || not (System.String.IsNullOrWhiteSpace(ap.UpdateCode))
                     let attributeKey = getAttributeKey ap.CustomAttributeKey ap.UniqueName

--- a/Fabulous.CodeGen/src/Fabulous.CodeGen/Generator/CodeGenerator.fs
+++ b/Fabulous.CodeGen/src/Fabulous.CodeGen/Generator/CodeGenerator.fs
@@ -151,7 +151,7 @@ module CodeGenerator =
         // Attached properties updaters
         if data.PropertiesWithAttachedProperties.Length > 0 then
             for p in data.PropertiesWithAttachedProperties do
-                w.printfn "        let update%sAttachedProperties overrideFunc (prevChildOpt: ViewElement voption) (newChild: ViewElement) targetChild =" p.UniqueName
+                w.printfn "        let update%sAttachedProperties overrideFunc (prevChildOpt: ViewElement voption) (newChild: ViewElement) (targetChild: Xamarin.Forms.BindableObject) =" p.UniqueName
                 for ap in p.AttachedProperties do
                     let hasApply = not (System.String.IsNullOrWhiteSpace(ap.ConvertModelToValue)) || not (System.String.IsNullOrWhiteSpace(ap.UpdateCode))
                     let attributeKey = getAttributeKey ap.CustomAttributeKey ap.UniqueName
@@ -177,8 +177,8 @@ module CodeGenerator =
                     else
                         w.printfn "            match prev%sOpt, curr%sOpt with" ap.UniqueName ap.UniqueName
                         w.printfn "            | ValueSome prevChildValue, ValueSome currChildValue when prevChildValue = currChildValue -> ()"
-                        w.printfn "            | _, ValueSome currChildValue -> %s.Set%s(targetChild, %s currChildValue)" data.FullName ap.Name ap.ConvertModelToValue
-                        w.printfn "            | ValueSome _, ValueNone -> %s.Set%s(targetChild, %s)" data.FullName ap.Name ap.DefaultValue
+                        w.printfn "            | _, ValueSome currChildValue -> targetChild.SetValue(%s.%sProperty, %s currChildValue)" data.FullName ap.Name ap.ConvertModelToValue
+                        w.printfn "            | ValueSome _, ValueNone -> targetChild.ClearValue(%s.%sProperty)" data.FullName ap.Name
                         w.printfn "            | _ -> ()"
                         
                     w.printfn "            overrideFunc prevChildOpt newChild targetChild"

--- a/Fabulous.CodeGen/src/Fabulous.CodeGen/Generator/Models.fs
+++ b/Fabulous.CodeGen/src/Fabulous.CodeGen/Generator/Models.fs
@@ -66,6 +66,7 @@ module Models =
     type UpdatePropertyWithAttachedProperties =
         { UniqueName: string
           CustomAttributeKey: string option
+          CollectionDataElementType: string option
           AttachedProperties: UpdateAttachedProperty array }
 
     type UpdateData =

--- a/Fabulous.CodeGen/src/Fabulous.CodeGen/Generator/Preparer.fs
+++ b/Fabulous.CodeGen/src/Fabulous.CodeGen/Generator/Preparer.fs
@@ -101,6 +101,7 @@ module Preparer =
             |> Array.map (fun p ->
                 { UniqueName = p.UniqueName
                   CustomAttributeKey = p.CustomAttributeKey
+                  CollectionDataElementType = p.CollectionData |> Option.map (fun c -> c.ElementType)
                   AttachedProperties =
                      p.CollectionData
                      |> Option.map (fun cd ->


### PR DESCRIPTION
Attached properties like `Grid.Column`, `Grid.ColumnSpan` had invalid default values because Fabulous was using the designated helper (`Grid.SetColumn(child, value)`) that has no "unset" equivalent.

This led to crashes in certain conditions.

So instead, Fabulous will now use directly the BindableProperty field (e.g. `Grid.ColumnProperty`) so it can clear the value if needed.