### PR TITLE
Update related properties and events at the same time

### DIFF
--- a/docs/content/en/docs/v2/architecture/attribute-definitions.md
+++ b/docs/content/en/docs/v2/architecture/attribute-definitions.md
@@ -1,0 +1,103 @@
+---
+id: "v2-attribute-definitions"
+title: "Attribute definitions"
+description: ""
+lead: ""
+date: 2022-04-21T00:00:00+00:00
+lastmod: 2022-04-21T00:00:00+00:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "architecture"
+weight: 503
+toc: true
+---
+
+## Attribute definition helpers
+
+### defineBindableWithEvent (Xamarin.Forms)
+
+Values and event handlers are very similar. They are both values: one has a concrete value, the other has a function value.
+That's why in v2, values and events are both treated as individual scalar attributes.
+
+That works most of the time, but some properties and events have a strong dependency.
+E.g.:
+
+- Entry: Text / TextChanged
+- Slider: Value / ValueChanged
+- ListView: SelectedIndex / SelectedIndex
+
+This is required to be able to react to user interactions like users are inputting text, toggling a switch, etc.
+But in Xamarin.Forms, those events are also triggered by programmatic changes.
+
+If you, as a developer, decides to toggle the switch from false to true, it will raise a `Toggled` event - the same event if the users had toggle the switch themselves.
+
+Firstly this makes it hard to differentiate if we are reacting to a user change or a programmatic change.
+The latter is not really interesting since we already know what's inside the app model.
+
+This behavior seems rather harmless because in case of programmatic change, Fabulous will see that the event is actually trying to set the related property to the same value, so no change is needed.
+Eg.: [Programmatic Change: Value = true] -> [Event msg: Value changed to true] -> [Value was true, now is true] -> [do nothing]
+
+But on Android, this can lead to an infinite update loop.
+Android delays its event triggering a little bit so if the user is quickly changing the input, Fabulous and Android can get out of sync and freeze the app.
+
+Example: User wants to write "Hello"
+
+1) User taps letter `H`
+2) User taps letter `e`
+3) Android raises event "TextChanged: H" -> Fabulous will change the Entry's text to `H` (was `He`) -> triggering another event
+4) Android raises event "TextChanged: He" -> Fabulous will change the Entry's text to `He` (was `H`)
+5) Android raises event "TextChanged: H" (because of (3)) -> Fabulous will change to `H` (was `He`)
+6) Android raises event "TextChanged: He" (because of (4)) -> Fabulous will change the Entry's text to `He` (was `H`)
+7) etc. 
+
+To avoid this from happening, the only way is to ignore the events triggered by programmatic changes.
+This is done by removing the event handler before updating the value and reset it after.
+
+To guarantee the order of execution, we need to handle both the property and the related event in a single attribute, where the `UpdateNode` function of the attribute will take care of updating in the right order.
+
+1) Remove old handler if any
+2) Update the value (it will trigger an event, but we don't listen to it anymore)
+    - If attribute was removed, then we clean the old value 
+    - Otherwise we set the new value
+3) Set the new handler if any
+
+Here is the attribute declaration to use:
+
+Before we had 2 attribute definitions (property and event)
+
+```fs
+module Slider =
+    let Value = Attributes.defineBindable<float> Slider.ValueProperty
+
+    let ValueChanged =
+        Attributes.defineEventWithArgs<ValueChangedEventArgs>
+            "Slider_ValueChanged"
+            (fun target -> (target :?> Slider).ValueChanged)
+
+type Fabulous.XamarinForms.View with
+    static member inline Slider<'msg>(value: float, onValueChanged: ValueChangedEventArgs -> 'msg) =
+        WidgetBuilder<'msg, ISlider>(
+            Slider.WidgetKey,
+            Slider.Value.WithValue(value),
+            Slider.ValueChanged.WithValue(fun args -> onValueChanged args |> box)
+        )
+```
+
+Now, there is a new attribute definition to update both the property and the event in a single attribute.
+```fs
+module Slider =
+    let ValueWithEvent =
+        Attributes.defineBindableWithEvent<float, ValueChangedEventArgs>
+            "Slider_ValueChanged"
+            Slider.ValueProperty
+            (fun target -> (target :?> Slider).ValueChanged)
+
+type Fabulous.XamarinForms.View with
+    static member inline Slider<'msg>(value: float, onValueChanged: ValueChangedEventArgs -> 'msg) =
+        WidgetBuilder<'msg, ISlider>(
+            Slider.WidgetKey,
+            Slider.ValueWithEvent.WithValue(ValueEventData.create value (fun args -> onValueChanged args |> box))
+        )
+```

--- a/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/Controls/BorderedEntry.fs
+++ b/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/Controls/BorderedEntry.fs
@@ -30,8 +30,9 @@ module EntryBuilders =
         static member inline BorderedEntry<'msg>(text, onTextChanged: string -> 'msg) =
             WidgetBuilder<'msg, IBorderedEntry>(
                 BorderedEntry.WidgetKey,
