### PR TITLE
Fix: Add native main menu to MacOS template

### DIFF
--- a/Fabulous.XamarinForms/templates/content/blank/NewApp.macOS/AppDelegate.fs
+++ b/Fabulous.XamarinForms/templates/content/blank/NewApp.macOS/AppDelegate.fs
@@ -19,6 +19,7 @@ type AppDelegate() =
 
     override this.DidFinishLaunching(notification: NSNotification) =
         Forms.Init()
+        this.SetupNativeMenu()
         this.LoadApplication(new NewApp.App())
 
         base.DidFinishLaunching(notification)
@@ -28,6 +29,21 @@ type AppDelegate() =
         ()
         
     override __.ApplicationShouldTerminateAfterLastWindowClosed(_) = true        
+
+    member this.SetupNativeMenu() =
+        let menuBar = new NSMenu()
+        let appMenuItem = new NSMenuItem()
+        menuBar.AddItem(appMenuItem)
+        
+        let appMenu = new NSMenu()
+        appMenuItem.Submenu <- appMenu
+        
+        let quitMenuItem = new NSMenuItem(sprintf "Quit %s" window.Title, "q", EventHandler(fun _ _ ->
+            NSApplication.SharedApplication.Terminate(menuBar)
+        ))
+        appMenu.AddItem(quitMenuItem)
+            
+        NSApplication.SharedApplication.MainMenu <- menuBar
 
 module EntryClass = 
     [<EntryPoint>]

--- a/docs/Fabulous.XamarinForms/update.md
+++ b/docs/Fabulous.XamarinForms/update.md
@@ -297,7 +297,7 @@ match model.IsLoggedIn with
 Platform-specific dispatch
 -----
 
-Some platform-specific features (like deep linking, memory warnings, ...) are not available in Xamarin.Forms, and need you to implement them in the corresponding app projet.  
+Some platform-specific features (like deep linking, memory warnings, ...) are not available in Xamarin.Forms, and need you to implement them in the corresponding app project.  
 In this case, you might want to dispatch a message from the app project to Fabulous to start a shared logic between platforms (to warn user, ...).
 
 To allow for this kind of use case, the `dispatch` function is exposed as a `Dispatch(msg)` method by the `ProgramRunner`. By default this runner is not accessible, but you can make a read-only property to let apps access it.


### PR DESCRIPTION
fix #696 

@TimLariviere I also fixed a typo in the docs `update.md`