### PR TITLE
Fix FSharp.Core warnings on UWP samples

### DIFF
--- a/Fabulous.StaticView/samples/StaticViewCounterApp/UWP/StaticViewCounterApp.UWP.csproj
+++ b/Fabulous.StaticView/samples/StaticViewCounterApp/UWP/StaticViewCounterApp.UWP.csproj
@@ -2,6 +2,7 @@
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
+    <IsPackable>false</IsPackable>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProjectGuid>{707CFDB4-4AF2-4082-8F29-B1127974BD0F}</ProjectGuid>

--- a/Fabulous.XamarinForms/samples/AllControls/UWP/AllControls.UWP.csproj
+++ b/Fabulous.XamarinForms/samples/AllControls/UWP/AllControls.UWP.csproj
@@ -2,6 +2,7 @@
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
+    <IsPackable>false</IsPackable>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProjectGuid>{6641E98C-A57A-4710-9B52-966C7A2618FD}</ProjectGuid>

--- a/Fabulous.XamarinForms/samples/Calculator/UWP/Calculator.UWP.csproj
+++ b/Fabulous.XamarinForms/samples/Calculator/UWP/Calculator.UWP.csproj
@@ -2,6 +2,7 @@
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
+    <IsPackable>false</IsPackable>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProjectGuid>{E9603EAD-114B-4AB6-A9D7-135B206BEC18}</ProjectGuid>

--- a/Fabulous.XamarinForms/samples/CounterApp/UWP/CounterApp.UWP.csproj
+++ b/Fabulous.XamarinForms/samples/CounterApp/UWP/CounterApp.UWP.csproj
@@ -2,6 +2,7 @@
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
+    <IsPackable>false</IsPackable>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProjectGuid>{DE0EC9B1-B7F0-4B11-864D-5FE821A0E6A7}</ProjectGuid>

--- a/Fabulous.XamarinForms/samples/FabulousWeather/UWP/FabulousWeather.UWP.csproj
+++ b/Fabulous.XamarinForms/samples/FabulousWeather/UWP/FabulousWeather.UWP.csproj
@@ -2,6 +2,7 @@
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
+    <IsPackable>false</IsPackable>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProjectGuid>{EA10B4EC-0F47-4DB6-A2E6-D726AECD5E1A}</ProjectGuid>

--- a/Fabulous.XamarinForms/samples/LoginShape/UWP/LoginShape.UWP.csproj
+++ b/Fabulous.XamarinForms/samples/LoginShape/UWP/LoginShape.UWP.csproj
@@ -2,6 +2,7 @@
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
+    <IsPackable>false</IsPackable>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProjectGuid>{4F929009-1997-4BCB-A490-8870FC409BED}</ProjectGuid>

--- a/Fabulous.XamarinForms/samples/ShapesDemo/UWP/ShapesDemo.UWP.csproj
+++ b/Fabulous.XamarinForms/samples/ShapesDemo/UWP/ShapesDemo.UWP.csproj
@@ -2,6 +2,7 @@
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
+    <IsPackable>false</IsPackable>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProjectGuid>{D844F7AD-2860-4D92-8D53-B0017D62FC1F}</ProjectGuid>

--- a/Fabulous.XamarinForms/samples/TicTacToe/UWP/TicTacToe.UWP.csproj
+++ b/Fabulous.XamarinForms/samples/TicTacToe/UWP/TicTacToe.UWP.csproj
@@ -2,6 +2,7 @@
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
+    <IsPackable>false</IsPackable>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProjectGuid>{F29D5D09-1D84-4617-A650-80E6E2C58890}</ProjectGuid>


### PR DESCRIPTION
UWP projects were complaining because they used the fixed FSharp.Core 4.7.0 of the Fabulous projects while the shared projects used FSharp.Core 4.7.2.
This PR makes UWP projects use FSharp.Core 4.7.2 too.