-                InputView.Text.WithValue(text),
-                InputView.TextChanged.WithValue(fun args -> onTextChanged args.NewTextValue |> box)
+                InputView.TextWithEvent.WithValue(
+                    ValueEventData.create text (fun args -> onTextChanged args.NewTextValue |> box)
+                )
             )
 
 [<AutoOpen>]

--- a/src/Fabulous.XamarinForms/Attributes.fs
+++ b/src/Fabulous.XamarinForms/Attributes.fs
@@ -81,7 +81,7 @@ module Attributes =
     /// Update both a property and its related event.
     /// This definition makes sure that the event is only raised when the property is changed by the user,
     /// and not when the property is set by the code
-    let defineValueWithEventArgs<'data, 'args>
+    let defineBindableWithEvent<'data, 'args>
         name
         (bindableProperty: BindableProperty)
         (getEvent: obj -> IEvent<EventHandler<'args>, 'args>)

--- a/src/Fabulous.XamarinForms/Attributes.fs
+++ b/src/Fabulous.XamarinForms/Attributes.fs
@@ -2,6 +2,7 @@ namespace Fabulous.XamarinForms
 
 open Fabulous
 open Xamarin.Forms
+open System
 
 [<Struct>]
 type AppThemeValues<'T> = { Light: 'T; Dark: 'T voption }
@@ -13,6 +14,14 @@ module AppTheme =
               match dark with
               | None -> ValueNone
               | Some v -> ValueSome v }
+
+[<Struct>]
+type ValueEventData<'data, 'eventArgs> =
+    { Value: 'data
+      Event: 'eventArgs -> obj }
+
+module ValueEventData =
+    let create (value: 'data) (event: 'eventArgs -> obj) = { Value = value; Event = event }
 
 module Attributes =
     /// Define an attribute storing a Widget for a bindable property
@@ -68,3 +77,58 @@ module Attributes =
                 | ValueSome { Light = light; Dark = ValueNone } -> target.SetValue(bindableProperty, light)
                 | ValueSome { Light = light; Dark = ValueSome dark } ->
                     target.SetOnAppTheme(bindableProperty, light, dark))
+
+    /// Update both a property and its related event.
+    /// This definition makes sure that the event is only raised when the property is changed by the user,
+    /// and not when the property is set by the code
+    let defineValueWithEventArgs<'data, 'args>
+        name
+        (bindableProperty: BindableProperty)
+        (getEvent: obj -> IEvent<EventHandler<'args>, 'args>)
+        =
+        let key = AttributeDefinitionStore.getNextKey()
+
+        let definition: ScalarAttributeDefinition<ValueEventData<'data, 'args>, _, _> =
+            { Key = key
+              Name = name
+              Convert = id
+              ConvertValue = id
+              Compare = ScalarAttributeComparers.noCompare
+              UpdateNode =
+                  fun oldValueOpt newValueOpt node ->
+                      let target = node.Target :?> BindableObject
+                      let event = getEvent target
+
+                      match newValueOpt with
+                      | ValueNone ->
+                          // The attribute is no longer applied, so we clean up the event
+                          match node.TryGetHandler(key) with
+                          | ValueNone -> ()
+                          | ValueSome handler -> event.RemoveHandler(handler)
+
+                          // Only clear the property if a value was set before
+                          match oldValueOpt with
+                          | ValueNone -> ()
+                          | ValueSome _ -> target.ClearValue(bindableProperty)
+
+                      | ValueSome curr ->
+                          // Clean up the old event handler if any
+                          match node.TryGetHandler(key) with
+                          | ValueNone -> ()
+                          | ValueSome handler -> event.RemoveHandler(handler)
+
+                          // Set the new value
+                          target.SetValue(bindableProperty, curr.Value)
+
+                          // Set the new event handler
+                          let handler =
+                              EventHandler<'args>
+                                  (fun _ args ->
+                                      let r = curr.Event args
+                                      Dispatcher.dispatch node r)
+
+                          node.SetHandler(key, ValueSome handler)
+                          event.AddHandler(handler) }
+
+        AttributeDefinitionStore.set key definition
+        definition

--- a/src/Fabulous.XamarinForms/Controls.fs
+++ b/src/Fabulous.XamarinForms/Controls.fs
@@ -77,3 +77,23 @@ type CustomEntryCell() =
     override this.OnPropertyChanging(propertyName) =
         if propertyName = EntryCell.TextProperty.PropertyName then
             oldText <- this.Text
+
+/// Xamarin.Forms doesn't have an event args on the SelectedIndexChanged event, so we implement it
+type CustomPicker() =
+    inherit Picker()
+
+    let mutable oldSelectedIndex = -1
+
+    let selectedIndexChanged =
+        Event<EventHandler<PositionChangedEventArgs>, _>()
+
+    [<CLIEvent>]
+    member _.CustomSelectedIndexChanged = selectedIndexChanged.Publish
+
+    override this.OnPropertyChanged(propertyName) =
+        if propertyName = Picker.SelectedIndexProperty.PropertyName then
+            selectedIndexChanged.Trigger(this, PositionChangedEventArgs(oldSelectedIndex, this.SelectedIndex))
+
+    override this.OnPropertyChanging(propertyName) =
+        if propertyName = Picker.SelectedIndexProperty.PropertyName then
+            oldSelectedIndex <- this.SelectedIndex

