### PR TITLE
Add ViewRef support in ListView/CollectionView

### DIFF
--- a/Fabulous.XamarinForms/samples/AllControls/AllControls/AllControls.fsproj
+++ b/Fabulous.XamarinForms/samples/AllControls/AllControls/AllControls.fsproj
@@ -39,6 +39,7 @@
       <Compile Include="Samples\UseCases\WebCall.fs" />
       <Compile Include="Samples\UseCases\CollectionsAndLists\InfiniteScrollList.fs" />
       <Compile Include="Samples\UseCases\CollectionsAndLists\InfiniteScrollCollection.fs" />
+      <Compile Include="Samples\UseCases\CollectionsAndLists\ViewRefsCollection.fs" />
       <Compile Include="Samples\Samples.fs" />
       <Compile Include="App.fs" />
       <EmbeddedResource Include="Baboon_Serengeti.jpg" />

--- a/Fabulous.XamarinForms/samples/AllControls/AllControls/Samples/Samples.fs
+++ b/Fabulous.XamarinForms/samples/AllControls/AllControls/Samples/Samples.fs
@@ -147,7 +147,13 @@ module Samples =
                                                    Init = UseCases.InfiniteScrollList.init
                                                    Update = UseCases.InfiniteScrollList.update |> ignoreExternalMsg
                                                    View = UseCases.InfiniteScrollList.view
-                                                   MapToCmd = UseCases.InfiniteScrollList.mapToCmd } |> boxSampleDefinition) ] }
+                                                   MapToCmd = UseCases.InfiniteScrollList.mapToCmd } |> boxSampleDefinition)
+                                            Sample
+                                                ({ Title = "Collection with ViewRefs"
+                                                   Init = UseCases.ViewRefsCollection.init
+                                                   Update = UseCases.ViewRefsCollection.update |> ignoreExternalMsg
+                                                   View = UseCases.ViewRefsCollection.view
+                                                   MapToCmd = UseCases.ViewRefsCollection.mapToCmd } |> boxSampleDefinition) ] }
                                 Sample (createViewOnlyDefinition "CSS Styling" UseCases.CssStyling.view)
                                 Sample (createViewOnlyDefinition "Effects" UseCases.Effects.view)
                                 Sample

--- a/Fabulous.XamarinForms/samples/AllControls/AllControls/Samples/UseCases/CollectionsAndLists/ViewRefsCollection.fs
+++ b/Fabulous.XamarinForms/samples/AllControls/AllControls/Samples/UseCases/CollectionsAndLists/ViewRefsCollection.fs
@@ -1,0 +1,70 @@
+namespace AllControls.Samples.UseCases
+
+open Fabulous
+open Fabulous.XamarinForms
+open Xamarin.Forms
+
+open AllControls.Helpers
+
+module ViewRefsCollection =
+    type Msg =
+        | CheckItem75
+        
+    type CmdMsg = Nothing
+    
+    type Model =
+        { Item75SizeOpt: (int * int) option }
+        
+    let viewRef = ViewRef<Label>()
+        
+    let mapToCmd _ = Cmd.none
+        
+    let init () =
+        { Item75SizeOpt = None }
+        
+    let update msg model =
+        match msg with
+        | CheckItem75 ->
+            let size =
+                match viewRef.TryValue with
+                | None -> None
+                | Some ref -> Some ((int ref.Width), (int ref.Height))
+            { model with Item75SizeOpt = size }, []
+    
+    let view model dispatch =
+        dependsOn (model.Item75SizeOpt) (fun model (item75SizeOpt) -> 
+            View.ContentPage(
+                title = "ViewRefsCollection",
+                content = View.StackLayout([
+                    View.Label(text="ViewRefsCollection:")
+                    View.Button(
+                        text = "Check if Item 75 is alive",
+                        horizontalOptions = LayoutOptions.Center,
+                        command = fun () -> dispatch CheckItem75
+                    )
+                    View.Label(
+                        horizontalOptions = LayoutOptions.Center,
+                        text =
+                            match item75SizeOpt with
+                            | None -> "Item 75 is not alive"
+                            | Some (w, h) -> sprintf "Item 75 is alive. Size: Width = %i; Height = %i" w h
+                    )
+                    View.CollectionView(
+                        horizontalOptions = LayoutOptions.CenterAndExpand,                        
+                        items = [
+                            for i in 1 .. 100 -> 
+                                dependsOn i (fun _ i ->
+                                    View.Label(
+                                        ?ref = (if i = 75 then Some viewRef else None),
+                                        text = "Item " + string i,
+                                        textColor = randomColor(),
+                                        height = 30.,
+                                        verticalTextAlignment = TextAlignment.Center
+                                    )
+                                )
+                        ]
+                    )
+                ])
+            )
+        )
+

