### PR TITLE
Ensure MapMsg is updated on view reuse

### DIFF
--- a/src/Fabulous/MapMsg.fs
+++ b/src/Fabulous/MapMsg.fs
@@ -13,7 +13,7 @@ module MapMsg =
               Name = "Fabulous_MapMsg"
               Convert = id
               ConvertValue = id
-              Compare = fun _ _ -> ScalarAttributeComparison.Identical
+              Compare = fun _ _ -> ScalarAttributeComparison.Different
               UpdateNode =
                   fun _oldValueOpt newValueOpt node ->
                       match newValueOpt with


### PR DESCRIPTION
Functions like MapMsg can't be compared directly so we rely on a hard-coded ScalarAttributeComparison.
MapMsg was set to `Identical` which will force Fabulous to still use the initial MapMsg, even in case of reuse with a different MapMsg.

We simply need to set it to `Different` to fix that.