--- a/src/Fabulous.XamarinForms/Views/Cells/EntryCell.fs
+++ b/src/Fabulous.XamarinForms/Views/Cells/EntryCell.fs
@@ -10,9 +10,6 @@ type IEntryCell =
 module EntryCell =
     let WidgetKey = Widgets.register<CustomEntryCell>()
 
-    let Text =
-        Attributes.defineBindable<string> EntryCell.TextProperty
-
     let Label =
         Attributes.defineBindable<string> EntryCell.LabelProperty
 
@@ -31,9 +28,10 @@ module EntryCell =
     let Keyboard =
         Attributes.defineBindable<Keyboard> EntryCell.KeyboardProperty
 
-    let TextChanged =
-        Attributes.defineEvent<TextChangedEventArgs>
+    let TextWithEvent =
+        Attributes.defineValueWithEventArgs
             "EntryCell_TextChanged"
+            EntryCell.TextProperty
             (fun target -> (target :?> CustomEntryCell).TextChanged)
 
     let OnCompleted =
@@ -47,8 +45,9 @@ module EntryCellBuilders =
             WidgetBuilder<'msg, IEntryCell>(
                 EntryCell.WidgetKey,
                 EntryCell.Label.WithValue(label),
-                EntryCell.Text.WithValue(text),
-                EntryCell.TextChanged.WithValue(fun args -> onTextChanged args.NewTextValue |> box)
+                EntryCell.TextWithEvent.WithValue(
+                    ValueEventData.create text (fun args -> onTextChanged args.NewTextValue |> box)
+                )
             )
 
 [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Cells/EntryCell.fs
+++ b/src/Fabulous.XamarinForms/Views/Cells/EntryCell.fs
@@ -29,7 +29,7 @@ module EntryCell =
         Attributes.defineBindable<Keyboard> EntryCell.KeyboardProperty
 
     let TextWithEvent =
-        Attributes.defineValueWithEventArgs
+        Attributes.defineBindableWithEvent
             "EntryCell_TextChanged"
             EntryCell.TextProperty
             (fun target -> (target :?> CustomEntryCell).TextChanged)

--- a/src/Fabulous.XamarinForms/Views/Cells/SwitchCell.fs
+++ b/src/Fabulous.XamarinForms/Views/Cells/SwitchCell.fs
@@ -15,7 +15,7 @@ module SwitchCell =
         Attributes.defineBindable<string> SwitchCell.TextProperty
 
     let OnWithEvent =
-        Attributes.defineValueWithEventArgs
+        Attributes.defineBindableWithEvent
             "SwitchCell_OnChanged"
             SwitchCell.OnProperty
             (fun target -> (target :?> SwitchCell).OnChanged)

--- a/src/Fabulous.XamarinForms/Views/Cells/SwitchCell.fs
+++ b/src/Fabulous.XamarinForms/Views/Cells/SwitchCell.fs
@@ -11,15 +11,13 @@ type ISwitchCell =
 module SwitchCell =
     let WidgetKey = Widgets.register<SwitchCell>()
 
-    let On =
-        Attributes.defineBindable<bool> SwitchCell.OnProperty
-
     let Text =
         Attributes.defineBindable<string> SwitchCell.TextProperty
 
-    let OnChanged =
-        Attributes.defineEvent<ToggledEventArgs>
+    let OnWithEvent =
+        Attributes.defineValueWithEventArgs
             "SwitchCell_OnChanged"
+            SwitchCell.OnProperty
             (fun target -> (target :?> SwitchCell).OnChanged)
 
     let OnColor =
@@ -31,9 +29,8 @@ module SwitchCellBuilders =
         static member inline SwitchCell<'msg>(text: string, value: bool, onChanged: bool -> 'msg) =
             WidgetBuilder<'msg, ISwitchCell>(
                 SwitchCell.WidgetKey,
-                SwitchCell.On.WithValue(value),
-                SwitchCell.Text.WithValue(text),
-                SwitchCell.OnChanged.WithValue(fun args -> onChanged args.Value |> box)
+                SwitchCell.OnWithEvent.WithValue(ValueEventData.create value (fun args -> onChanged args.Value |> box)),
+                SwitchCell.Text.WithValue(text)
             )
 
 [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Controls/CheckBox.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/CheckBox.fs
@@ -11,15 +11,13 @@ module CheckBox =
 
     let WidgetKey = Widgets.register<CheckBox>()
 
-    let IsChecked =
-        Attributes.defineBindable<bool> CheckBox.IsCheckedProperty
-
     let Color =
         Attributes.defineAppThemeBindable<Color> CheckBox.ColorProperty
 
-    let CheckedChanged =
-        Attributes.defineEvent<CheckedChangedEventArgs>
+    let IsCheckedWithEvent =
+        Attributes.defineValueWithEventArgs
             "CheckBox_CheckedChanged"
+            CheckBox.IsCheckedProperty
             (fun target -> (target :?> CheckBox).CheckedChanged)
 
 [<AutoOpen>]
@@ -28,8 +26,9 @@ module CheckBoxBuilders =
         static member inline CheckBox<'msg>(isChecked: bool, onCheckedChanged: bool -> 'msg) =
             WidgetBuilder<'msg, ICheckBox>(
                 CheckBox.WidgetKey,
