### PR TITLE
Better handling of corner cases of Label.Text/Label.FormattedText

### DIFF
--- a/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/InputTypes.fs
+++ b/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/InputTypes.fs
@@ -120,3 +120,14 @@ module InputTypes =
         let fromString str = Text str
         /// An element used as content
         let fromElement viewElement = ViewElement viewElement
+        
+    /// Represents a text value for Xamarin.Forms.Label
+    module LabelText =
+        type Value =
+            | PlainString of string
+            | FormattedString of ViewElement
+            
+        /// Use a plain string
+        let fromString str = PlainString str
+        /// Use a formatted string
+        let fromFormattedString viewElement = FormattedString viewElement

--- a/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/ViewUpdaters.fs
+++ b/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/ViewUpdaters.fs
@@ -704,22 +704,22 @@ module ViewUpdaters =
     /// Update the Label Text/FormattedText properties in a single pass.
     /// We need to do this because Xamarin.Forms automatically sets to null the one property when the other is setted.
     /// To can lead to unexpected states that can crash the application
-    let updateLabelText (prevFormattedTextOpt: Fabulous.XamarinForms.InputTypes.LabelText.Value voption) (currFormattedTextOpt: Fabulous.XamarinForms.InputTypes.LabelText.Value voption) (prevValueOpt: Fabulous.XamarinForms.InputTypes.LabelText.Value voption) (currValueOpt: Fabulous.XamarinForms.InputTypes.LabelText.Value voption) (target: Xamarin.Forms.Label) =
+    let updateLabelText (prevFormattedTextOpt: ViewElement voption) (currFormattedTextOpt: ViewElement voption) (prevValueOpt: string voption) (currValueOpt: string voption) (target: Xamarin.Forms.Label) =
         // IMPORTANT NOTE: In case the user provided both Text and FormattedText, we favor the FormattedText value
         
         let prevOpt =
             match struct (prevValueOpt, prevFormattedTextOpt) with
             | struct (ValueNone, ValueNone) -> ValueNone
-            | struct (ValueSome prev, ValueNone) -> ValueSome prev
-            | struct (ValueNone, ValueSome prev) -> ValueSome prev
-            | struct (ValueSome _, ValueSome prev) -> ValueSome prev
+            | struct (ValueSome prev, ValueNone) -> ValueSome (LabelText.fromString prev)
+            | struct (ValueNone, ValueSome prev) -> ValueSome (LabelText.fromFormattedString prev)
+            | struct (ValueSome _, ValueSome prev) -> ValueSome (LabelText.fromFormattedString prev)
             
         let currOpt =
             match struct (currValueOpt, currFormattedTextOpt) with
             | struct (ValueNone, ValueNone) -> ValueNone
-            | struct (ValueSome curr, ValueNone) -> ValueSome curr
-            | struct (ValueNone, ValueSome curr) -> ValueSome curr
-            | struct (ValueSome _, ValueSome curr) -> ValueSome curr
+            | struct (ValueSome curr, ValueNone) -> ValueSome (LabelText.fromString curr)
+            | struct (ValueNone, ValueSome curr) -> ValueSome (LabelText.fromFormattedString curr)
+            | struct (ValueSome _, ValueSome curr) -> ValueSome (LabelText.fromFormattedString curr)
         
         match struct (prevOpt, currOpt) with
         | struct (ValueNone, ValueNone) -> ()

--- a/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/ViewUpdaters.fs
+++ b/Fabulous.XamarinForms/src/Fabulous.XamarinForms.Core/ViewUpdaters.fs
@@ -700,3 +700,45 @@ module ViewUpdaters =
     /// Update the points of a PolyQuadraticBezierSegment, given previous and current view elements
     let inline updatePolyQuadraticBezierSegmentPoints prevOpt currOpt (target: PolyQuadraticBezierSegment) =
         updatePoints target PolyQuadraticBezierSegment.PointsProperty prevOpt currOpt
