### PR TITLE
Update Scalar attributes after updating children to fix issue with invalid hierarchy

### DIFF
--- a/src/Fabulous/ViewNode.fs
+++ b/src/Fabulous/ViewNode.fs
@@ -106,6 +106,6 @@ type ViewNode(parent: IViewNode option, treeContext: ViewTreeContext, targetRef:
             if not targetRef.IsAlive then
                 ()
             else
-                x.ApplyScalarDiffs(&diff.ScalarChanges)
                 x.ApplyWidgetDiffs(&diff.WidgetChanges)
                 x.ApplyWidgetCollectionDiffs(&diff.WidgetCollectionChanges)
+                x.ApplyScalarDiffs(&diff.ScalarChanges)


### PR DESCRIPTION
When dispatching a message in a child view using a different type of message, we rely on `ViewNode` having both the `MapMsg` function set and a reference to the parent `ViewNode` to be able to map the child message to the app root message type.

```
Root (RootMsg)
    -> ChildA (ChildAMsg)
       -> GrandChild
           -> GrandGrandChild (GrandGrandChildMsg)
    -> ChildB (ChildBMsg)
       -> GrandChild
           -> GrandGrandChild (GrandGrandChildMsg)
```

Except during the `ApplyDiff`, the scalar properties (including MapMsg) were updated before the children.
This could result in the GrandGrandChild to try to dispatch a message while the hierarchy is changing.

To avoid this, we first update the children and then the scalar properties.