-                CheckBox.IsChecked.WithValue(isChecked),
-                CheckBox.CheckedChanged.WithValue(fun args -> onCheckedChanged args.Value |> box)
+                CheckBox.IsCheckedWithEvent.WithValue(
+                    ValueEventData.create isChecked (fun args -> onCheckedChanged args.Value |> box)
+                )
             )
 
 [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Controls/CheckBox.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/CheckBox.fs
@@ -15,7 +15,7 @@ module CheckBox =
         Attributes.defineAppThemeBindable<Color> CheckBox.ColorProperty
 
     let IsCheckedWithEvent =
-        Attributes.defineValueWithEventArgs
+        Attributes.defineBindableWithEvent
             "CheckBox_CheckedChanged"
             CheckBox.IsCheckedProperty
             (fun target -> (target :?> CheckBox).CheckedChanged)

--- a/src/Fabulous.XamarinForms/Views/Controls/DatePicker.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/DatePicker.fs
@@ -14,9 +14,6 @@ module DatePicker =
     let CharacterSpacing =
         Attributes.defineBindable<float> DatePicker.CharacterSpacingProperty
 
-    let Date =
-        Attributes.defineBindable<System.DateTime> DatePicker.DateProperty
-
     let FontAttributes =
         Attributes.defineBindable<Xamarin.Forms.FontAttributes> DatePicker.FontAttributesProperty
 
@@ -41,9 +38,10 @@ module DatePicker =
     let TextTransform =
         Attributes.defineBindable<Xamarin.Forms.TextTransform> DatePicker.TextTransformProperty
 
-    let DateSelected =
-        Attributes.defineEvent<DateChangedEventArgs>
+    let DateWithEvent =
+        Attributes.defineValueWithEventArgs
             "DatePicker_DateSelected"
+            DatePicker.DateProperty
             (fun target -> (target :?> DatePicker).DateSelected)
 
     let UpdateMode =
@@ -65,8 +63,9 @@ module DatePickerBuilders =
         static member inline DatePicker<'msg>(date: System.DateTime, onDateSelected: System.DateTime -> 'msg) =
             WidgetBuilder<'msg, IDatePicker>(
                 DatePicker.WidgetKey,
-                DatePicker.Date.WithValue(date),
-                DatePicker.DateSelected.WithValue(fun args -> onDateSelected args.NewDate |> box)
+                DatePicker.DateWithEvent.WithValue(
+                    ValueEventData.create date (fun args -> onDateSelected args.NewDate |> box)
+                )
             )
 
 [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Controls/DatePicker.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/DatePicker.fs
@@ -39,7 +39,7 @@ module DatePicker =
         Attributes.defineBindable<Xamarin.Forms.TextTransform> DatePicker.TextTransformProperty
 
     let DateWithEvent =
-        Attributes.defineValueWithEventArgs
+        Attributes.defineBindableWithEvent
             "DatePicker_DateSelected"
             DatePicker.DateProperty
             (fun target -> (target :?> DatePicker).DateSelected)

--- a/src/Fabulous.XamarinForms/Views/Controls/Editor.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Editor.fs
@@ -34,8 +34,9 @@ module EditorBuilders =
         static member inline Editor<'msg>(text: string, onTextChanged: string -> 'msg) =
             WidgetBuilder<'msg, IEditor>(
                 Editor.WidgetKey,
-                InputView.Text.WithValue(text),
-                InputView.TextChanged.WithValue(fun args -> onTextChanged args.NewTextValue |> box)
+                InputView.TextWithEvent.WithValue(
+                    ValueEventData.create text (fun args -> onTextChanged args.NewTextValue |> box)
+                )
             )
 
 [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Controls/Entry.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Entry.fs
@@ -67,8 +67,9 @@ module EntryBuilders =
         static member inline Entry<'msg>(text: string, onTextChanged: string -> 'msg) =
             WidgetBuilder<'msg, IEntry>(
                 Entry.WidgetKey,
-                InputView.Text.WithValue(text),
-                InputView.TextChanged.WithValue(fun args -> onTextChanged args.NewTextValue |> box)
+                InputView.TextWithEvent.WithValue(
+                    ValueEventData.create text (fun args -> onTextChanged args.NewTextValue |> box)
+                )
             )
 
 [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Controls/Picker.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Picker.fs
@@ -52,7 +52,7 @@ module Picker =
                 | ValueSome value -> target.SetValue(Picker.ItemsSourceProperty, value))
 
     let SelectedIndexWithEvent =