+        
+    /// Update the Label Text/FormattedText properties in a single pass.
+    /// We need to do this because Xamarin.Forms automatically sets to null the one property when the other is setted.
+    /// To can lead to unexpected states that can crash the application
+    let updateLabelText (prevFormattedTextOpt: Fabulous.XamarinForms.InputTypes.LabelText.Value voption) (currFormattedTextOpt: Fabulous.XamarinForms.InputTypes.LabelText.Value voption) (prevValueOpt: Fabulous.XamarinForms.InputTypes.LabelText.Value voption) (currValueOpt: Fabulous.XamarinForms.InputTypes.LabelText.Value voption) (target: Xamarin.Forms.Label) =
+        // IMPORTANT NOTE: In case the user provided both Text and FormattedText, we favor the FormattedText value
+        
+        let prevOpt =
+            match struct (prevValueOpt, prevFormattedTextOpt) with
+            | struct (ValueNone, ValueNone) -> ValueNone
+            | struct (ValueSome prev, ValueNone) -> ValueSome prev
+            | struct (ValueNone, ValueSome prev) -> ValueSome prev
+            | struct (ValueSome _, ValueSome prev) -> ValueSome prev
+            
+        let currOpt =
+            match struct (currValueOpt, currFormattedTextOpt) with
+            | struct (ValueNone, ValueNone) -> ValueNone
+            | struct (ValueSome curr, ValueNone) -> ValueSome curr
+            | struct (ValueNone, ValueSome curr) -> ValueSome curr
+            | struct (ValueSome _, ValueSome curr) -> ValueSome curr
+        
+        match struct (prevOpt, currOpt) with
+        | struct (ValueNone, ValueNone) -> ()
+        | struct (ValueSome prev, ValueSome curr) when prev = curr -> ()
+        
+        | struct (_, ValueNone) ->
+            target.ClearValue(Label.TextProperty)
+            target.ClearValue(Label.FormattedTextProperty)
+        
+        | struct (ValueNone, ValueSome curr) ->
+            match curr with
+            | LabelText.Value.PlainString text -> target.Text <- text
+            | LabelText.Value.FormattedString viewElement -> target.FormattedText <- viewElement.Create() :?> Xamarin.Forms.FormattedString
+            
+        | struct (ValueSome _, ValueSome (LabelText.Value.PlainString newText)) ->
+            target.Text <- newText
+            
+        | struct (ValueSome (LabelText.Value.FormattedString prevVE), ValueSome (LabelText.Value.FormattedString currVE)) ->
+            currVE.UpdateIncremental(prevVE, target.FormattedText)
+            
+        | struct (ValueSome (LabelText.Value.PlainString _), ValueSome (LabelText.Value.FormattedString currVE)) ->
+            target.FormattedText <- currVE.Create() :?> Xamarin.Forms.FormattedString

