### PR TITLE
Update views-navigation.md

### DIFF
--- a/docs/Fabulous.XamarinForms/views-navigation.md
+++ b/docs/Fabulous.XamarinForms/views-navigation.md
@@ -61,6 +61,15 @@ type Model =
 type Msg =
     | ...
     | ShowAbout of bool
+    
+let update msg model =
+    match msg with
+    | ...
+    | ShowAbout status ->       
+        if status then 
+            { model with ShowAbout = true }, Cmd.none    
+        else 
+            { model with ShowAbout = false }, Cmd.none   
 
 let view model dispatch =
     ...
@@ -72,14 +81,14 @@ let view model dispatch =
             content= View.StackLayout(
                 children = [
                     View.Label(text = "Fabulous!")
-                    View.Button(text = "Continue", command = (fun () -> dispatch (ShowAbout false) ))
+                    View.Button(text = "Continue", command = (fun args -> dispatch (ShowAbout false) ))
                 ]))
 
     View.NavigationPage(pages=
         [ yield rootPage dispatch
           if model.ShowAbout then
               yield modalPage dispatch
-        ])
+        ], popped = fun args -> dispatch (ShowAbout false))
 ```
 
 ### TabbedPage navigation

--- a/docs/Fabulous.XamarinForms/views-navigation.md
+++ b/docs/Fabulous.XamarinForms/views-navigation.md
@@ -81,7 +81,7 @@ let view model dispatch =
             content= View.StackLayout(
                 children = [
                     View.Label(text = "Fabulous!")
-                    View.Button(text = "Continue", command = (fun args -> dispatch (ShowAbout false) ))
+                    View.Button(text = "Continue", command = (fun () -> dispatch (ShowAbout false) ))
                 ]))
 
     View.NavigationPage(pages=


### PR DESCRIPTION
Without the added "| ShowAbout status ->" the modal page won't show up. 
Without the added "popped = fun args -> dispatch (ShowAbout false)" using the back button (hardware or navigation) will cause every other dispatch call to re-push the "About" page.