-        Attributes.defineValueWithEventArgs
+        Attributes.defineBindableWithEvent
             "Picker_SelectedIndexChanged"
             Picker.SelectedIndexProperty
             (fun target ->

--- a/src/Fabulous.XamarinForms/Views/Controls/Picker.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Picker.fs
@@ -9,7 +9,7 @@ type IPicker =
     inherit IView
 
 module Picker =
-    let WidgetKey = Widgets.register<Picker>()
+    let WidgetKey = Widgets.register<CustomPicker>()
 
     let CharacterSpacing =
         Attributes.defineBindable<float> Picker.CharacterSpacingProperty
@@ -51,13 +51,13 @@ module Picker =
                 | ValueNone -> target.ClearValue(Picker.ItemsSourceProperty)
                 | ValueSome value -> target.SetValue(Picker.ItemsSourceProperty, value))
 
-    let SelectedIndex =
-        Attributes.defineBindable<int> Picker.SelectedIndexProperty
-
-    let SelectedIndexChanged =
-        Attributes.defineEventWithAdditionalStep
+    let SelectedIndexWithEvent =
+        Attributes.defineValueWithEventArgs
             "Picker_SelectedIndexChanged"
-            (fun target -> (target :?> Picker).SelectedIndexChanged)
+            Picker.SelectedIndexProperty
+            (fun target ->
+                (target :?> CustomPicker)
+                    .CustomSelectedIndexChanged)
 
     let UpdateMode =
         Attributes.define<iOSSpecific.UpdateMode>
@@ -79,12 +79,9 @@ module PickerBuilders =
             WidgetBuilder<'msg, IPicker>(
                 Picker.WidgetKey,
                 Picker.ItemSource.WithValue(items |> Array.ofList),
-                Picker.SelectedIndex.WithValue(selectedIndex),
-                Picker.SelectedIndexChanged.WithValue
-                    (fun sender ->
-                        let picker = sender :?> Picker
-
-                        onSelectedIndexChanged picker.SelectedIndex |> box)
+                Picker.SelectedIndexWithEvent.WithValue(
+                    ValueEventData.create selectedIndex (fun args -> onSelectedIndexChanged args.CurrentPosition |> box)
+                )
             )
 
 [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Controls/RadioButton.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/RadioButton.fs
@@ -55,7 +55,7 @@ module RadioButton =
         Attributes.defineBindable<string> RadioButtonGroup.GroupNameProperty
 
     let IsCheckedWithEvent =
-        Attributes.defineValueWithEventArgs
+        Attributes.defineBindableWithEvent
             "RadioButton_CheckedChanged"
             RadioButton.IsCheckedProperty
             (fun target -> (target :?> RadioButton).CheckedChanged)

--- a/src/Fabulous.XamarinForms/Views/Controls/RadioButton.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/RadioButton.fs
@@ -42,9 +42,6 @@ module RadioButton =
     let FontSize =
         Attributes.defineBindable<float> RadioButton.FontSizeProperty
 
-    let IsChecked =
-        Attributes.defineBindable<bool> RadioButton.IsCheckedProperty
-
     let TextColor =
         Attributes.defineAppThemeBindable<Color> RadioButton.TextColorProperty
 
@@ -57,9 +54,10 @@ module RadioButton =
     let RadioButtonGroupName =
         Attributes.defineBindable<string> RadioButtonGroup.GroupNameProperty
 
-    let CheckedChanged =
-        Attributes.defineEvent<CheckedChangedEventArgs>
+    let IsCheckedWithEvent =
+        Attributes.defineValueWithEventArgs
             "RadioButton_CheckedChanged"
+            RadioButton.IsCheckedProperty
             (fun target -> (target :?> RadioButton).CheckedChanged)
 
 [<AutoOpen>]
@@ -69,9 +67,10 @@ module RadioButtonBuilders =
         static member inline RadioButton<'msg>(content: string, isChecked: bool, onChecked: bool -> 'msg) =
             WidgetBuilder<'msg, IRadioButton>(
                 RadioButton.WidgetKey,
-                RadioButton.IsChecked.WithValue(isChecked),
-                RadioButton.ContentString.WithValue(content),
-                RadioButton.CheckedChanged.WithValue(fun args -> onChecked args.Value |> box)
+                RadioButton.IsCheckedWithEvent.WithValue(
+                    ValueEventData.create isChecked (fun args -> onChecked args.Value |> box)
+                ),
+                RadioButton.ContentString.WithValue(content)
             )
 
         static member inline RadioButton<'msg, 'marker when 'marker :> IView>