--- a/Fabulous.XamarinForms/src/Fabulous.XamarinForms/Xamarin.Forms.Core.json
+++ b/Fabulous.XamarinForms/src/Fabulous.XamarinForms/Xamarin.Forms.Core.json
@@ -2005,8 +2005,6 @@
         {
           "_comment": "Label.FormattedText and Label.Text are handled as one property",
           "source": "FormattedText",
-          "modelType": "Fabulous.XamarinForms.InputTypes.LabelText.Value",
-          "convertInputToModel": "Fabulous.XamarinForms.InputTypes.LabelText.fromFormattedString",
           "updateCode": "(fun _ _ _ -> ())"
         },
         {
@@ -2027,8 +2025,6 @@
         {
           "_comment": "Label.FormattedText and Label.Text are handled as one property",
           "source": "Text",
-          "modelType": "Fabulous.XamarinForms.InputTypes.LabelText.Value",
-          "convertInputToModel": "Fabulous.XamarinForms.InputTypes.LabelText.fromString",
           "updateCode": "ViewUpdaters.updateLabelText prevFormattedTextOpt currFormattedTextOpt"
         },
         {

--- a/Fabulous.XamarinForms/src/Fabulous.XamarinForms/Xamarin.Forms.Core.json
+++ b/Fabulous.XamarinForms/src/Fabulous.XamarinForms/Xamarin.Forms.Core.json
@@ -2003,7 +2003,11 @@
           "convertModelToValue": "ViewConverters.convertFabulousFontSizeToXamarinFormsDouble (target.GetType())"
         },
         {
-          "source": "FormattedText"
+          "_comment": "Label.FormattedText and Label.Text are handled as one property",
+          "source": "FormattedText",
+          "modelType": "Fabulous.XamarinForms.InputTypes.LabelText.Value",
+          "convertInputToModel": "Fabulous.XamarinForms.InputTypes.LabelText.fromFormattedString",
+          "updateCode": "(fun _ _ _ -> ())"
         },
         {
           "source": "HorizontalTextAlignment"
@@ -2021,7 +2025,11 @@
           "source": "Padding"
         },
         {
-          "source": "Text"
+          "_comment": "Label.FormattedText and Label.Text are handled as one property",
+          "source": "Text",
+          "modelType": "Fabulous.XamarinForms.InputTypes.LabelText.Value",
+          "convertInputToModel": "Fabulous.XamarinForms.InputTypes.LabelText.fromString",
+          "updateCode": "ViewUpdaters.updateLabelText prevFormattedTextOpt currFormattedTextOpt"
         },
         {
           "source": "TextColor"

--- a/Fabulous.XamarinForms/tests/Fabulous.XamarinForms.Tests/Fabulous.XamarinForms.Tests.fsproj
+++ b/Fabulous.XamarinForms/tests/Fabulous.XamarinForms.Tests/Fabulous.XamarinForms.Tests.fsproj
@@ -12,6 +12,7 @@
     <Compile Include="Collections\DiffTests.fs" />
     <Compile Include="Collections\AdaptDiffTests.fs" />
     <Compile Include="Collections\UpdateChildrenTests.fs" />
+    <Compile Include="ViewUpdatersTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" />

--- a/Fabulous.XamarinForms/tests/Fabulous.XamarinForms.Tests/ViewUpdatersTests.fs
+++ b/Fabulous.XamarinForms/tests/Fabulous.XamarinForms.Tests/ViewUpdatersTests.fs
@@ -25,7 +25,7 @@ module ViewUpdatersTests =
     [<Test>]
     let ``UpdateLabelText Text None to Some``() =
         let prevTextOpt = ValueNone
-        let currTextOpt = ValueSome (LabelText.fromString "ABC")
+        let currTextOpt = ValueSome "ABC"
         
         let prevFormattedTextOpt = ValueNone
         let currFormattedTextOpt = ValueNone
@@ -39,8 +39,8 @@ module ViewUpdatersTests =
         
     [<Test>]
     let ``UpdateLabelText Text Some to Some``() =
-        let prevTextOpt = ValueSome (LabelText.fromString "ABC")
-        let currTextOpt = ValueSome (LabelText.fromString "DEF")
+        let prevTextOpt = ValueSome "ABC"
+        let currTextOpt = ValueSome "DEF"
         
         let prevFormattedTextOpt = ValueNone
         let currFormattedTextOpt = ValueNone
@@ -58,7 +58,7 @@ module ViewUpdatersTests =
         let currTextOpt = ValueNone
         
         let prevFormattedTextOpt = ValueNone
-        let currFormattedTextOpt = ValueSome (LabelText.fromFormattedString (View.FormattedString(spans = [ View.Span("ABC") ])))
+        let currFormattedTextOpt = ValueSome (View.FormattedString(spans = [ View.Span("ABC") ]))
         
         let target = Label(Text = null, FormattedText = null)
         
@@ -74,8 +74,8 @@ module ViewUpdatersTests =
         let prevTextOpt = ValueNone
         let currTextOpt = ValueNone
         
-        let prevFormattedTextOpt = ValueSome (LabelText.fromFormattedString (View.FormattedString(spans = [ View.Span("ABC") ])))
-        let currFormattedTextOpt = ValueSome (LabelText.fromFormattedString (View.FormattedString(spans = [ View.Span("DEF") ])))
+        let prevFormattedTextOpt = ValueSome (View.FormattedString(spans = [ View.Span("ABC") ]))
+        let currFormattedTextOpt = ValueSome (View.FormattedString(spans = [ View.Span("DEF") ]))
         
         let formattedString = FormattedString()
         formattedString.Spans.Add(Span(Text = "ABC"))
@@ -91,11 +91,11 @@ module ViewUpdatersTests =
         
     [<Test>]
     let ``UpdateLabelText Text Some to FormattedText Some``() =
-        let prevTextOpt = ValueSome (LabelText.fromString "ABC")
+        let prevTextOpt = ValueSome "ABC"
         let currTextOpt = ValueNone
         
         let prevFormattedTextOpt = ValueNone
-        let currFormattedTextOpt = ValueSome (LabelText.fromFormattedString (View.FormattedString(spans = [ View.Span("DEF") ])))
+        let currFormattedTextOpt = ValueSome (View.FormattedString(spans = [ View.Span("DEF") ]))
                 
         let target = Label(Text = "ABC", FormattedText = null)
         
@@ -109,9 +109,9 @@ module ViewUpdatersTests =
     [<Test>]
     let ``UpdateLabelText FormattedText Some to Text Some``() =
         let prevTextOpt = ValueNone
-        let currTextOpt = ValueSome (LabelText.fromString "DEF")
+        let currTextOpt = ValueSome "DEF"
         
-        let prevFormattedTextOpt = ValueSome (LabelText.fromFormattedString (View.FormattedString(spans = [ View.Span("ABC") ])))
+        let prevFormattedTextOpt = ValueSome (View.FormattedString(spans = [ View.Span("ABC") ]))
         let currFormattedTextOpt = ValueNone
         
         let formattedString = FormattedString()
@@ -126,11 +126,11 @@ module ViewUpdatersTests =
         
     [<Test>]
     let ``UpdateLabelText Text/FormattedText Some to Text/FormattedText Some``() =
-        let prevTextOpt = ValueSome (LabelText.fromString "ABC")
-        let currTextOpt = ValueSome (LabelText.fromString "DEF")
+        let prevTextOpt = ValueSome "ABC"
+        let currTextOpt = ValueSome "DEF"
         
-        let prevFormattedTextOpt = ValueSome (LabelText.fromFormattedString (View.FormattedString(spans = [ View.Span("GHI") ])))
-        let currFormattedTextOpt = ValueSome (LabelText.fromFormattedString (View.FormattedString(spans = [ View.Span("JKL") ])))
+        let prevFormattedTextOpt = ValueSome (View.FormattedString(spans = [ View.Span("GHI") ]))
+        let currFormattedTextOpt = ValueSome (View.FormattedString(spans = [ View.Span("JKL") ]))
 
         let formattedString = FormattedString()
         formattedString.Spans.Add(Span(Text = "GHI"))

--- a/Fabulous.XamarinForms/tests/Fabulous.XamarinForms.Tests/ViewUpdatersTests.fs
+++ b/Fabulous.XamarinForms/tests/Fabulous.XamarinForms.Tests/ViewUpdatersTests.fs
@@ -1,0 +1,145 @@
+// Copyright Fabulous contributors. See LICENSE.md for license.
+namespace Fabulous.XamarinForms.Tests
+
+open Fabulous.XamarinForms
+open NUnit.Framework
+open FsUnit
+open Xamarin.Forms
+
+module ViewUpdatersTests =
+    [<Test>]
+    let ``UpdateLabelText All none``() =
+        let prevTextOpt = ValueNone
+        let currTextOpt = ValueNone
+        
+        let prevFormattedTextOpt = ValueNone
+        let currFormattedTextOpt = ValueNone
+        
+        let target = Label(Text = null, FormattedText = null)
+        
+        ViewUpdaters.updateLabelText prevFormattedTextOpt currFormattedTextOpt prevTextOpt currTextOpt target
+        
+        target.Text |> should equal null
+        target.FormattedText |> should equal null
+        
+    [<Test>]
+    let ``UpdateLabelText Text None to Some``() =
+        let prevTextOpt = ValueNone
+        let currTextOpt = ValueSome (LabelText.fromString "ABC")
+        
+        let prevFormattedTextOpt = ValueNone
+        let currFormattedTextOpt = ValueNone
+        
+        let target = Label(Text = null, FormattedText = null)
+        
+        ViewUpdaters.updateLabelText prevFormattedTextOpt currFormattedTextOpt prevTextOpt currTextOpt target
+        
+        target.Text |> should equal "ABC"
+        target.FormattedText |> should equal null
+        
+    [<Test>]
+    let ``UpdateLabelText Text Some to Some``() =
+        let prevTextOpt = ValueSome (LabelText.fromString "ABC")
+        let currTextOpt = ValueSome (LabelText.fromString "DEF")
+        
+        let prevFormattedTextOpt = ValueNone
+        let currFormattedTextOpt = ValueNone
+        
+        let target = Label(Text = "ABC", FormattedText = null)
+        
+        ViewUpdaters.updateLabelText prevFormattedTextOpt currFormattedTextOpt prevTextOpt currTextOpt target
+        
+        target.Text |> should equal "DEF"
+        target.FormattedText |> should equal null
+        
+    [<Test>]
+    let ``UpdateLabelText FormattedText None to Some``() =
+        let prevTextOpt = ValueNone
+        let currTextOpt = ValueNone
+        
+        let prevFormattedTextOpt = ValueNone
+        let currFormattedTextOpt = ValueSome (LabelText.fromFormattedString (View.FormattedString(spans = [ View.Span("ABC") ])))
+        
+        let target = Label(Text = null, FormattedText = null)
+        
+        ViewUpdaters.updateLabelText prevFormattedTextOpt currFormattedTextOpt prevTextOpt currTextOpt target
+        
+        target.Text |> should equal null
+        target.FormattedText |> should not' (equal null)
+        target.FormattedText.Spans.Count |> should equal 1
+        target.FormattedText.Spans.[0].Text |> should equal "ABC"
+        
+    [<Test>]
+    let ``UpdateLabelText FormattedText Some to Some``() =
+        let prevTextOpt = ValueNone
+        let currTextOpt = ValueNone
+        
+        let prevFormattedTextOpt = ValueSome (LabelText.fromFormattedString (View.FormattedString(spans = [ View.Span("ABC") ])))
+        let currFormattedTextOpt = ValueSome (LabelText.fromFormattedString (View.FormattedString(spans = [ View.Span("DEF") ])))
+        
+        let formattedString = FormattedString()
+        formattedString.Spans.Add(Span(Text = "ABC"))
+        
+        let target = Label(Text = null, FormattedText = formattedString)
+        
+        ViewUpdaters.updateLabelText prevFormattedTextOpt currFormattedTextOpt prevTextOpt currTextOpt target
+        
+        target.Text |> should equal null
+        target.FormattedText |> should not' (equal null)
+        target.FormattedText.Spans.Count |> should equal 1
+        target.FormattedText.Spans.[0].Text |> should equal "DEF"
+        
+    [<Test>]
+    let ``UpdateLabelText Text Some to FormattedText Some``() =
+        let prevTextOpt = ValueSome (LabelText.fromString "ABC")
+        let currTextOpt = ValueNone
+        
+        let prevFormattedTextOpt = ValueNone
+        let currFormattedTextOpt = ValueSome (LabelText.fromFormattedString (View.FormattedString(spans = [ View.Span("DEF") ])))
+                
+        let target = Label(Text = "ABC", FormattedText = null)
+        
+        ViewUpdaters.updateLabelText prevFormattedTextOpt currFormattedTextOpt prevTextOpt currTextOpt target
+        
+        target.Text |> should equal null
+        target.FormattedText |> should not' (equal null)
+        target.FormattedText.Spans.Count |> should equal 1
+        target.FormattedText.Spans.[0].Text |> should equal "DEF"
+        
+    [<Test>]
+    let ``UpdateLabelText FormattedText Some to Text Some``() =
+        let prevTextOpt = ValueNone
+        let currTextOpt = ValueSome (LabelText.fromString "DEF")
+        
+        let prevFormattedTextOpt = ValueSome (LabelText.fromFormattedString (View.FormattedString(spans = [ View.Span("ABC") ])))
+        let currFormattedTextOpt = ValueNone
+        
+        let formattedString = FormattedString()
+        formattedString.Spans.Add(Span(Text = "ABC"))
+        
+        let target = Label(Text = null, FormattedText = formattedString)
+        
+        ViewUpdaters.updateLabelText prevFormattedTextOpt currFormattedTextOpt prevTextOpt currTextOpt target
+        
+        target.Text |> should equal "DEF"
+        target.FormattedText |> should equal null
+        
+    [<Test>]
+    let ``UpdateLabelText Text/FormattedText Some to Text/FormattedText Some``() =
+        let prevTextOpt = ValueSome (LabelText.fromString "ABC")
+        let currTextOpt = ValueSome (LabelText.fromString "DEF")
+        
+        let prevFormattedTextOpt = ValueSome (LabelText.fromFormattedString (View.FormattedString(spans = [ View.Span("GHI") ])))
+        let currFormattedTextOpt = ValueSome (LabelText.fromFormattedString (View.FormattedString(spans = [ View.Span("JKL") ])))
+
+        let formattedString = FormattedString()
+        formattedString.Spans.Add(Span(Text = "GHI"))
+        
+        let target = Label(Text = null, FormattedText = formattedString)
+        
+        ViewUpdaters.updateLabelText prevFormattedTextOpt currFormattedTextOpt prevTextOpt currTextOpt target
+        
+        target.Text |> should equal null
+        target.FormattedText |> should not' (equal null)
+        target.FormattedText.Spans.Count |> should equal 1
+        target.FormattedText.Spans.[0].Text |> should equal "JKL"


### PR DESCRIPTION
When using `Label.Text`/`Label.FormattedText`, Xamarin.Forms automatically sets the other property to null.
This can lead to some corner cases where Fabulous has a ViewElement that does not match the real control state.

So to avoid that, the `Text` and `FormattedText` property are handled like only one property.
In case the user provided both `Text` and `FormattedText`, `FormattedText` takes precedence.