--- a/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/CustomControls.fs
+++ b/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/CustomControls.fs
@@ -59,6 +59,16 @@ type ViewElementHolderGroup(shortName: string, viewElement: ViewElement, items: 
     member __.Items = items
 
 module BindableHelpers =
+    let private setRef (viewElement: ViewElement) (target: obj) =
+        match viewElement.TryGetAttributeKeyed(ViewElement.RefAttribKey) with
+        | ValueSome f -> f.Set (box target)
+        | ValueNone -> ()
+        
+    let private unsetRef (viewElement: ViewElement) =
+        match viewElement.TryGetAttributeKeyed(ViewElement.RefAttribKey) with
+        | ValueSome f -> f.Unset ()
+        | ValueNone -> ()
+    
     let createOnBindingContextChanged (bindableObject: BindableObject) =
         let mutable holderOpt : IViewElementHolder voption = ValueNone
         let mutable prevModelOpt : ViewElement voption = ValueNone
@@ -67,6 +77,7 @@ module BindableHelpers =
             match args.PropertyName, holderOpt, prevModelOpt with
             | "ViewElement", ValueSome holder, ValueSome prevModel ->
                 holder.ViewElement.UpdateIncremental (prevModel, bindableObject)
+                setRef holder.ViewElement bindableObject
                 prevModelOpt <- ValueSome holder.ViewElement
             | _ -> ()
         )
@@ -74,12 +85,15 @@ module BindableHelpers =
         let onBindingContextChanged () =
             match holderOpt with
             | ValueNone -> ()
-            | ValueSome prevHolder -> prevHolder.PropertyChanged.RemoveHandler onDataPropertyChanged
+            | ValueSome prevHolder ->
+                prevHolder.PropertyChanged.RemoveHandler onDataPropertyChanged
+                unsetRef prevHolder.ViewElement
             
             match bindableObject.BindingContext with
             | :? IViewElementHolder as newHolder ->
                 newHolder.PropertyChanged.AddHandler onDataPropertyChanged
                 newHolder.ViewElement.UpdateInherited(prevModelOpt, newHolder.ViewElement, bindableObject)
+                setRef newHolder.ViewElement bindableObject
                 holderOpt <- ValueSome newHolder
                 prevModelOpt <- ValueSome newHolder.ViewElement
             | _ ->

--- a/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/CustomControls.fs
+++ b/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/CustomControls.fs
@@ -76,6 +76,7 @@ module BindableHelpers =
         let onDataPropertyChanged = PropertyChangedEventHandler(fun _ args ->
             match args.PropertyName, holderOpt, prevModelOpt with
             | "ViewElement", ValueSome holder, ValueSome prevModel ->
+                unsetRef prevModel
                 holder.ViewElement.UpdateIncremental (prevModel, bindableObject)
                 setRef holder.ViewElement bindableObject
                 prevModelOpt <- ValueSome holder.ViewElement

--- a/src/Fabulous/ViewElement.fs
+++ b/src/Fabulous/ViewElement.fs
@@ -73,6 +73,10 @@ type ViewRef() =
         handle.SetTarget(target)
         valueChanged.Trigger(target) 
 
+    member __.Unset() : unit = 
+        handle.SetTarget(null)
+        valueChanged.Trigger(null) 
+
     member __.TryValue = 
         match handle.TryGetTarget() with 
         | true, null -> None


### PR DESCRIPTION
Closes #653 

This PR adds support for ViewRef in ListView/CollectionView.
It is now possible to retrieve the actual XF instance of a cell with `ViewRef`.
```fs
let secondLabelRef = ViewRef<Label>()

View.CollectionView([
    View.Label()
    View.Label(ref = secondLabelRef)
    View.Label()
])
```

Note that `created` is not supported and won't be in the future, the reason is the list is virtualized so XF works with a small set of cells and automatically reuses them when scrolling. Hence there is no specific moment when the second label is "created".