@@ -83,9 +82,10 @@ module RadioButtonBuilders =
             WidgetBuilder<'msg, IRadioButton>(
                 RadioButton.WidgetKey,
                 AttributesBundle(
-                    StackList.two(
-                        RadioButton.IsChecked.WithValue(isChecked),
-                        RadioButton.CheckedChanged.WithValue(fun args -> onChecked args.Value |> box)
+                    StackList.one(
+                        RadioButton.IsCheckedWithEvent.WithValue(
+                            ValueEventData.create isChecked (fun args -> onChecked args.Value |> box)
+                        )
                     ),
                     ValueSome [| RadioButton.ContentWidget.WithValue(content.Compile()) |],
                     ValueNone

--- a/src/Fabulous.XamarinForms/Views/Controls/SearchBar.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/SearchBar.fs
@@ -39,8 +39,9 @@ module SearchBarBuilders =
         static member inline SearchBar<'msg>(text: string, onTextChanged: string -> 'msg, onSearchButtonPressed: 'msg) =
             WidgetBuilder<'msg, ISearchBar>(
                 SearchBar.WidgetKey,
-                InputView.Text.WithValue(text),
-                InputView.TextChanged.WithValue(fun args -> onTextChanged args.NewTextValue |> box),
+                InputView.TextWithEvent.WithValue(
+                    ValueEventData.create text (fun args -> onTextChanged args.NewTextValue |> box)
+                ),
                 SearchBar.SearchButtonPressed.WithValue(onSearchButtonPressed)
             )
 

--- a/src/Fabulous.XamarinForms/Views/Controls/Slider.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Slider.fs
@@ -29,7 +29,7 @@ module Slider =
         Attributes.defineAppThemeBindable<ImageSource> Slider.ThumbImageSourceProperty
 
     let ValueWithEvent =
-        Attributes.defineValueWithEventArgs
+        Attributes.defineBindableWithEvent
             "Slider_ValueWithEvent"
             Slider.ValueProperty
             (fun target -> (target :?> Slider).ValueChanged)

--- a/src/Fabulous.XamarinForms/Views/Controls/Slider.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Slider.fs
@@ -28,12 +28,10 @@ module Slider =
     let ThumbImageSource =
         Attributes.defineAppThemeBindable<ImageSource> Slider.ThumbImageSourceProperty
 
-    let Value =
-        Attributes.defineBindable<float> Slider.ValueProperty
-
-    let ValueChanged =
-        Attributes.defineEvent<ValueChangedEventArgs>
-            "Slider_ValueChanged"
+    let ValueWithEvent =
+        Attributes.defineValueWithEventArgs
+            "Slider_ValueWithEvent"
+            Slider.ValueProperty
             (fun target -> (target :?> Slider).ValueChanged)
 
     let DragCompleted =
@@ -48,9 +46,10 @@ module SliderBuilders =
         static member inline Slider<'msg>(min: float, max: float, value: float, onValueChanged: float -> 'msg) =
             WidgetBuilder<'msg, ISlider>(
                 Slider.WidgetKey,
-                Slider.Value.WithValue(value),
-                Slider.ValueChanged.WithValue(fun args -> onValueChanged args.NewValue |> box),
-                Slider.MinimumMaximum.WithValue(struct (min, max))
+                Slider.MinimumMaximum.WithValue(struct (min, max)),
+                Slider.ValueWithEvent.WithValue(
+                    ValueEventData.create value (fun args -> onValueChanged args.NewValue |> box)
+                )
             )
 
 [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Controls/Stepper.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Stepper.fs
@@ -16,12 +16,10 @@ module Stepper =
     let MinimumMaximum =
         Attributes.define<struct (float * float)> "Stepper_MinimumMaximum" ViewUpdaters.updateStepperMinMax
 
-    let Value =
-        Attributes.defineBindable<float> Stepper.ValueProperty
-
-    let ValueChanged =
-        Attributes.defineEvent<ValueChangedEventArgs>
+    let ValueWithEvent =
+        Attributes.defineValueWithEventArgs
             "Stepper_ValueChanged"
+            Stepper.ValueProperty
             (fun target -> (target :?> Stepper).ValueChanged)
 
 [<AutoOpen>]
@@ -30,9 +28,10 @@ module StepperBuilders =
         static member inline Stepper<'msg>(min: float, max: float, value: float, onValueChanged: float -> 'msg) =
             WidgetBuilder<'msg, IStepper>(
                 Stepper.WidgetKey,
-                Stepper.Value.WithValue(value),
-                Stepper.ValueChanged.WithValue(fun args -> onValueChanged args.NewValue |> box),
-                Stepper.MinimumMaximum.WithValue(struct (min, max))
+                Stepper.MinimumMaximum.WithValue(struct (min, max)),
+                Stepper.ValueWithEvent.WithValue(
+                    ValueEventData.create value (fun args -> onValueChanged args.NewValue |> box)
+                )
             )
 
 [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Controls/Stepper.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Stepper.fs
@@ -17,7 +17,7 @@ module Stepper =
         Attributes.define<struct (float * float)> "Stepper_MinimumMaximum" ViewUpdaters.updateStepperMinMax
 
     let ValueWithEvent =
-        Attributes.defineValueWithEventArgs
+        Attributes.defineBindableWithEvent
             "Stepper_ValueChanged"
             Stepper.ValueProperty
             (fun target -> (target :?> Stepper).ValueChanged)

--- a/src/Fabulous.XamarinForms/Views/Controls/Switch.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Switch.fs
@@ -17,7 +17,7 @@ module Switch =
         Attributes.defineAppThemeBindable<Color> Switch.ThumbColorProperty
 
     let IsToggledWithEvent =
-        Attributes.defineValueWithEventArgs
+        Attributes.defineBindableWithEvent
             "Switch_Toggled"
             Switch.IsToggledProperty
             (fun target -> (target :?> Switch).Toggled)

--- a/src/Fabulous.XamarinForms/Views/Controls/Switch.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Switch.fs
@@ -10,17 +10,17 @@ type ISwitch =
 module Switch =
     let WidgetKey = Widgets.register<Switch>()
 
-    let IsToggled =
-        Attributes.defineBindable<bool> Switch.IsToggledProperty
-
     let ColorOn =
         Attributes.defineAppThemeBindable<Color> Switch.OnColorProperty
 
     let ThumbColor =
         Attributes.defineAppThemeBindable<Color> Switch.ThumbColorProperty
 
-    let Toggled =
-        Attributes.defineEvent<ToggledEventArgs> "Switch_Toggled" (fun target -> (target :?> Switch).Toggled)
+    let IsToggledWithEvent =
+        Attributes.defineValueWithEventArgs
+            "Switch_Toggled"
+            Switch.IsToggledProperty
+            (fun target -> (target :?> Switch).Toggled)
 
 [<AutoOpen>]
 module SwitchBuilders =
@@ -28,8 +28,9 @@ module SwitchBuilders =
         static member inline Switch<'msg>(isToggled: bool, onToggled: bool -> 'msg) =
             WidgetBuilder<'msg, ISwitch>(
                 Switch.WidgetKey,
