### PR TITLE
Fix: AssemblyResolver is used after dispose

### DIFF
--- a/Fabulous.CodeGen/src/Fabulous.CodeGen/AssemblyReader/AssemblyResolver.fs
+++ b/Fabulous.CodeGen/src/Fabulous.CodeGen/AssemblyReader/AssemblyResolver.fs
@@ -36,7 +36,6 @@ module AssemblyResolver =
         resolver.RegisterAssembly assembly
         assembly
 
-    let loadAllAssemblies (paths: seq<string>) =
-        use resolver = new RegistrableResolver()
+    let loadAllAssemblies resolver (paths: seq<string>) =
         let loadAssembly = loadAssembly resolver
         paths |> Seq.toArray |> Array.map loadAssembly

--- a/Fabulous.CodeGen/src/Fabulous.CodeGen/AssemblyReader/Reader.fs
+++ b/Fabulous.CodeGen/src/Fabulous.CodeGen/AssemblyReader/Reader.fs
@@ -127,7 +127,8 @@ module Reader =
             (baseTypeName: string)
             assemblies : WorkflowResult<AssemblyType array> =
         
-        let cecilAssemblies = AssemblyResolver.loadAllAssemblies assemblies
+        use resolver = new AssemblyResolver.RegistrableResolver()
+        let cecilAssemblies = AssemblyResolver.loadAllAssemblies resolver assemblies
         let assemblies = loadAllAssembliesByReflection assemblies
         
         let allTypes = Resolver.getAllTypesFromAssemblies cecilAssemblies


### PR DESCRIPTION
It looks like assemblies in Mono.Cecil are resolved lazily. I am getting the following error:

```
"C:\Program Files\dotnet\dotnet.exe" G:/dev/FSharp/Fabulous.Android/tools/Fabulous.Android.Generator/bin/Debug/netcoreapp3.1/Fabulous.Android.Generator.dll -d true -m G:\dev\FSharp\Fabulous.Android\src\Fabulous.Android\Fabulous.Android.json -o G:\dev\FSharp\Fabulous.Android\src\Fabulous.Android\Fabulous.Android.fs
Unhandled exception. Mono.Cecil.AssemblyResolutionException: Failed to resolve assembly: 'Mono.Android, Version=0.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065'
   at Mono.Cecil.BaseAssemblyResolver.Resolve(AssemblyNameReference name, ReaderParameters parameters)
   at Mono.Cecil.BaseAssemblyResolver.Resolve(AssemblyNameReference name)
   at Fabulous.CodeGen.AssemblyReader.AssemblyResolver.RegistrableResolver.Resolve(AssemblyNameReference name) in G:\dev\FSharp\Fabulous\Fabulous.CodeGen\src\Fabulous.CodeGen\AssemblyReader\AssemblyResolver.fs:line 16
   at Mono.Cecil.MetadataResolver.Resolve(TypeReference type)
   at Mono.Cecil.ModuleDefinition.Resolve(TypeReference type)
   at Mono.Cecil.TypeReference.Resolve()
   at Fabulous.CodeGen.AssemblyReader.Resolver.getHierarchyForTypeInner(String stopAtType, TypeDefinition type, FSharpList`1 state) in G:\dev\FSharp\Fabulous\Fabulous.CodeGen\src\Fabulous.CodeGen\AssemblyReader\Resolver.fs:line 89
   at Fabulous.CodeGen.AssemblyReader.Resolver.getHierarchyForType(String stopAtType, TypeDefinition type) in G:\dev\FSharp\Fabulous\Fabulous.CodeGen\src\Fabulous.CodeGen\AssemblyReader\Resolver.fs:line 102
   at Fabulous.CodeGen.AssemblyReader.Reader.readType(FSharpFunc`2 convertTypeName, FSharpFunc`2 tryGetStringRepresentationOfDefaultValue, FSharpFunc`2 tryGetProperty, String propertyBaseType, String baseTypeName, TypeDefinition tdef) in G:\dev\FSharp\Fabulous\Fabulous.CodeGen\src\Fabulous.CodeGen\AssemblyReader\Reader.fs:line 112
   at Fabulous.CodeGen.AssemblyReader.Reader.data@142.Invoke(TypeDefinition tdef) in G:\dev\FSharp\Fabulous\Fabulous.CodeGen\src\Fabulous.CodeGen\AssemblyReader\Reader.fs:line 142
   at Fabulous.CodeGen.AssemblyReader.Reader.readAssemblies(FSharpFunc`2 loadAllAssembliesByReflection, FSharpFunc`2 tryGetAttachedPropertyByReflection, FSharpFunc`2 isTypeResolvable, FSharpFunc`2 convertTypeName, FSharpFunc`2 tryGetStringRepresentationOfDefaultValue, String propertyBaseType, String baseTypeName, IEnumerable`1 assemblies) in G:\dev\F
Sharp\Fabulous\Fabulous.CodeGen\src\Fabulous.CodeGen\AssemblyReader\Reader.fs:line 141
   at Fabulous.CodeGen.Functions.readAssemblies(Configuration configuration, ReadAssembliesConfiguration readAssembliesConfiguration, IEnumerable`1 assemblies) in G:\dev\FSharp\Fabulous\Fabulous.CodeGen\src\Fabulous.CodeGen\Program.fs:line 75
   at Fabulous.CodeGen.ProgramModule.mkProgram@132-1.Invoke(Configuration configuration, ReadAssembliesConfiguration readAssembliesConfiguration, String[] assemblies) in G:\dev\FSharp\Fabulous\Fabulous.CodeGen\src\Fabulous.CodeGen\Program.fs:line 132
   at Fabulous.CodeGen.Functions.readAssemblies@92T.Invoke(Tuple`2 tupledArg) in G:\dev\FSharp\Fabulous\Fabulous.CodeGen\src\Fabulous.CodeGen\Program.fs:line 93
   at Fabulous.CodeGen.WorkflowResult.bind[a,b,c,d,e](FSharpFunc`2 f, FSharpResult`2 result) in G:\dev\FSharp\Fabulous\Fabulous.CodeGen\src\Fabulous.CodeGen\Result.fs:line 17
   at Fabulous.CodeGen.Functions.runProgram(Program program, String mappingFile, String outputFile) in G:\dev\FSharp\Fabulous\Fabulous.CodeGen\src\Fabulous.CodeGen\Program.fs:line 117
   at Fabulous.CodeGen.ProgramModule.run(String bindingsFile, String outputFile, Program program) in G:\dev\FSharp\Fabulous\Fabulous.CodeGen\src\Fabulous.CodeGen\Program.fs:line 160
   at Fabulous.Android.Generator.Program.main(String[] args) in G:\dev\FSharp\Fabulous.Android\tools\Fabulous.Android.Generator\Program.fs:line 35
```

This is because `RegistrableResolver.Resolve` method are invoked after `RegistrableResolver.Dispose`. This PR is fixes the error.