-                Switch.IsToggled.WithValue(isToggled),
-                Switch.Toggled.WithValue(fun args -> onToggled args.Value |> box)
+                Switch.IsToggledWithEvent.WithValue(
+                    ValueEventData.create isToggled (fun args -> onToggled args.Value |> box)
+                )
             )
 
 [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Controls/TimePicker.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/TimePicker.fs
@@ -14,11 +14,11 @@ module TimePicker =
     let CharacterSpacing =
         Attributes.defineBindable<float> TimePicker.CharacterSpacingProperty
 
-    let Time =
-        Attributes.defineBindable<System.TimeSpan> TimePicker.TimeProperty
-
-    let TimeSelected =
-        Attributes.defineEvent "TimePicker_TimeSelected" (fun target -> (target :?> FabulousTimePicker).TimeSelected)
+    let TimeWithEvent =
+        Attributes.defineValueWithEventArgs
+            "TimePicker_TimeSelected"
+            TimePicker.TimeProperty
+            (fun target -> (target :?> FabulousTimePicker).TimeSelected)
 
     let FontAttributes =
         Attributes.defineBindable<Xamarin.Forms.FontAttributes> TimePicker.FontAttributesProperty
@@ -57,8 +57,9 @@ module TimePickerBuilders =
         static member inline TimePicker<'msg>(time: System.TimeSpan, onTimeSelected: System.TimeSpan -> 'msg) =
             WidgetBuilder<'msg, ITimePicker>(
                 TimePicker.WidgetKey,
-                TimePicker.Time.WithValue(time),
-                TimePicker.TimeSelected.WithValue(fun args -> onTimeSelected args.NewTime |> box)
+                TimePicker.TimeWithEvent.WithValue(
+                    ValueEventData.create time (fun args -> onTimeSelected args.NewTime |> box)
+                )
             )
 
 [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Controls/TimePicker.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/TimePicker.fs
@@ -15,7 +15,7 @@ module TimePicker =
         Attributes.defineBindable<float> TimePicker.CharacterSpacingProperty
 
     let TimeWithEvent =
-        Attributes.defineValueWithEventArgs
+        Attributes.defineBindableWithEvent
             "TimePicker_TimeSelected"
             TimePicker.TimeProperty
             (fun target -> (target :?> FabulousTimePicker).TimeSelected)

--- a/src/Fabulous.XamarinForms/Views/Controls/_InputView.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/_InputView.fs
@@ -37,7 +37,7 @@ module InputView =
         Attributes.defineBindable<TextTransform> InputView.TextTransformProperty
 
     let TextWithEvent =
-        Attributes.defineValueWithEventArgs<string, TextChangedEventArgs>
+        Attributes.defineBindableWithEvent<string, TextChangedEventArgs>
             "InputView_TextChanged"
             InputView.TextProperty
             (fun target -> (target :?> InputView).TextChanged)

--- a/src/Fabulous.XamarinForms/Views/Controls/_InputView.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/_InputView.fs
@@ -30,18 +30,16 @@ module InputView =
     let TextColor =
         Attributes.defineAppThemeBindable<Color> InputView.TextColorProperty
 
-    let Text =
-        Attributes.defineBindable<string> InputView.TextProperty
-
     let Keyboard =
         Attributes.defineBindable<Keyboard> InputView.KeyboardProperty
 
     let TextTransform =
         Attributes.defineBindable<TextTransform> InputView.TextTransformProperty
 
-    let TextChanged =
-        Attributes.defineEvent<TextChangedEventArgs>
+    let TextWithEvent =
+        Attributes.defineValueWithEventArgs<string, TextChangedEventArgs>
             "InputView_TextChanged"
+            InputView.TextProperty
             (fun target -> (target :?> InputView).TextChanged)
 
 [<Extension>]

--- a/src/Fabulous/Attributes.fs
+++ b/src/Fabulous/Attributes.fs
@@ -197,39 +197,6 @@ module Attributes =
         AttributeDefinitionStore.set key definition
         definition
 
-    let defineEventWithAdditionalStep name (getEvent: obj -> IEvent<EventHandler, EventArgs>) =
-        let key = AttributeDefinitionStore.getNextKey()
-
-        let definition: ScalarAttributeDefinition<_, _, _> =
-            { Key = key
-              Name = name
-              Convert = id
-              ConvertValue = id
-              Compare = ScalarAttributeComparers.noCompare
-              UpdateNode =
-                  fun _ (newValueOpt: (obj -> obj) voption) node ->
-                      let event = getEvent node.Target
-
-                      match node.TryGetHandler(key) with
-                      | ValueNone -> ()
-                      | ValueSome handler -> event.RemoveHandler handler
-
-                      match newValueOpt with
-                      | ValueNone -> node.SetHandler(key, ValueNone)
-                      | ValueSome fn ->
-                          let handler =
-                              EventHandler
-                                  (fun sender _ ->
-                                      let r = fn sender
-                                      Dispatcher.dispatch node r)
-
-                          node.SetHandler(key, ValueSome handler)
-                          event.AddHandler handler }
-
-        AttributeDefinitionStore.set key definition
-        definition
-
-
     let defineEvent<'args> name (getEvent: obj -> IEvent<EventHandler<'args>, 'args>) =
         let key = AttributeDefinitionStore.getNextKey()
 


### PR DESCRIPTION
Values and event handlers are very similar. They are both values: one has a concrete value, the other has a function value.
That's why in v2, values and events are both treated as individual scalar attributes.

That works most of the time, but some properties and events have a strong dependency.
E.g.:
- Entry: Text / TextChanged
- Slider: Value / ValueChanged
- ListView: SelectedIndex / SelectedIndex

This is required to be able to react to user interactions like users are inputting text, toggling a switch, etc.
But in Xamarin.Forms, those events are also triggered by programmatic changes.

If you, as a developer, decides to toggle the switch from false to true, it will raise a `Toggled` event - the same event if the users had toggle the switch themselves.

Firstly this makes it hard to differentiate if we are reacting to a user change or a programmatic change.
The latter is not really interesting since we already know what's inside the app model.

This behavior seems rather harmless because in case of programmatic change, Fabulous will see that the event is actually trying to set the related property to the same value, so no change is needed.
Eg.: [Programmatic Change: Value = true] -> [Event msg: Value changed to true] -> [Value was true, now is true] -> [do nothing]

But on Android, this can lead to an infinite update loop.
Android delays its event triggering a little bit so if the user is quickly changing the input, Fabulous and Android can get out of sync and freeze the app.

Example: User wants to write "Hello"
1) User taps letter `H`
2) User taps letter `e`
3) Android raises event "TextChanged: H" -> Fabulous will change the Entry's text to `H` (was `He`) -> triggering another event
4) Android raises event "TextChanged: He" -> Fabulous will change the Entry's text to `He` (was `H`)
5) Android raises event "TextChanged: H" (because of (3)) -> Fabulous will change to `H` (was `He`)
6) Android raises event "TextChanged: He" (because of (4)) -> Fabulous will change the Entry's text to `He` (was `H`)
7) etc. 

To avoid this from happening, the only way is to ignore the events triggered by programmatic changes.
This is done by removing the event handler before updating the value and reset it after.

To guarantee the order of execution, we need to handle both the property and the related event in a single attribute, where the `UpdateNode` function of the attribute will take care of updating in the right order.

1) Remove old handler if any
2) Update the value (it will trigger an event, but we don't listen to it anymore)
    - If attribute was removed, then we clean the old value 
    - Otherwise we set the new value
3) Set the new handler if any

Here is the attribute declaration to use:

Before we had 2 attribute definitions (property and event)
```fs
module Slider =
    let Value = Attributes.defineBindable<float> Slider.ValueProperty

    let ValueChanged =
        Attributes.defineEventWithArgs<ValueChangedEventArgs>
            "Slider_ValueChanged"
            (fun target -> (target :?> Slider).ValueChanged)

type Fabulous.XamarinForms.View with
    static inline member Slider<'msg>(value: float, onValueChanged: ValueChangedEventArgs -> 'msg) =
        WidgetBuilder<'msg, ISlider>(
            Slider.WidgetKey,
            Slider.Value.WithValue(value),
            Slider.ValueChanged.WithValue(fun args -> onValueChanged args |> box)
        )
```

Now, there is a new attribute definition to update both the property and the event in a single attribute.
```fs
module Slider =
    let ValueWithEvent =
        Attributes.defineBindableWithEvent<float, ValueChangedEventArgs>
            "Slider_ValueChanged"
            Slider.ValueProperty
            (fun target -> (target :?> Slider).ValueChanged)

type Fabulous.XamarinForms.View with
    static inline member Slider<'msg>(value: float, onValueChanged: ValueChangedEventArgs -> 'msg) =
        WidgetBuilder<'msg, ISlider>(
            Slider.WidgetKey,
            Slider.ValueWithEvent.WithValue(ValueEventData.create value (fun args -> onValueChanged args |> box))
        )
```