### PR TITLE
Introduced the notion of small scalars (can fit into 8 bytes) and converted all XF attributes that made sense

### DIFF
--- a/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/Controls/BorderedEntry.fs
+++ b/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/Controls/BorderedEntry.fs
@@ -22,7 +22,7 @@ module BorderedEntry =
     let WidgetKey = Widgets.register<BorderedEntry>()
 
     let BorderColor =
-        Attributes.defineBindable<Color> BorderedEntry.BorderColorProperty
+        Attributes.defineBindableColor BorderedEntry.BorderColorProperty
 
 [<AutoOpen>]
 module EntryBuilders =

--- a/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/Controls/Map.fs
+++ b/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/Controls/Map.fs
@@ -36,10 +36,10 @@
 //         Attributes.defineWidgetCollection<Pin> "Map_Pins" (fun target -> (target :?> Map).Pins)
 
 //     let HasZoomEnabled =
-//         Attributes.defineBindable<bool> Map.HasZoomEnabledProperty
+//         Attributes.defineBindableBool Map.HasZoomEnabledProperty
 
 //     let HasScrollEnabled =
-//         Attributes.defineBindable<bool> Map.HasScrollEnabledProperty
+//         Attributes.defineBindableBool Map.HasScrollEnabledProperty
 
 //     let MapKey = Widgets.register<Map> ()
 

--- a/src/Fabulous.Tests/APISketchTests.fs
+++ b/src/Fabulous.Tests/APISketchTests.fs
@@ -18,12 +18,11 @@ let rec findOptional (root: TestViewElement) (id: string) : TestViewElement opti
     else
         match root with
         | :? TestStack as stack ->
-            let children =
-                (stack :> IContainer).Children
+            let children = (stack :> IContainer).Children
 
             children
             |> Array.ofSeq
-            |> Array.fold (fun res child -> res |> Option.orElse(findOptional child id)) None
+            |> Array.fold(fun res child -> res |> Option.orElse(findOptional child id)) None
 
         | _ -> None
 
@@ -61,8 +60,7 @@ module SimpleLabelTests =
 
         let el = (instance.Start())
 
-        let label =
-            find<TestLabel> el "label" :> IText
+        let label = find<TestLabel> el "label" :> IText
 
         Assert.AreEqual(label.Text, "hi")
         instance.ProcessMessage(SetText "yo")
@@ -119,18 +117,19 @@ module SimpleStackTests =
         | AddNew (id, text) -> (id, text) :: model
         | ChangeText (id, text) ->
             model
-            |> List.map (fun (id_, text_) ->
-                if id = id_ then
-                    (id, text)
-                else
-                    (id_, text_))
+            |> List.map
+                (fun (id_, text_) ->
+                    if id = id_ then
+                        (id, text)
+                    else
+                        (id_, text_))
 
     let view model =
         (Stack() {
             yield!
                 model
                 |> List.map(fun (id, text) -> (Label(text).automationId(id.ToString())))
-        })
+         })
             .automationId("stack")
 
 
@@ -203,13 +202,12 @@ module ComputationExpressionTest =
             Stack() { Button("inc", Inc).automationId("inc") }
 
         let instance =
-            StatefulWidget.mkSimpleView (fun () -> 0) update view
+            StatefulWidget.mkSimpleView(fun () -> 0) update view
             |> Run.Instance
 
         let tree = (instance.Start())
 
-        let btn =
-            find<TestButton> tree "inc" :> IText
+        let btn = find<TestButton> tree "inc" :> IText
 
         Assert.AreEqual(btn.Text, "inc")
 
@@ -223,12 +221,12 @@ module ComputationExpressionTest =
                     Label("label").automationId("label")
                 else
                     Button("btn", Inc).automationId("btn")
-            })
+             })
                 .automationId("stack")
 
 
         let instance =
-            StatefulWidget.mkSimpleView (fun () -> 0) update view
+            StatefulWidget.mkSimpleView(fun () -> 0) update view
             |> Run.Instance
 
         let tree = (instance.Start())
@@ -239,8 +237,7 @@ module ComputationExpressionTest =
         Assert.AreEqual(1, stack.Children.Count)
 
         // we start with zero, thus label should be present
-        let label =
-            find<TestLabel> tree "label" :> IText
+        let label = find<TestLabel> tree "label" :> IText
 
         Assert.AreEqual(label.Text, "label")
 
@@ -250,8 +247,7 @@ module ComputationExpressionTest =
         Assert.AreEqual(1, stack.Children.Count)
 
         // but now Button should be present
-        let btn =
-            find<TestButton> tree "btn" :> IText
+        let btn = find<TestButton> tree "btn" :> IText
 
         Assert.AreEqual(btn.Text, "btn")
 
@@ -264,17 +260,17 @@ module ComputationExpressionTest =
             Stack() {
                 // requires implemented "YieldFrom"
                 yield!
-                    [ for i in 0..model -> i.ToString() ]
+                    [ for i in 0 .. model -> i.ToString() ]
                     |> List.map(fun i -> Label(i).automationId(i))
             }
 
         let instance =
-            StatefulWidget.mkSimpleView (fun () -> count) update view
+            StatefulWidget.mkSimpleView(fun () -> count) update view
             |> Run.Instance
 
         let tree = (instance.Start())
 
-        for i in 0..count do
+        for i in 0 .. count do
             let label =
                 find<TestLabel> tree (i.ToString()) :> IText
 
@@ -289,16 +285,16 @@ module ComputationExpressionTest =
         let view model =
             Stack() {
                 // requires implemented "For"
-                for i in 0..model -> Label(i.ToString()).automationId(i.ToString())
+                for i in 0 .. model -> Label(i.ToString()).automationId(i.ToString())
             }
 
         let instance =
-            StatefulWidget.mkSimpleView (fun () -> count) update view
+            StatefulWidget.mkSimpleView(fun () -> count) update view
             |> Run.Instance
 
         let tree = (instance.Start())
 
-        for i in 0..count do
+        for i in 0 .. count do
             let label =
                 find<TestLabel> tree (i.ToString()) :> IText
 
@@ -350,11 +346,9 @@ module MapViewTests =
 
         let addBtn = find<TestButton> tree "add"
 
-        let removeBtn =
-            find<TestButton> tree "remove"
+        let removeBtn = find<TestButton> tree "remove"
 
-        let label =
-            find<TestLabel> tree "label" :> IText
+        let label = find<TestLabel> tree "label" :> IText
 
         Assert.AreEqual("0", label.Text)
 
@@ -410,11 +404,9 @@ module MemoTests =
             // executed just once to construct the tree
             Assert.AreEqual(1, renderCount)
 
-            let notMemoLabel =
-                find<TestLabel> tree "not_memo" :> IText
+            let notMemoLabel = find<TestLabel> tree "not_memo" :> IText
 
-            let memoLabel =
-                find<TestLabel> tree "memo" :> IText
+            let memoLabel = find<TestLabel> tree "memo" :> IText
 
             Assert.AreEqual("0", memoLabel.Text)
 
@@ -447,9 +439,9 @@ module MemoTests =
         let view model =
             (Stack() {
                 match model with
-                | Btn -> View.lazy' (fun i -> Button(string i, Change).automationId("btn")) model
-                | Lbl -> View.lazy' (fun i -> Label(string i).automationId("label")) model
-            })
+                | Btn -> View.lazy'(fun i -> Button(string i, Change).automationId("btn")) model
+                | Lbl -> View.lazy'(fun i -> Label(string i).automationId("label")) model
+             })
                 .automationId("stack")
 
         [<Test>]
@@ -476,8 +468,7 @@ module MemoTests =
             Assert.AreEqual(1, stack.Children.Count)
 
             // but it is label now
-            let label =
-                find<TestLabel> tree "label" :> IText
+            let label = find<TestLabel> tree "label" :> IText
 
             Assert.AreEqual(string Lbl, label.Text)
 
@@ -532,8 +523,7 @@ module MemoTests =
 
             instance.ProcessMessage(Change)
 
-            let labelAgain =
-                find<TestLabel> tree "label"
+            let labelAgain = find<TestLabel> tree "label"
 
             // same instance
             Assert.AreSame(label, labelAgain)
@@ -555,7 +545,9 @@ module SmallScalars =
 
     let update msg model =
         match msg with
-        | Inc value -> { model with value = model.value + value }
+        | Inc value ->
+            { model with
+                  value = model.value + value }
 
     let view model =
         InlineNumericBag(model.value, model.value + 1UL, float(model.value + 2UL))
@@ -572,8 +564,7 @@ module SmallScalars =
 
         let el = (instance.Start())
 
-        let numbers =
-            find<TestNumericBag> el "numbers"
+        let numbers = find<TestNumericBag> el "numbers"
 
         Assert.AreEqual(numbers.valueOne, 0UL)
         Assert.AreEqual(numbers.valueTwo, 1UL)
@@ -612,18 +603,15 @@ module Issue99 =
         let instance = Run.Instance program
         let tree = instance.Start()
 
-        let button1Start =
-            find<TestButton> tree "button1"
+        let button1Start = find<TestButton> tree "button1"
 
         instance.ProcessMessage(Toggle)
 
-        let button1Toggled =
-            find<TestButton> tree "button1"
+        let button1Toggled = find<TestButton> tree "button1"
 
         instance.ProcessMessage(Toggle)
 
-        let button1Untoggled =
-            find<TestButton> tree "button1"
+        let button1Untoggled = find<TestButton> tree "button1"
 
         Assert.AreSame(button1Start, button1Toggled)
         Assert.AreSame(button1Start, button1Untoggled)
@@ -653,8 +641,7 @@ module Issue104 =
     let Attr5 =
         Attributes.define<string> "Attr5" (fun _ _ _ -> ())
 
-    let ControlWidgetKey =
-        Widgets.register<TestButton>()
+    let ControlWidgetKey = Widgets.register<TestButton>()
 
     let Control<'msg> () =
         WidgetBuilder<'msg, TestButtonMarker>(
@@ -738,8 +725,7 @@ module Attributes =
     let IntEnumCodecForSmallScalars () =
         let one = MyEnumAttr.WithValue(MyEnum.One)
 
-        let minusOne =
-            MyEnumAttr.WithValue(MyEnum.MinusOne)
+        let minusOne = MyEnumAttr.WithValue(MyEnum.MinusOne)
 
         Assert.AreEqual(MyEnum.One, SmallScalars.IntEnum.decode<MyEnum> one.NumericValue)
         Assert.AreEqual(MyEnum.MinusOne, SmallScalars.IntEnum.decode<MyEnum> minusOne.NumericValue)

--- a/src/Fabulous.Tests/APISketchTests.fs
+++ b/src/Fabulous.Tests/APISketchTests.fs
@@ -18,11 +18,12 @@ let rec findOptional (root: TestViewElement) (id: string) : TestViewElement opti
     else
         match root with
         | :? TestStack as stack ->
-            let children = (stack :> IContainer).Children
+            let children =
+                (stack :> IContainer).Children
 
             children
             |> Array.ofSeq
-            |> Array.fold(fun res child -> res |> Option.orElse(findOptional child id)) None
+            |> Array.fold (fun res child -> res |> Option.orElse(findOptional child id)) None
 
         | _ -> None
 
@@ -60,7 +61,8 @@ module SimpleLabelTests =
 
         let el = (instance.Start())
 
-        let label = find<TestLabel> el "label" :> IText
+        let label =
+            find<TestLabel> el "label" :> IText
 
         Assert.AreEqual(label.Text, "hi")
         instance.ProcessMessage(SetText "yo")
@@ -117,19 +119,18 @@ module SimpleStackTests =
         | AddNew (id, text) -> (id, text) :: model
         | ChangeText (id, text) ->
             model
-            |> List.map
-                (fun (id_, text_) ->
-                    if id = id_ then
-                        (id, text)
-                    else
-                        (id_, text_))
+            |> List.map (fun (id_, text_) ->
+                if id = id_ then
+                    (id, text)
+                else
+                    (id_, text_))
 
     let view model =
         (Stack() {
             yield!
                 model
                 |> List.map(fun (id, text) -> (Label(text).automationId(id.ToString())))
-         })
+        })
             .automationId("stack")
 
 
@@ -202,12 +203,13 @@ module ComputationExpressionTest =
             Stack() { Button("inc", Inc).automationId("inc") }
 
         let instance =
-            StatefulWidget.mkSimpleView(fun () -> 0) update view
+            StatefulWidget.mkSimpleView (fun () -> 0) update view
             |> Run.Instance
 
         let tree = (instance.Start())
 
-        let btn = find<TestButton> tree "inc" :> IText
+        let btn =
+            find<TestButton> tree "inc" :> IText
 
         Assert.AreEqual(btn.Text, "inc")
 
@@ -221,12 +223,12 @@ module ComputationExpressionTest =
                     Label("label").automationId("label")
                 else
                     Button("btn", Inc).automationId("btn")
-             })
+            })
                 .automationId("stack")
 
 
         let instance =
-            StatefulWidget.mkSimpleView(fun () -> 0) update view
+            StatefulWidget.mkSimpleView (fun () -> 0) update view
             |> Run.Instance
 
         let tree = (instance.Start())
@@ -237,7 +239,8 @@ module ComputationExpressionTest =
         Assert.AreEqual(1, stack.Children.Count)
 
         // we start with zero, thus label should be present
-        let label = find<TestLabel> tree "label" :> IText
+        let label =
+            find<TestLabel> tree "label" :> IText
 
         Assert.AreEqual(label.Text, "label")
 
@@ -247,7 +250,8 @@ module ComputationExpressionTest =
         Assert.AreEqual(1, stack.Children.Count)
 
         // but now Button should be present
-        let btn = find<TestButton> tree "btn" :> IText
+        let btn =
+            find<TestButton> tree "btn" :> IText
 
         Assert.AreEqual(btn.Text, "btn")
 
@@ -260,17 +264,17 @@ module ComputationExpressionTest =
             Stack() {
                 // requires implemented "YieldFrom"
                 yield!
-                    [ for i in 0 .. model -> i.ToString() ]
+                    [ for i in 0..model -> i.ToString() ]
                     |> List.map(fun i -> Label(i).automationId(i))
             }
 
         let instance =
-            StatefulWidget.mkSimpleView(fun () -> count) update view
+            StatefulWidget.mkSimpleView (fun () -> count) update view
             |> Run.Instance
 
         let tree = (instance.Start())
 
-        for i in 0 .. count do
+        for i in 0..count do
             let label =
                 find<TestLabel> tree (i.ToString()) :> IText
 
@@ -285,16 +289,16 @@ module ComputationExpressionTest =
         let view model =
             Stack() {
                 // requires implemented "For"
-                for i in 0 .. model -> Label(i.ToString()).automationId(i.ToString())
+                for i in 0..model -> Label(i.ToString()).automationId(i.ToString())
             }
 
         let instance =
-            StatefulWidget.mkSimpleView(fun () -> count) update view
+            StatefulWidget.mkSimpleView (fun () -> count) update view
             |> Run.Instance
 
         let tree = (instance.Start())
 
-        for i in 0 .. count do
+        for i in 0..count do
             let label =
                 find<TestLabel> tree (i.ToString()) :> IText
 
@@ -345,8 +349,12 @@ module MapViewTests =
         let tree = (instance.Start())
 
         let addBtn = find<TestButton> tree "add"
-        let removeBtn = find<TestButton> tree "remove"
-        let label = find<TestLabel> tree "label" :> IText
+
+        let removeBtn =
+            find<TestButton> tree "remove"
+
+        let label =
+            find<TestLabel> tree "label" :> IText
 
         Assert.AreEqual("0", label.Text)
 
@@ -402,8 +410,11 @@ module MemoTests =
             // executed just once to construct the tree
             Assert.AreEqual(1, renderCount)
 
-            let notMemoLabel = find<TestLabel> tree "not_memo" :> IText
-            let memoLabel = find<TestLabel> tree "memo" :> IText
+            let notMemoLabel =
+                find<TestLabel> tree "not_memo" :> IText
+
+            let memoLabel =
+                find<TestLabel> tree "memo" :> IText
 
             Assert.AreEqual("0", memoLabel.Text)
 
@@ -436,9 +447,9 @@ module MemoTests =
         let view model =
             (Stack() {
                 match model with
-                | Btn -> View.lazy'(fun i -> Button(string i, Change).automationId("btn")) model
-                | Lbl -> View.lazy'(fun i -> Label(string i).automationId("label")) model
-             })
+                | Btn -> View.lazy' (fun i -> Button(string i, Change).automationId("btn")) model
+                | Lbl -> View.lazy' (fun i -> Label(string i).automationId("label")) model
+            })
                 .automationId("stack")
 
         [<Test>]
@@ -465,7 +476,9 @@ module MemoTests =
             Assert.AreEqual(1, stack.Children.Count)
 
             // but it is label now
-            let label = find<TestLabel> tree "label" :> IText
+            let label =
+                find<TestLabel> tree "label" :> IText
+
             Assert.AreEqual(string Lbl, label.Text)
 
     module ViewNodeInstanceCanBeReused =
@@ -519,7 +532,8 @@ module MemoTests =
 
             instance.ProcessMessage(Change)
 
-            let labelAgain = find<TestLabel> tree "label"
+            let labelAgain =
+                find<TestLabel> tree "label"
 
             // same instance
             Assert.AreSame(label, labelAgain)
@@ -541,9 +555,7 @@ module SmallScalars =
 
     let update msg model =
         match msg with
-        | Inc value ->
-            { model with
-                  value = model.value + value }
+        | Inc value -> { model with value = model.value + value }
 
     let view model =
         InlineNumericBag(model.value, model.value + 1UL, float(model.value + 2UL))
@@ -560,7 +572,8 @@ module SmallScalars =
 
         let el = (instance.Start())
 
-        let numbers = find<TestNumericBag> el "numbers"
+        let numbers =
+            find<TestNumericBag> el "numbers"
 
         Assert.AreEqual(numbers.valueOne, 0UL)
         Assert.AreEqual(numbers.valueTwo, 1UL)
@@ -599,13 +612,18 @@ module Issue99 =
         let instance = Run.Instance program
         let tree = instance.Start()
 
-        let button1Start = find<TestButton> tree "button1"
+        let button1Start =
+            find<TestButton> tree "button1"
 
         instance.ProcessMessage(Toggle)
-        let button1Toggled = find<TestButton> tree "button1"
+
+        let button1Toggled =
+            find<TestButton> tree "button1"
 
         instance.ProcessMessage(Toggle)
-        let button1Untoggled = find<TestButton> tree "button1"
+
+        let button1Untoggled =
+            find<TestButton> tree "button1"
 
         Assert.AreSame(button1Start, button1Toggled)
         Assert.AreSame(button1Start, button1Untoggled)
@@ -635,7 +653,8 @@ module Issue104 =
     let Attr5 =
         Attributes.define<string> "Attr5" (fun _ _ _ -> ())
 
-    let ControlWidgetKey = Widgets.register<TestButton>()
+    let ControlWidgetKey =
+        Widgets.register<TestButton>()
 
     let Control<'msg> () =
         WidgetBuilder<'msg, TestButtonMarker>(
@@ -705,3 +724,22 @@ module Issue104 =
         let tree = instance.Start()
 
         instance.ProcessMessage(Toggle)
+
+module Attributes =
+
+    type MyEnum =
+        | One = 1
+        | MinusOne = -1
+
+    let MyEnumAttr =
+        Attributes.defineEnum<MyEnum> "hey" (fun _ _ _ -> ())
+
+    [<Test>]
+    let IntEnumCodecForSmallScalars () =
+        let one = MyEnumAttr.WithValue(MyEnum.One)
+
+        let minusOne =
+            MyEnumAttr.WithValue(MyEnum.MinusOne)
+
+        Assert.AreEqual(MyEnum.One, SmallScalars.IntEnum.decode<MyEnum> one.NumericValue)
+        Assert.AreEqual(MyEnum.MinusOne, SmallScalars.IntEnum.decode<MyEnum> minusOne.NumericValue)

--- a/src/Fabulous.Tests/TestUI.Attributes.fs
+++ b/src/Fabulous.Tests/TestUI.Attributes.fs
@@ -41,7 +41,7 @@ module Attributes =
 
     module Text =
         let Record =
-            Attributes.define<bool> "Text" TestUI_ViewUpdaters.updateRecord
+            Attributes.defineBool "Text" TestUI_ViewUpdaters.updateRecord
 
         let Text =
             Attributes.define<string> "Text" TestUI_ViewUpdaters.updateText
@@ -65,7 +65,7 @@ module Attributes =
     module Automation =
         let AutomationId =
             Attributes.define<string> "AutomationId" TestUI_ViewUpdaters.updateAutomationId
-
+   
     module NumericBag =
         let InlineValueOne =
             Attributes.defineSmallScalar<uint64> "InlineValueOne" id TestUI_ViewUpdaters.updateNumericValueOne

--- a/src/Fabulous.Tests/TestUI.Attributes.fs
+++ b/src/Fabulous.Tests/TestUI.Attributes.fs
@@ -41,7 +41,7 @@ module Attributes =
 
     module Text =
         let Record =
-            Attributes.defineBool "Text" TestUI_ViewUpdaters.updateRecord
+            Attributes.defineBool "Record" TestUI_ViewUpdaters.updateRecord
 
         let Text =
             Attributes.define<string> "Text" TestUI_ViewUpdaters.updateText

--- a/src/Fabulous.Tests/TestUI.Attributes.fs
+++ b/src/Fabulous.Tests/TestUI.Attributes.fs
@@ -65,7 +65,7 @@ module Attributes =
     module Automation =
         let AutomationId =
             Attributes.define<string> "AutomationId" TestUI_ViewUpdaters.updateAutomationId
-   
+
     module NumericBag =
         let InlineValueOne =
             Attributes.defineSmallScalar<uint64> "InlineValueOne" id TestUI_ViewUpdaters.updateNumericValueOne

--- a/src/Fabulous.Tests/TestUI.Widgets.fs
+++ b/src/Fabulous.Tests/TestUI.Widgets.fs
@@ -20,33 +20,34 @@ open Tests.TestUI_ViewNode
 
 module Widgets =
     let register<'T when 'T :> TestViewElement and 'T: (new: unit -> 'T)> () =
-        let key = WidgetDefinitionStore.getNextKey ()
+        let key = WidgetDefinitionStore.getNextKey()
 
         let definition =
             { Key = key
               Name = typeof<'T>.Name
               TargetType = typeof<'T>
               CreateView =
-                fun (widget, context, parentNode) ->
-                    let name = typeof<'T>.Name
-                    //                      printfn $"Creating view for {name}"
+                  fun (widget, context, parentNode) ->
+                      let name = typeof<'T>.Name
+                      //                      printfn $"Creating view for {name}"
 
-                    let view = new 'T()
-                    let weakReference = WeakReference(view)
+                      let view = new 'T()
+                      let weakReference = WeakReference(view)
 
-                    let parentNode =
-                        match parentNode with
-                        | ValueNone -> None
-                        | ValueSome parent -> Some parent
+                      let parentNode =
+                          match parentNode with
+                          | ValueNone -> None
+                          | ValueSome parent -> Some parent
 
-                    let viewNode = ViewNode(parentNode, context, weakReference)
+                      let viewNode =
+                          ViewNode(parentNode, context, weakReference)
 
-                    view.PropertyBag.Add(ViewNode.ViewNodeProperty, viewNode)
+                      view.PropertyBag.Add(ViewNode.ViewNodeProperty, viewNode)
 
-                    let oldWidget: Widget voption = ValueNone
+                      let oldWidget: Widget voption = ValueNone
 
-                    Reconciler.update context.CanReuseView oldWidget widget viewNode
-                    struct (viewNode :> IViewNode, box view) }
+                      Reconciler.update context.CanReuseView oldWidget widget viewNode
+                      struct (viewNode :> IViewNode, box view) }
 
         WidgetDefinitionStore.set key definition
         key
@@ -110,10 +111,10 @@ type WidgetExtensions() =
 
 [<AbstractClass; Sealed>]
 type View private () =
-    static let TestLabelKey = Widgets.register<TestLabel> ()
-    static let TestButtonKey = Widgets.register<TestButton> ()
-    static let TestStackKey = Widgets.register<TestStack> ()
-    static let TestNumericBagKey = Widgets.register<TestNumericBag> ()
+    static let TestLabelKey = Widgets.register<TestLabel>()
+    static let TestButtonKey = Widgets.register<TestButton>()
+    static let TestStackKey = Widgets.register<TestStack>()
+    static let TestNumericBagKey = Widgets.register<TestNumericBag>()
 
     static member Label<'msg>(text: string) =
         WidgetBuilder<'msg, TestLabelMarker>(TestLabelKey, Attributes.Text.Text.WithValue(text))
@@ -139,7 +140,7 @@ type View private () =
             TestNumericBagKey,
             Attributes.NumericBag.InlineValueOne.WithValue(one, (fun x -> x)),
             Attributes.NumericBag.InlineValueTwo.WithValue(two, (fun x -> x)),
-//            Attributes.NumericBag.InlineValueOne.WithValue(one, Attributes.func),
+            //            Attributes.NumericBag.InlineValueOne.WithValue(one, Attributes.func),
 //            Attributes.NumericBag.InlineValueTwo.WithValue(two, Attributes.func),
             Attributes.NumericBag.InlineValueThree.WithValue(three, BitConverter.DoubleToUInt64Bits)
         )
@@ -147,7 +148,7 @@ type View private () =
     static member Stack<'msg, 'marker when 'marker :> IMarker>() =
         CollectionBuilder<'msg, TestStackMarker, 'marker>(
             TestStackKey,
-            StackList.empty (),
+            StackList.empty(),
             Attributes.Container.Children
         )
 
@@ -179,10 +180,10 @@ type CollectionBuilderExtensions =
         ) : Content<'msg> =
         // TODO optimize this one with addMut
         { Widgets =
-            x
-            |> Seq.map (fun wb -> wb.Compile())
-            |> Seq.toArray
-            |> MutStackArray1.fromArray }
+              x
+              |> Seq.map(fun wb -> wb.Compile())
+              |> Seq.toArray
+              |> MutStackArray1.fromArray }
 
 
 
@@ -237,7 +238,8 @@ module Run =
             let widget = program.View(model).Compile()
             let widgetDef = WidgetDefinitionStore.get widget.Key
 
-            let struct (_node, view) = widgetDef.CreateView(widget, x.viewContext, ValueNone)
+            let struct (_node, view) =
+                widgetDef.CreateView(widget, x.viewContext, ValueNone)
 
             state <- Some(model, view, widget)
 

--- a/src/Fabulous.Tests/TestUI.Widgets.fs
+++ b/src/Fabulous.Tests/TestUI.Widgets.fs
@@ -103,7 +103,7 @@ type WidgetExtensions() =
             this: WidgetBuilder<'msg, 'marker>,
             value: bool
         ) =
-        this.AddScalar(Attributes.Text.Record.WithValue(value, SmallScalars.Bool.encode))
+        this.AddScalar(Attributes.Text.Record.WithValue(value))
 
 ///----------------
 ///----------------

--- a/src/Fabulous.Tests/TestUI.Widgets.fs
+++ b/src/Fabulous.Tests/TestUI.Widgets.fs
@@ -20,34 +20,33 @@ open Tests.TestUI_ViewNode
 
 module Widgets =
     let register<'T when 'T :> TestViewElement and 'T: (new: unit -> 'T)> () =
-        let key = WidgetDefinitionStore.getNextKey()
+        let key = WidgetDefinitionStore.getNextKey ()
 
         let definition =
             { Key = key
               Name = typeof<'T>.Name
               TargetType = typeof<'T>
               CreateView =
-                  fun (widget, context, parentNode) ->
-                      let name = typeof<'T>.Name
-                      //                      printfn $"Creating view for {name}"
+                fun (widget, context, parentNode) ->
+                    let name = typeof<'T>.Name
+                    //                      printfn $"Creating view for {name}"
 
-                      let view = new 'T()
-                      let weakReference = WeakReference(view)
+                    let view = new 'T()
+                    let weakReference = WeakReference(view)
 
-                      let parentNode =
-                          match parentNode with
-                          | ValueNone -> None
-                          | ValueSome parent -> Some parent
+                    let parentNode =
+                        match parentNode with
+                        | ValueNone -> None
+                        | ValueSome parent -> Some parent
 
-                      let viewNode =
-                          ViewNode(parentNode, context, weakReference)
+                    let viewNode = ViewNode(parentNode, context, weakReference)
 
-                      view.PropertyBag.Add(ViewNode.ViewNodeProperty, viewNode)
+                    view.PropertyBag.Add(ViewNode.ViewNodeProperty, viewNode)
 
-                      let oldWidget: Widget voption = ValueNone
+                    let oldWidget: Widget voption = ValueNone
 
-                      Reconciler.update context.CanReuseView oldWidget widget viewNode
-                      struct (viewNode :> IViewNode, box view) }
+                    Reconciler.update context.CanReuseView oldWidget widget viewNode
+                    struct (viewNode :> IViewNode, box view) }
 
         WidgetDefinitionStore.set key definition
         key
@@ -104,16 +103,17 @@ type WidgetExtensions() =
             this: WidgetBuilder<'msg, 'marker>,
             value: bool
         ) =
-        this.AddScalar(Attributes.Text.Record.WithValue(value))
+        this.AddScalar(Attributes.Text.Record.WithValue(value, SmallScalars.Bool.encode))
 
+///----------------
 ///----------------
 
 [<AbstractClass; Sealed>]
 type View private () =
-    static let TestLabelKey = Widgets.register<TestLabel>()
-    static let TestButtonKey = Widgets.register<TestButton>()
-    static let TestStackKey = Widgets.register<TestStack>()
-    static let TestNumericBagKey = Widgets.register<TestNumericBag>()
+    static let TestLabelKey = Widgets.register<TestLabel> ()
+    static let TestButtonKey = Widgets.register<TestButton> ()
+    static let TestStackKey = Widgets.register<TestStack> ()
+    static let TestNumericBagKey = Widgets.register<TestNumericBag> ()
 
     static member Label<'msg>(text: string) =
         WidgetBuilder<'msg, TestLabelMarker>(TestLabelKey, Attributes.Text.Text.WithValue(text))
@@ -139,13 +139,15 @@ type View private () =
             TestNumericBagKey,
             Attributes.NumericBag.InlineValueOne.WithValue(one, (fun x -> x)),
             Attributes.NumericBag.InlineValueTwo.WithValue(two, (fun x -> x)),
+//            Attributes.NumericBag.InlineValueOne.WithValue(one, Attributes.func),
+//            Attributes.NumericBag.InlineValueTwo.WithValue(two, Attributes.func),
             Attributes.NumericBag.InlineValueThree.WithValue(three, BitConverter.DoubleToUInt64Bits)
         )
 
     static member Stack<'msg, 'marker when 'marker :> IMarker>() =
         CollectionBuilder<'msg, TestStackMarker, 'marker>(
             TestStackKey,
-            StackList.empty(),
+            StackList.empty (),
             Attributes.Container.Children
         )
 
@@ -177,10 +179,10 @@ type CollectionBuilderExtensions =
         ) : Content<'msg> =
         // TODO optimize this one with addMut
         { Widgets =
-              x
-              |> Seq.map(fun wb -> wb.Compile())
-              |> Seq.toArray
-              |> MutStackArray1.fromArray }
+            x
+            |> Seq.map (fun wb -> wb.Compile())
+            |> Seq.toArray
+            |> MutStackArray1.fromArray }
 
 
 
@@ -235,8 +237,7 @@ module Run =
             let widget = program.View(model).Compile()
             let widgetDef = WidgetDefinitionStore.get widget.Key
 
-            let struct (_node, view) =
-                widgetDef.CreateView(widget, x.viewContext, ValueNone)
+            let struct (_node, view) = widgetDef.CreateView(widget, x.viewContext, ValueNone)
 
             state <- Some(model, view, widget)
 

--- a/src/Fabulous.XamarinForms/Attributes.fs
+++ b/src/Fabulous.XamarinForms/Attributes.fs
@@ -164,7 +164,7 @@ module Attributes =
     /// that is, it allocates 2 bytes for each of channel of RGBA.
     /// Technically it might loose precision of (0.0 .. 1.0) float range used in XF.Color.
     /// If you want to avoid any potential loss of accuracy you can use "defineBindable" instead.
-    /// It is 100% accurate but allocates XF.Color values on the heap (thus slower) 
+    /// It is 100% accurate but allocates XF.Color values on the heap (thus slower)
     let inline defineBindableColor (bindableProperty: BindableProperty) =
         defineSmallBindable bindableProperty SmallScalars.Color.decode
 

--- a/src/Fabulous.XamarinForms/Attributes.fs
+++ b/src/Fabulous.XamarinForms/Attributes.fs
@@ -159,7 +159,12 @@ module Attributes =
     let inline defineBindableInt (bindableProperty: BindableProperty) =
         defineSmallBindable bindableProperty SmallScalars.Int.decode
 
-    /// Defines a bindable Color attribute and encodes it as a small scalar (8 bytes)
+    /// Defines a bindable Color attribute and encodes it as a small scalar (8 bytes).
+    /// Note that this uses a faster but a technically lossy internal representation
+    /// that is, it allocates 2 bytes for each of channel of RGBA.
+    /// Technically it might loose precision of (0.0 .. 1.0) float range used in XF.Color.
+    /// If you want to avoid any potential loss of accuracy you can use "defineBindable" instead.
+    /// It is 100% accurate but allocates XF.Color values on the heap (thus slower) 
     let inline defineBindableColor (bindableProperty: BindableProperty) =
         defineSmallBindable bindableProperty SmallScalars.Color.decode
 

--- a/src/Fabulous.XamarinForms/Attributes.fs
+++ b/src/Fabulous.XamarinForms/Attributes.fs
@@ -13,9 +13,9 @@ module AppTheme =
     let inline create<'T> (light: 'T) (dark: 'T option) =
         { Light = light
           Dark =
-            match dark with
-            | None -> ValueNone
-            | Some v -> ValueSome v }
+              match dark with
+              | None -> ValueNone
+              | Some v -> ValueSome v }
 
 [<Struct>]
 type ValueEventData<'data, 'eventArgs> =
@@ -42,14 +42,11 @@ module SmallScalars =
             r ||| g ||| b ||| a
 
         let inline decode (encoded: uint64) : Color =
-            let r =
-                (encoded &&& 0xFFFF000000000000UL) >>> 6
+            let r = (encoded &&& 0xFFFF000000000000UL) >>> 6
 
-            let g =
-                (encoded &&& 0x0000FFFF00000000UL) >>> 4
+            let g = (encoded &&& 0x0000FFFF00000000UL) >>> 4
 
-            let b =
-                (encoded &&& 0x00000000FFFF0000UL) >>> 2
+            let b = (encoded &&& 0x00000000FFFF0000UL) >>> 2
 
             let a = (encoded &&& 0x000000000000FFFFUL)
             let inline toFloat value = (float value) / 65535.0
@@ -59,8 +56,7 @@ module SmallScalars =
         let inline encode (v: LayoutOptions) : uint64 =
             let alignment = uint64 v.Alignment
 
-            let expands: uint64 =
-                if v.Expands then 1UL else 0UL
+            let expands: uint64 = if v.Expands then 1UL else 0UL
 
             (alignment <<< 4) ||| expands
 
@@ -68,8 +64,7 @@ module SmallScalars =
             let alignment =
                 enum<LayoutAlignment>(int((encoded &&& 0xFFFFFFFF00000000UL) >>> 4))
 
-            let expands =
-                (encoded &&& 0x00000000FFFFFFFFUL) = 1UL
+            let expands = (encoded &&& 0x00000000FFFFFFFFUL) = 1UL
 
             LayoutOptions(alignment, expands)
 
@@ -95,8 +90,7 @@ module Attributes =
 
                 ViewNode.get childTarget)
             (fun target value ->
-                let bindableObject =
-                    target :?> BindableObject
+                let bindableObject = target :?> BindableObject
 
                 if value = null then
                     bindableObject.ClearValue(bindableProperty)
@@ -123,31 +117,38 @@ module Attributes =
                 | ValueSome v -> target.SetValue(bindableProperty, v))
 
     let inline defineBindable<'T when 'T: equality> (bindableProperty: BindableProperty) =
-        Attributes.define<'T> bindableProperty.PropertyName (fun _ newValueOpt node ->
-            let target = node.Target :?> BindableObject
+        Attributes.define<'T>
+            bindableProperty.PropertyName
+            (fun _ newValueOpt node ->
+                let target = node.Target :?> BindableObject
 
-            match newValueOpt with
-            | ValueNone -> target.ClearValue(bindableProperty)
-            | ValueSome v -> target.SetValue(bindableProperty, v))
+                match newValueOpt with
+                | ValueNone -> target.ClearValue(bindableProperty)
+                | ValueSome v -> target.SetValue(bindableProperty, v))
 
     let inline defineBindableEnum< ^T when ^T: enum<int>>
         (bindableProperty: BindableProperty)
         : SmallScalarAttributeDefinition< ^T > =
-        Attributes.defineEnum< ^T> bindableProperty.PropertyName (fun _ newValueOpt node ->
-            let target = node.Target :?> BindableObject
+        Attributes.defineEnum< ^T>
+            bindableProperty.PropertyName
+            (fun _ newValueOpt node ->
+                let target = node.Target :?> BindableObject
 
-            match newValueOpt with
-            | ValueNone -> target.ClearValue(bindableProperty)
-            | ValueSome v -> target.SetValue(bindableProperty, v))
+                match newValueOpt with
+                | ValueNone -> target.ClearValue(bindableProperty)
+                | ValueSome v -> target.SetValue(bindableProperty, v))
 
 
     let inline defineSmallBindable<'T> (bindableProperty: BindableProperty) ([<InlineIfLambda>] decode: uint64 -> 'T) =
-        Attributes.defineSmallScalar<'T> bindableProperty.PropertyName decode (fun _ newValueOpt node ->
-            let target = node.Target :?> BindableObject
+        Attributes.defineSmallScalar<'T>
+            bindableProperty.PropertyName
+            decode
+            (fun _ newValueOpt node ->
+                let target = node.Target :?> BindableObject
 
-            match newValueOpt with
-            | ValueNone -> target.ClearValue(bindableProperty)
-            | ValueSome v -> target.SetValue(bindableProperty, v))
+                match newValueOpt with
+                | ValueNone -> target.ClearValue(bindableProperty)
+                | ValueSome v -> target.SetValue(bindableProperty, v))
 
     let inline defineBindableFloat (bindableProperty: BindableProperty) =
         defineSmallBindable bindableProperty SmallScalars.Float.decode
@@ -163,13 +164,16 @@ module Attributes =
         defineSmallBindable bindableProperty SmallScalars.Color.decode
 
     let inline defineAppThemeBindable<'T when 'T: equality> (bindableProperty: BindableProperty) =
-        Attributes.define<AppThemeValues<'T>> bindableProperty.PropertyName (fun _ newValueOpt node ->
-            let target = node.Target :?> BindableObject
+        Attributes.define<AppThemeValues<'T>>
+            bindableProperty.PropertyName
+            (fun _ newValueOpt node ->
+                let target = node.Target :?> BindableObject
 
-            match newValueOpt with
-            | ValueNone -> target.ClearValue(bindableProperty)
-            | ValueSome { Light = light; Dark = ValueNone } -> target.SetValue(bindableProperty, light)
-            | ValueSome { Light = light; Dark = ValueSome dark } -> target.SetOnAppTheme(bindableProperty, light, dark))
+                match newValueOpt with
+                | ValueNone -> target.ClearValue(bindableProperty)
+                | ValueSome { Light = light; Dark = ValueNone } -> target.SetValue(bindableProperty, light)
+                | ValueSome { Light = light; Dark = ValueSome dark } ->
+                    target.SetOnAppTheme(bindableProperty, light, dark))
 
     /// Update both a property and its related event.
     /// This definition makes sure that the event is only raised when the property is changed by the user,
@@ -210,9 +214,10 @@ module Attributes =
 
                         // Set the new event handler
                         let handler =
-                            EventHandler<'args> (fun _ args ->
-                                let r = curr.Event args
-                                Dispatcher.dispatch node r)
+                            EventHandler<'args>
+                                (fun _ args ->
+                                    let r = curr.Event args
+                                    Dispatcher.dispatch node r)
 
                         node.SetHandler(name, ValueSome handler)
                         event.AddHandler(handler))

--- a/src/Fabulous.XamarinForms/Views/Cells/EntryCell.fs
+++ b/src/Fabulous.XamarinForms/Views/Cells/EntryCell.fs
@@ -8,8 +8,7 @@ type IEntryCell =
     inherit ICell
 
 module EntryCell =
-    let WidgetKey =
-        Widgets.register<CustomEntryCell>()
+    let WidgetKey = Widgets.register<CustomEntryCell>()
 
     let Label =
         Attributes.defineBindable<string> EntryCell.LabelProperty
@@ -30,8 +29,10 @@ module EntryCell =
         Attributes.defineBindable<Keyboard> EntryCell.KeyboardProperty
 
     let TextWithEvent =
-        Attributes.defineBindableWithEvent "EntryCell_TextChanged" EntryCell.TextProperty (fun target ->
-            (target :?> CustomEntryCell).TextChanged)
+        Attributes.defineBindableWithEvent
+            "EntryCell_TextChanged"
+            EntryCell.TextProperty
+            (fun target -> (target :?> CustomEntryCell).TextChanged)
 
     let OnCompleted =
         Attributes.defineEventNoArg "EntryCell_Completed" (fun target -> (target :?> EntryCell).Completed)

--- a/src/Fabulous.XamarinForms/Views/Cells/EntryCell.fs
+++ b/src/Fabulous.XamarinForms/Views/Cells/EntryCell.fs
@@ -63,13 +63,13 @@ type EntryCellModifiers =
     /// param name="alignment">The horizontal text alignment</summary>
     [<Extension>]
     static member inline horizontalTextAlignment(this: WidgetBuilder<'msg, #IEntryCell>, alignment: TextAlignment) =
-        this.AddScalar(EntryCell.HorizontalTextAlignment.WithValue(alignment, SmallScalars.TextAlignment.encode))
+        this.AddScalar(EntryCell.HorizontalTextAlignment.WithValue(alignment))
 
     /// <summary>Set the vertical text alignment</summary>
     /// param name="alignment">The vertical text alignment</summary>
     [<Extension>]
     static member inline verticalTextAlignment(this: WidgetBuilder<'msg, #IEntryCell>, alignment: TextAlignment) =
-        this.AddScalar(EntryCell.VerticalTextAlignment.WithValue(alignment, SmallScalars.TextAlignment.encode))
+        this.AddScalar(EntryCell.VerticalTextAlignment.WithValue(alignment))
 
     /// <summary>Set the keyboard</summary>
     /// param name="keyboard">The keyboard type</summary>

--- a/src/Fabulous.XamarinForms/Views/Cells/EntryCell.fs
+++ b/src/Fabulous.XamarinForms/Views/Cells/EntryCell.fs
@@ -8,7 +8,8 @@ type IEntryCell =
     inherit ICell
 
 module EntryCell =
-    let WidgetKey = Widgets.register<CustomEntryCell>()
+    let WidgetKey =
+        Widgets.register<CustomEntryCell>()
 
     let Label =
         Attributes.defineBindable<string> EntryCell.LabelProperty
@@ -20,19 +21,17 @@ module EntryCell =
         Attributes.defineBindable<string> EntryCell.PlaceholderProperty
 
     let HorizontalTextAlignment =
-        Attributes.defineSmallBindable<TextAlignment> EntryCell.HorizontalTextAlignmentProperty SmallScalars.TextAlignment.decode
+        Attributes.defineBindableEnum<TextAlignment> EntryCell.HorizontalTextAlignmentProperty
 
     let VerticalTextAlignment =
-        Attributes.defineSmallBindable<TextAlignment> EntryCell.VerticalTextAlignmentProperty SmallScalars.TextAlignment.decode
+        Attributes.defineBindableEnum<TextAlignment> EntryCell.VerticalTextAlignmentProperty
 
     let Keyboard =
         Attributes.defineBindable<Keyboard> EntryCell.KeyboardProperty
 
     let TextWithEvent =
-        Attributes.defineBindableWithEvent
-            "EntryCell_TextChanged"
-            EntryCell.TextProperty
-            (fun target -> (target :?> CustomEntryCell).TextChanged)
+        Attributes.defineBindableWithEvent "EntryCell_TextChanged" EntryCell.TextProperty (fun target ->
+            (target :?> CustomEntryCell).TextChanged)
 
     let OnCompleted =
         Attributes.defineEventNoArg "EntryCell_Completed" (fun target -> (target :?> EntryCell).Completed)

--- a/src/Fabulous.XamarinForms/Views/Cells/EntryCell.fs
+++ b/src/Fabulous.XamarinForms/Views/Cells/EntryCell.fs
@@ -20,10 +20,10 @@ module EntryCell =
         Attributes.defineBindable<string> EntryCell.PlaceholderProperty
 
     let HorizontalTextAlignment =
-        Attributes.defineBindable<TextAlignment> EntryCell.HorizontalTextAlignmentProperty
+        Attributes.defineSmallBindable<TextAlignment> EntryCell.HorizontalTextAlignmentProperty SmallScalars.TextAlignment.decode
 
     let VerticalTextAlignment =
-        Attributes.defineBindable<TextAlignment> EntryCell.VerticalTextAlignmentProperty
+        Attributes.defineSmallBindable<TextAlignment> EntryCell.VerticalTextAlignmentProperty SmallScalars.TextAlignment.decode
 
     let Keyboard =
         Attributes.defineBindable<Keyboard> EntryCell.KeyboardProperty
@@ -63,13 +63,13 @@ type EntryCellModifiers =
     /// param name="alignment">The horizontal text alignment</summary>
     [<Extension>]
     static member inline horizontalTextAlignment(this: WidgetBuilder<'msg, #IEntryCell>, alignment: TextAlignment) =
-        this.AddScalar(EntryCell.HorizontalTextAlignment.WithValue(alignment))
+        this.AddScalar(EntryCell.HorizontalTextAlignment.WithValue(alignment, SmallScalars.TextAlignment.encode))
 
     /// <summary>Set the vertical text alignment</summary>
     /// param name="alignment">The vertical text alignment</summary>
     [<Extension>]
     static member inline verticalTextAlignment(this: WidgetBuilder<'msg, #IEntryCell>, alignment: TextAlignment) =
-        this.AddScalar(EntryCell.VerticalTextAlignment.WithValue(alignment))
+        this.AddScalar(EntryCell.VerticalTextAlignment.WithValue(alignment, SmallScalars.TextAlignment.encode))
 
     /// <summary>Set the keyboard</summary>
     /// param name="keyboard">The keyboard type</summary>

--- a/src/Fabulous.XamarinForms/Views/Cells/_Cell.fs
+++ b/src/Fabulous.XamarinForms/Views/Cells/_Cell.fs
@@ -38,13 +38,13 @@ type CellModifiers =
     /// <param name="value">true if the cell IsEnabled; otherwise, false.</param>
     [<Extension>]
     static member inline isEnabled(this: WidgetBuilder<'msg, #ICell>, value: bool) =
-        this.AddScalar(Cell.IsEnabled.WithValue(value, SmallScalars.Bool.encode))
+        this.AddScalar(Cell.IsEnabled.WithValue(value))
 
     /// <summary>Sets the height of the cell</summary>
     /// <param name="value">The height of the cell</param>
     [<Extension>]
     static member inline height(this: WidgetBuilder<'msg, #ICell>, value: float) =
-        this.AddScalar(Cell.Height.WithValue(value, SmallScalars.Float.encode))
+        this.AddScalar(Cell.Height.WithValue(value))
 
     [<Extension>]
     static member inline onAppearing(this: WidgetBuilder<'msg, #ICell>, onAppearing: 'msg) =

--- a/src/Fabulous.XamarinForms/Views/Cells/_Cell.fs
+++ b/src/Fabulous.XamarinForms/Views/Cells/_Cell.fs
@@ -9,7 +9,7 @@ type ICell =
 
 module Cell =
     let IsEnabled =
-        Attributes.defineSmallBindable<bool> Cell.IsEnabledProperty SmallScalars.Bool.decode
+        Attributes.defineBindableBool Cell.IsEnabledProperty
 
     let Height =
         Attributes.defineFloat "Cell_Height" (fun _ newValueOpt node ->

--- a/src/Fabulous.XamarinForms/Views/Cells/_Cell.fs
+++ b/src/Fabulous.XamarinForms/Views/Cells/_Cell.fs
@@ -12,15 +12,17 @@ module Cell =
         Attributes.defineBindableBool Cell.IsEnabledProperty
 
     let Height =
-        Attributes.defineFloat "Cell_Height" (fun _ newValueOpt node ->
-            let cell = node.Target :?> Cell
+        Attributes.defineFloat
+            "Cell_Height"
+            (fun _ newValueOpt node ->
+                let cell = node.Target :?> Cell
 
-            let value =
-                match newValueOpt with
-                | ValueNone -> cell.Height
-                | ValueSome v -> v
+                let value =
+                    match newValueOpt with
+                    | ValueNone -> cell.Height
+                    | ValueSome v -> v
 
-            cell.Height <- value)
+                cell.Height <- value)
 
     let Appearing =
         Attributes.defineEventNoArg "Cell_Appearing" (fun target -> (target :?> Cell).Appearing)

--- a/src/Fabulous.XamarinForms/Views/Cells/_Cell.fs
+++ b/src/Fabulous.XamarinForms/Views/Cells/_Cell.fs
@@ -9,20 +9,18 @@ type ICell =
 
 module Cell =
     let IsEnabled =
-        Attributes.defineBindable<bool> Cell.IsEnabledProperty
+        Attributes.defineSmallBindable<bool> Cell.IsEnabledProperty SmallScalars.Bool.decode
 
     let Height =
-        Attributes.define<float>
-            "Cell_Height"
-            (fun _ newValueOpt node ->
-                let cell = node.Target :?> Cell
+        Attributes.defineFloat "Cell_Height" (fun _ newValueOpt node ->
+            let cell = node.Target :?> Cell
 
-                let value =
-                    match newValueOpt with
-                    | ValueNone -> cell.Height
-                    | ValueSome v -> v
+            let value =
+                match newValueOpt with
+                | ValueNone -> cell.Height
+                | ValueSome v -> v
 
-                cell.Height <- value)
+            cell.Height <- value)
 
     let Appearing =
         Attributes.defineEventNoArg "Cell_Appearing" (fun target -> (target :?> Cell).Appearing)
@@ -40,13 +38,13 @@ type CellModifiers =
     /// <param name="value">true if the cell IsEnabled; otherwise, false.</param>
     [<Extension>]
     static member inline isEnabled(this: WidgetBuilder<'msg, #ICell>, value: bool) =
-        this.AddScalar(Cell.IsEnabled.WithValue(value))
+        this.AddScalar(Cell.IsEnabled.WithValue(value, SmallScalars.Bool.encode))
 
     /// <summary>Sets the height of the cell</summary>
     /// <param name="value">The height of the cell</param>
     [<Extension>]
     static member inline height(this: WidgetBuilder<'msg, #ICell>, value: float) =
-        this.AddScalar(Cell.Height.WithValue(value))
+        this.AddScalar(Cell.Height.WithValue(value, SmallScalars.Float.encode))
 
     [<Extension>]
     static member inline onAppearing(this: WidgetBuilder<'msg, #ICell>, onAppearing: 'msg) =

--- a/src/Fabulous.XamarinForms/Views/Collections/CarouselView.fs
+++ b/src/Fabulous.XamarinForms/Views/Collections/CarouselView.fs
@@ -12,19 +12,19 @@ module CarouselView =
     let WidgetKey = Widgets.register<CarouselView>()
 
     let IsBounceEnabled =
-        Attributes.defineBindable<bool> CarouselView.IsBounceEnabledProperty
+        Attributes.defineBindableBool CarouselView.IsBounceEnabledProperty
 
     let IsDragging =
-        Attributes.defineBindable<bool> CarouselView.IsDraggingProperty
+        Attributes.defineBindableBool CarouselView.IsDraggingProperty
 
     let IsScrollAnimated =
-        Attributes.defineBindable<bool> CarouselView.IsScrollAnimatedProperty
+        Attributes.defineBindableBool CarouselView.IsScrollAnimatedProperty
 
     let IsSwipeEnabled =
-        Attributes.defineBindable<bool> CarouselView.IsSwipeEnabledProperty
+        Attributes.defineBindableBool CarouselView.IsSwipeEnabledProperty
 
     let Loop =
-        Attributes.defineBindable<bool> CarouselView.LoopProperty
+        Attributes.defineBindableBool CarouselView.LoopProperty
 
     let PeekAreaInsets =
         Attributes.defineBindable<Thickness> CarouselView.PeekAreaInsetsProperty

--- a/src/Fabulous.XamarinForms/Views/Collections/CollectionView.fs
+++ b/src/Fabulous.XamarinForms/Views/Collections/CollectionView.fs
@@ -49,7 +49,7 @@ module CollectionView =
                     collectionView.SetValue(CollectionView.ItemsSourceProperty, value.OriginalItems))
 
     let SelectionMode =
-        Attributes.defineBindable<SelectionMode> CollectionView.SelectionModeProperty
+        Attributes.defineBindableEnum<SelectionMode> CollectionView.SelectionModeProperty
 
     let Header =
         Attributes.defineBindableWidget CollectionView.HeaderProperty
@@ -58,7 +58,7 @@ module CollectionView =
         Attributes.defineBindableWidget CollectionView.FooterProperty
 
     let ItemSizingStrategy =
-        Attributes.defineBindable<ItemSizingStrategy> CollectionView.ItemSizingStrategyProperty
+        Attributes.defineBindableEnum<ItemSizingStrategy> CollectionView.ItemSizingStrategyProperty
 
     let SelectionChanged =
         Attributes.defineEvent<SelectionChangedEventArgs>

--- a/src/Fabulous.XamarinForms/Views/Collections/ListView.fs
+++ b/src/Fabulous.XamarinForms/Views/Collections/ListView.fs
@@ -147,7 +147,7 @@ type ListViewModifiers =
 
     [<Extension>]
     static member inline hasUnevenRows(this: WidgetBuilder<'msg, #IListView>, value: bool) =
-        this.AddScalar(ListView.HasUnevenRows.WithValue(value, SmallScalars.Bool.encode))
+        this.AddScalar(ListView.HasUnevenRows.WithValue(value))
 
     [<Extension>]
     static member inline horizontalScrollBarVisibility
@@ -167,11 +167,11 @@ type ListViewModifiers =
 
     [<Extension>]
     static member inline isPullToRefreshEnabled(this: WidgetBuilder<'msg, #IListView>, value: bool) =
-        this.AddScalar(ListView.IsPullToRefreshEnabled.WithValue(value, SmallScalars.Bool.encode))
+        this.AddScalar(ListView.IsPullToRefreshEnabled.WithValue(value))
 
     [<Extension>]
     static member inline isRefreshing(this: WidgetBuilder<'msg, #IListView>, value: bool) =
-        this.AddScalar(ListView.IsRefreshing.WithValue(value, SmallScalars.Bool.encode))
+        this.AddScalar(ListView.IsRefreshing.WithValue(value))
 
     [<Extension>]
     static member inline refreshControlColor(this: WidgetBuilder<'msg, #IListView>, light: Color, ?dark: Color) =
@@ -187,7 +187,7 @@ type ListViewModifiers =
 
     [<Extension>]
     static member inline rowHeight(this: WidgetBuilder<'msg, #IListView>, value: int) =
-        this.AddScalar(ListView.RowHeight.WithValue(value, SmallScalars.Int.encode))
+        this.AddScalar(ListView.RowHeight.WithValue(value))
 
     [<Extension>]
     static member inline selectionMode(this: WidgetBuilder<'msg, #IListView>, value: ListViewSelectionMode) =

--- a/src/Fabulous.XamarinForms/Views/Collections/ListView.fs
+++ b/src/Fabulous.XamarinForms/Views/Collections/ListView.fs
@@ -49,22 +49,22 @@ module ListView =
         Attributes.defineBindableWidget ListView.FooterProperty
 
     let RowHeight =
-        Attributes.defineSmallBindable<int> ListView.RowHeightProperty SmallScalars.Int.decode
+        Attributes.defineBindableInt ListView.RowHeightProperty
 
     let SelectionMode =
-        Attributes.defineBindable<ListViewSelectionMode> ListView.SelectionModeProperty
+        Attributes.defineBindableEnum<ListViewSelectionMode> ListView.SelectionModeProperty
 
     let IsPullToRefreshEnabled =
-        Attributes.defineSmallBindable<bool> ListView.IsPullToRefreshEnabledProperty SmallScalars.Bool.decode 
+        Attributes.defineBindableBool ListView.IsPullToRefreshEnabledProperty 
 
     let IsRefreshing =
-        Attributes.defineSmallBindable<bool> ListView.IsRefreshingProperty SmallScalars.Bool.decode
+        Attributes.defineBindableBool ListView.IsRefreshingProperty
 
     let HasUnevenRows =
-        Attributes.defineSmallBindable<bool> ListView.HasUnevenRowsProperty SmallScalars.Bool.decode
+        Attributes.defineBindableBool ListView.HasUnevenRowsProperty
 
     let SeparatorVisibility =
-        Attributes.defineBindable<SeparatorVisibility> ListView.SeparatorVisibilityProperty
+        Attributes.defineBindableEnum<SeparatorVisibility> ListView.SeparatorVisibilityProperty
 
     let SeparatorColor =
         Attributes.defineAppThemeBindable<Color> ListView.SeparatorColorProperty
@@ -73,10 +73,10 @@ module ListView =
         Attributes.defineAppThemeBindable<Color> ListView.RefreshControlColorProperty
 
     let HorizontalScrollBarVisibility =
-        Attributes.defineBindable<ScrollBarVisibility> ListView.HorizontalScrollBarVisibilityProperty
+        Attributes.defineBindableEnum<ScrollBarVisibility> ListView.HorizontalScrollBarVisibilityProperty
 
     let VerticalScrollBarVisibility =
-        Attributes.defineBindable<ScrollBarVisibility> ListView.VerticalScrollBarVisibilityProperty
+        Attributes.defineBindableEnum<ScrollBarVisibility> ListView.VerticalScrollBarVisibilityProperty
 
     let ItemAppearing =
         Attributes.defineEvent<ItemVisibilityEventArgs>

--- a/src/Fabulous.XamarinForms/Views/Collections/ListView.fs
+++ b/src/Fabulous.XamarinForms/Views/Collections/ListView.fs
@@ -49,19 +49,19 @@ module ListView =
         Attributes.defineBindableWidget ListView.FooterProperty
 
     let RowHeight =
-        Attributes.defineBindable<int> ListView.RowHeightProperty
+        Attributes.defineSmallBindable<int> ListView.RowHeightProperty SmallScalars.Int.decode
 
     let SelectionMode =
         Attributes.defineBindable<ListViewSelectionMode> ListView.SelectionModeProperty
 
     let IsPullToRefreshEnabled =
-        Attributes.defineBindable<bool> ListView.IsPullToRefreshEnabledProperty
+        Attributes.defineSmallBindable<bool> ListView.IsPullToRefreshEnabledProperty SmallScalars.Bool.decode 
 
     let IsRefreshing =
-        Attributes.defineBindable<bool> ListView.IsRefreshingProperty
+        Attributes.defineSmallBindable<bool> ListView.IsRefreshingProperty SmallScalars.Bool.decode
 
     let HasUnevenRows =
-        Attributes.defineBindable<bool> ListView.HasUnevenRowsProperty
+        Attributes.defineSmallBindable<bool> ListView.HasUnevenRowsProperty SmallScalars.Bool.decode
 
     let SeparatorVisibility =
         Attributes.defineBindable<SeparatorVisibility> ListView.SeparatorVisibilityProperty
@@ -147,7 +147,7 @@ type ListViewModifiers =
 
     [<Extension>]
     static member inline hasUnevenRows(this: WidgetBuilder<'msg, #IListView>, value: bool) =
-        this.AddScalar(ListView.HasUnevenRows.WithValue(value))
+        this.AddScalar(ListView.HasUnevenRows.WithValue(value, SmallScalars.Bool.encode))
 
     [<Extension>]
     static member inline horizontalScrollBarVisibility
@@ -167,11 +167,11 @@ type ListViewModifiers =
 
     [<Extension>]
     static member inline isPullToRefreshEnabled(this: WidgetBuilder<'msg, #IListView>, value: bool) =
-        this.AddScalar(ListView.IsPullToRefreshEnabled.WithValue(value))
+        this.AddScalar(ListView.IsPullToRefreshEnabled.WithValue(value, SmallScalars.Bool.encode))
 
     [<Extension>]
     static member inline isRefreshing(this: WidgetBuilder<'msg, #IListView>, value: bool) =
-        this.AddScalar(ListView.IsRefreshing.WithValue(value))
+        this.AddScalar(ListView.IsRefreshing.WithValue(value, SmallScalars.Bool.encode))
 
     [<Extension>]
     static member inline refreshControlColor(this: WidgetBuilder<'msg, #IListView>, light: Color, ?dark: Color) =
@@ -187,7 +187,7 @@ type ListViewModifiers =
 
     [<Extension>]
     static member inline rowHeight(this: WidgetBuilder<'msg, #IListView>, value: int) =
-        this.AddScalar(ListView.RowHeight.WithValue(value))
+        this.AddScalar(ListView.RowHeight.WithValue(value, SmallScalars.Int.encode))
 
     [<Extension>]
     static member inline selectionMode(this: WidgetBuilder<'msg, #IListView>, value: ListViewSelectionMode) =

--- a/src/Fabulous.XamarinForms/Views/Collections/ListView.fs
+++ b/src/Fabulous.XamarinForms/Views/Collections/ListView.fs
@@ -55,7 +55,7 @@ module ListView =
         Attributes.defineBindableEnum<ListViewSelectionMode> ListView.SelectionModeProperty
 
     let IsPullToRefreshEnabled =
-        Attributes.defineBindableBool ListView.IsPullToRefreshEnabledProperty 
+        Attributes.defineBindableBool ListView.IsPullToRefreshEnabledProperty
 
     let IsRefreshing =
         Attributes.defineBindableBool ListView.IsRefreshingProperty

--- a/src/Fabulous.XamarinForms/Views/Collections/_ItemsView.fs
+++ b/src/Fabulous.XamarinForms/Views/Collections/_ItemsView.fs
@@ -33,7 +33,7 @@ module ItemsView =
         Attributes.defineBindableWidget ItemsView.EmptyViewProperty
 
     let RemainingItemsThreshold =
-        Attributes.defineBindable<int> ItemsView.RemainingItemsThresholdProperty
+        Attributes.defineBindableInt ItemsView.RemainingItemsThresholdProperty
 
     let RemainingItemsThresholdReached =
         Attributes.defineEventNoArg
@@ -43,13 +43,13 @@ module ItemsView =
                     .RemainingItemsThresholdReached)
 
     let HorizontalScrollBarVisibility =
-        Attributes.defineBindable<ScrollBarVisibility> ItemsView.HorizontalScrollBarVisibilityProperty
+        Attributes.defineBindableEnum<ScrollBarVisibility> ItemsView.HorizontalScrollBarVisibilityProperty
 
     let VerticalScrollBarVisibility =
-        Attributes.defineBindable<ScrollBarVisibility> ItemsView.VerticalScrollBarVisibilityProperty
+        Attributes.defineBindableEnum<ScrollBarVisibility> ItemsView.VerticalScrollBarVisibilityProperty
 
     let ItemsUpdatingScrollMode =
-        Attributes.defineBindable<ItemsUpdatingScrollMode> ItemsView.ItemsUpdatingScrollModeProperty
+        Attributes.defineBindableEnum<ItemsUpdatingScrollMode> ItemsView.ItemsUpdatingScrollModeProperty
 
     let ScrollToRequested =
         Attributes.defineEvent<ScrollToRequestEventArgs>

--- a/src/Fabulous.XamarinForms/Views/Controls/ActivityIndicator.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/ActivityIndicator.fs
@@ -11,7 +11,7 @@ module ActivityIndicator =
     let WidgetKey = Widgets.register<ActivityIndicator>()
 
     let IsRunning =
-        Attributes.defineBindable<bool> ActivityIndicator.IsRunningProperty
+        Attributes.defineBindableBool ActivityIndicator.IsRunningProperty
 
     let Color =
         Attributes.defineAppThemeBindable<Color> ActivityIndicator.ColorProperty

--- a/src/Fabulous.XamarinForms/Views/Controls/BoxView.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/BoxView.fs
@@ -14,7 +14,7 @@ module BoxView =
         Attributes.defineAppThemeBindable<Color> BoxView.ColorProperty
 
     let CornerRadius =
-        Attributes.defineBindable<float> BoxView.CornerRadiusProperty
+        Attributes.defineBindableFloat BoxView.CornerRadiusProperty
 
 [<AutoOpen>]
 module BoxViewBuilders =

--- a/src/Fabulous.XamarinForms/Views/Controls/Button.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Button.fs
@@ -16,16 +16,16 @@ module Button =
         Attributes.defineAppThemeBindable<Color> Button.BorderColorProperty
 
     let BorderWidth =
-        Attributes.defineBindable<float> Button.BorderWidthProperty
+        Attributes.defineBindableFloat Button.BorderWidthProperty
 
     let CharacterSpacing =
-        Attributes.defineBindable<float> Button.CharacterSpacingProperty
+        Attributes.defineBindableFloat Button.CharacterSpacingProperty
 
     let ContentLayout =
         Attributes.defineBindable<Xamarin.Forms.Button.ButtonContentLayout> Button.ContentLayoutProperty
 
     let CornerRadius =
-        Attributes.defineBindable<int> Button.CornerRadiusProperty
+        Attributes.defineBindableInt Button.CornerRadiusProperty
 
     let FontAttributes =
         Attributes.defineBindable<Xamarin.Forms.FontAttributes> Button.FontAttributesProperty
@@ -34,7 +34,7 @@ module Button =
         Attributes.defineBindable<string> Button.FontFamilyProperty
 
     let FontSize =
-        Attributes.defineBindable<float> Button.FontSizeProperty
+        Attributes.defineBindableFloat Button.FontSizeProperty
 
     let ImageSource =
         Attributes.defineAppThemeBindable<ImageSource> Button.ImageSourceProperty

--- a/src/Fabulous.XamarinForms/Views/Controls/DatePicker.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/DatePicker.fs
@@ -12,7 +12,7 @@ module DatePicker =
     let WidgetKey = Widgets.register<DatePicker>()
 
     let CharacterSpacing =
-        Attributes.defineBindable<float> DatePicker.CharacterSpacingProperty
+        Attributes.defineBindableFloat DatePicker.CharacterSpacingProperty
 
     let FontAttributes =
         Attributes.defineBindable<Xamarin.Forms.FontAttributes> DatePicker.FontAttributesProperty
@@ -21,7 +21,7 @@ module DatePicker =
         Attributes.defineBindable<string> DatePicker.FontFamilyProperty
 
     let FontSize =
-        Attributes.defineBindable<float> DatePicker.FontSizeProperty
+        Attributes.defineBindableFloat DatePicker.FontSizeProperty
 
     let Format =
         Attributes.defineBindable<string> DatePicker.FormatProperty
@@ -36,7 +36,7 @@ module DatePicker =
         Attributes.defineAppThemeBindable<Color> DatePicker.TextColorProperty
 
     let TextTransform =
-        Attributes.defineBindable<Xamarin.Forms.TextTransform> DatePicker.TextTransformProperty
+        Attributes.defineBindableEnum<Xamarin.Forms.TextTransform> DatePicker.TextTransformProperty
 
     let DateWithEvent =
         Attributes.defineBindableWithEvent

--- a/src/Fabulous.XamarinForms/Views/Controls/Editor.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Editor.fs
@@ -11,7 +11,7 @@ module Editor =
     let WidgetKey = Widgets.register<Editor>()
 
     let AutoSize =
-        Attributes.defineBindable<EditorAutoSizeOption> Editor.AutoSizeProperty
+        Attributes.defineBindableEnum<EditorAutoSizeOption> Editor.AutoSizeProperty
 
     let FontAttributes =
         Attributes.defineBindable<FontAttributes> Editor.FontAttributesProperty
@@ -20,10 +20,10 @@ module Editor =
         Attributes.defineBindable<string> Editor.FontFamilyProperty
 
     let FontSize =
-        Attributes.defineBindable<float> Editor.FontSizeProperty
+        Attributes.defineBindableFloat Editor.FontSizeProperty
 
     let IsTextPredictionEnabled =
-        Attributes.defineBindable<bool> Editor.IsTextPredictionEnabledProperty
+        Attributes.defineBindableBool Editor.IsTextPredictionEnabledProperty
 
     let Completed =
         Attributes.defineEventNoArg "Editor_Completed" (fun target -> (target :?> Editor).Completed)

--- a/src/Fabulous.XamarinForms/Views/Controls/Entry.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Entry.fs
@@ -48,15 +48,18 @@ module Entry =
         Attributes.defineEventNoArg "Entry_Completed" (fun target -> (target :?> Entry).Completed)
 
     let CursorColor =
-        Attributes.defineSmallScalar<Color> "Entry_CursorColor" SmallScalars.Color.decode (fun _ newValueOpt node ->
-            let entry = node.Target :?> Entry
+        Attributes.defineSmallScalar<Color>
+            "Entry_CursorColor"
+            SmallScalars.Color.decode
+            (fun _ newValueOpt node ->
+                let entry = node.Target :?> Entry
 
-            let value =
-                match newValueOpt with
-                | ValueNone -> Color.Default
-                | ValueSome x -> x
+                let value =
+                    match newValueOpt with
+                    | ValueNone -> Color.Default
+                    | ValueSome x -> x
 
-            iOSSpecific.Entry.SetCursorColor(entry, value))
+                iOSSpecific.Entry.SetCursorColor(entry, value))
 
 [<AutoOpen>]
 module EntryBuilders =

--- a/src/Fabulous.XamarinForms/Views/Controls/Entry.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Entry.fs
@@ -15,7 +15,7 @@ module Entry =
         Attributes.defineBindable<ClearButtonVisibility> Entry.ClearButtonVisibilityProperty
 
     let CursorPosition =
-        Attributes.defineBindable<int> Entry.CursorPositionProperty
+        Attributes.defineSmallBindable<int> Entry.CursorPositionProperty SmallScalars.Int.decode
 
     let FontAttributes =
         Attributes.defineBindable<FontAttributes> Entry.FontAttributesProperty
@@ -36,10 +36,10 @@ module Entry =
         Attributes.defineSmallBindable<bool> Entry.IsTextPredictionEnabledProperty SmallScalars.Bool.decode
 
     let ReturnType =
-        Attributes.defineBindable<ReturnType> Entry.ReturnTypeProperty
+        Attributes.defineSmallBindable<ReturnType> Entry.ReturnTypeProperty SmallScalars.ReturnType.decode
 
     let SelectionLength =
-        Attributes.defineBindable<int> Entry.SelectionLengthProperty
+        Attributes.defineSmallBindable<int> Entry.SelectionLengthProperty SmallScalars.Int.decode
 
     let VerticalTextAlignment =
         Attributes.defineSmallBindable<TextAlignment> Entry.VerticalTextAlignmentProperty SmallScalars.TextAlignment.decode
@@ -96,11 +96,11 @@ type EntryModifiers =
 
         match size with
         | None -> ()
-        | Some v -> res <- res.AddScalar(Entry.FontSize.WithValue(v, SmallScalars.Float.encode))
+        | Some v -> res <- res.AddScalar(Entry.FontSize.WithValue(v))
 
         match namedSize with
         | None -> ()
-        | Some v -> res <- res.AddScalar(Entry.FontSize.WithValue(Device.GetNamedSize(v, typeof<Entry>), SmallScalars.Float.encode))
+        | Some v -> res <- res.AddScalar(Entry.FontSize.WithValue(Device.GetNamedSize(v, typeof<Entry>)))
 
         match attributes with
         | None -> ()
@@ -118,11 +118,11 @@ type EntryModifiers =
 
     [<Extension>]
     static member inline isPassword(this: WidgetBuilder<'msg, #IEntry>, value: bool) =
-        this.AddScalar(Entry.IsPassword.WithValue(value, SmallScalars.Bool.encode))
+        this.AddScalar(Entry.IsPassword.WithValue(value))
 
     [<Extension>]
     static member inline isTextPredictionEnabled(this: WidgetBuilder<'msg, #IEntry>, value: bool) =
-        this.AddScalar(Entry.IsTextPredictionEnabled.WithValue(value, SmallScalars.Bool.encode))
+        this.AddScalar(Entry.IsTextPredictionEnabled.WithValue(value))
 
     [<Extension>]
     static member inline returnType(this: WidgetBuilder<'msg, #IEntry>, value: ReturnType) =
@@ -134,7 +134,7 @@ type EntryModifiers =
 
     [<Extension>]
     static member inline verticalTextAlignment(this: WidgetBuilder<'msg, #IEntry>, value: TextAlignment) =
-        this.AddScalar(Entry.VerticalTextAlignment.WithValue(value, SmallScalars.TextAlignment.encode))
+        this.AddScalar(Entry.VerticalTextAlignment.WithValue(value))
 
     [<Extension>]
     static member inline onCompleted(this: WidgetBuilder<'msg, #IEntry>, onCompleted: 'msg) =
@@ -151,4 +151,4 @@ type EntryPlatformModifiers =
     /// <param name="value">The new cursor color.</param>
     [<Extension>]
     static member inline cursorColor(this: WidgetBuilder<'msg, #IEntry>, value: Color) =
-        this.AddScalar(Entry.CursorColor.WithValue(value, SmallScalars.Color.encode))
+        this.AddScalar(Entry.CursorColor.WithValue(value))

--- a/src/Fabulous.XamarinForms/Views/Controls/Entry.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Entry.fs
@@ -15,7 +15,7 @@ module Entry =
         Attributes.defineBindable<ClearButtonVisibility> Entry.ClearButtonVisibilityProperty
 
     let CursorPosition =
-        Attributes.defineSmallBindable<int> Entry.CursorPositionProperty SmallScalars.Int.decode
+        Attributes.defineBindableInt Entry.CursorPositionProperty
 
     let FontAttributes =
         Attributes.defineBindable<FontAttributes> Entry.FontAttributesProperty
@@ -24,42 +24,39 @@ module Entry =
         Attributes.defineBindable<string> Entry.FontFamilyProperty
 
     let FontSize =
-        Attributes.defineSmallBindable<float> Entry.FontSizeProperty SmallScalars.Float.decode
+        Attributes.defineBindableFloat Entry.FontSizeProperty
 
     let HorizontalTextAlignment =
-        Attributes.defineBindable<TextAlignment> Entry.HorizontalTextAlignmentProperty
+        Attributes.defineBindableEnum<TextAlignment> Entry.HorizontalTextAlignmentProperty
 
     let IsPassword =
-        Attributes.defineSmallBindable<bool> Entry.IsPasswordProperty SmallScalars.Bool.decode
+        Attributes.defineBindableBool Entry.IsPasswordProperty
 
     let IsTextPredictionEnabled =
-        Attributes.defineSmallBindable<bool> Entry.IsTextPredictionEnabledProperty SmallScalars.Bool.decode
+        Attributes.defineBindableBool Entry.IsTextPredictionEnabledProperty
 
     let ReturnType =
-        Attributes.defineSmallBindable<ReturnType> Entry.ReturnTypeProperty SmallScalars.ReturnType.decode
+        Attributes.defineBindableEnum<ReturnType> Entry.ReturnTypeProperty
 
     let SelectionLength =
-        Attributes.defineSmallBindable<int> Entry.SelectionLengthProperty SmallScalars.Int.decode
+        Attributes.defineBindableInt Entry.SelectionLengthProperty
 
     let VerticalTextAlignment =
-        Attributes.defineSmallBindable<TextAlignment> Entry.VerticalTextAlignmentProperty SmallScalars.TextAlignment.decode
+        Attributes.defineBindableEnum<TextAlignment> Entry.VerticalTextAlignmentProperty
 
     let Completed =
         Attributes.defineEventNoArg "Entry_Completed" (fun target -> (target :?> Entry).Completed)
 
     let CursorColor =
-        Attributes.defineSmallScalar<Color>
-            "Entry_CursorColor"
-            SmallScalars.Color.decode
-            (fun _ newValueOpt node ->
-                let entry = node.Target :?> Entry
+        Attributes.defineSmallScalar<Color> "Entry_CursorColor" SmallScalars.Color.decode (fun _ newValueOpt node ->
+            let entry = node.Target :?> Entry
 
-                let value =
-                    match newValueOpt with
-                    | ValueNone -> Color.Default
-                    | ValueSome x -> x
+            let value =
+                match newValueOpt with
+                | ValueNone -> Color.Default
+                | ValueSome x -> x
 
-                iOSSpecific.Entry.SetCursorColor(entry, value))
+            iOSSpecific.Entry.SetCursorColor(entry, value))
 
 [<AutoOpen>]
 module EntryBuilders =

--- a/src/Fabulous.XamarinForms/Views/Controls/Entry.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Entry.fs
@@ -24,16 +24,16 @@ module Entry =
         Attributes.defineBindable<string> Entry.FontFamilyProperty
 
     let FontSize =
-        Attributes.defineBindable<float> Entry.FontSizeProperty
+        Attributes.defineSmallBindable<float> Entry.FontSizeProperty SmallScalars.Float.decode
 
     let HorizontalTextAlignment =
         Attributes.defineBindable<TextAlignment> Entry.HorizontalTextAlignmentProperty
 
     let IsPassword =
-        Attributes.defineBindable<bool> Entry.IsPasswordProperty
+        Attributes.defineSmallBindable<bool> Entry.IsPasswordProperty SmallScalars.Bool.decode
 
     let IsTextPredictionEnabled =
-        Attributes.defineBindable<bool> Entry.IsTextPredictionEnabledProperty
+        Attributes.defineSmallBindable<bool> Entry.IsTextPredictionEnabledProperty SmallScalars.Bool.decode
 
     let ReturnType =
         Attributes.defineBindable<ReturnType> Entry.ReturnTypeProperty
@@ -42,14 +42,15 @@ module Entry =
         Attributes.defineBindable<int> Entry.SelectionLengthProperty
 
     let VerticalTextAlignment =
-        Attributes.defineBindable<TextAlignment> Entry.VerticalTextAlignmentProperty
+        Attributes.defineSmallBindable<TextAlignment> Entry.VerticalTextAlignmentProperty SmallScalars.TextAlignment.decode
 
     let Completed =
         Attributes.defineEventNoArg "Entry_Completed" (fun target -> (target :?> Entry).Completed)
 
     let CursorColor =
-        Attributes.define<Color>
+        Attributes.defineSmallScalar<Color>
             "Entry_CursorColor"
+            SmallScalars.Color.decode
             (fun _ newValueOpt node ->
                 let entry = node.Target :?> Entry
 
@@ -95,11 +96,11 @@ type EntryModifiers =
 
         match size with
         | None -> ()
-        | Some v -> res <- res.AddScalar(Entry.FontSize.WithValue(v))
+        | Some v -> res <- res.AddScalar(Entry.FontSize.WithValue(v, SmallScalars.Float.encode))
 
         match namedSize with
         | None -> ()
-        | Some v -> res <- res.AddScalar(Entry.FontSize.WithValue(Device.GetNamedSize(v, typeof<Entry>)))
+        | Some v -> res <- res.AddScalar(Entry.FontSize.WithValue(Device.GetNamedSize(v, typeof<Entry>), SmallScalars.Float.encode))
 
         match attributes with
         | None -> ()
@@ -117,11 +118,11 @@ type EntryModifiers =
 
     [<Extension>]
     static member inline isPassword(this: WidgetBuilder<'msg, #IEntry>, value: bool) =
-        this.AddScalar(Entry.IsPassword.WithValue(value))
+        this.AddScalar(Entry.IsPassword.WithValue(value, SmallScalars.Bool.encode))
 
     [<Extension>]
     static member inline isTextPredictionEnabled(this: WidgetBuilder<'msg, #IEntry>, value: bool) =
-        this.AddScalar(Entry.IsTextPredictionEnabled.WithValue(value))
+        this.AddScalar(Entry.IsTextPredictionEnabled.WithValue(value, SmallScalars.Bool.encode))
 
     [<Extension>]
     static member inline returnType(this: WidgetBuilder<'msg, #IEntry>, value: ReturnType) =
@@ -133,7 +134,7 @@ type EntryModifiers =
 
     [<Extension>]
     static member inline verticalTextAlignment(this: WidgetBuilder<'msg, #IEntry>, value: TextAlignment) =
-        this.AddScalar(Entry.VerticalTextAlignment.WithValue(value))
+        this.AddScalar(Entry.VerticalTextAlignment.WithValue(value, SmallScalars.TextAlignment.encode))
 
     [<Extension>]
     static member inline onCompleted(this: WidgetBuilder<'msg, #IEntry>, onCompleted: 'msg) =
@@ -150,4 +151,4 @@ type EntryPlatformModifiers =
     /// <param name="value">The new cursor color.</param>
     [<Extension>]
     static member inline cursorColor(this: WidgetBuilder<'msg, #IEntry>, value: Color) =
-        this.AddScalar(Entry.CursorColor.WithValue(value))
+        this.AddScalar(Entry.CursorColor.WithValue(value, SmallScalars.Color.encode))

--- a/src/Fabulous.XamarinForms/Views/Controls/Image.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Image.fs
@@ -13,13 +13,13 @@ module Image =
     let WidgetKey = Widgets.register<Image>()
 
     let Aspect =
-        Attributes.defineBindable<Aspect> Image.AspectProperty
+        Attributes.defineBindableEnum<Aspect> Image.AspectProperty
 
     let IsAnimationPlaying =
-        Attributes.defineBindable<bool> Image.IsAnimationPlayingProperty
+        Attributes.defineBindableBool Image.IsAnimationPlayingProperty
 
     let IsOpaque =
-        Attributes.defineBindable<bool> Image.IsOpaqueProperty
+        Attributes.defineBindableBool Image.IsOpaqueProperty
 
     let Source =
         Attributes.defineAppThemeBindable<ImageSource> Image.SourceProperty

--- a/src/Fabulous.XamarinForms/Views/Controls/ImageButton.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/ImageButton.fs
@@ -13,25 +13,25 @@ module ImageButton =
     let WidgetKey = Widgets.register<ImageButton>()
 
     let Aspect =
-        Attributes.defineBindable<Xamarin.Forms.Aspect> ImageButton.AspectProperty
+        Attributes.defineBindableEnum<Xamarin.Forms.Aspect> ImageButton.AspectProperty
 
     let BorderColor =
         Attributes.defineAppThemeBindable<Color> ImageButton.BorderColorProperty
 
     let BorderWidth =
-        Attributes.defineBindable<float> ImageButton.BorderWidthProperty
+        Attributes.defineBindableFloat ImageButton.BorderWidthProperty
 
     let CornerRadius =
-        Attributes.defineBindable<float> ImageButton.CornerRadiusProperty
+        Attributes.defineBindableFloat ImageButton.CornerRadiusProperty
 
     let IsLoading =
-        Attributes.defineBindable<bool> ImageButton.IsLoadingProperty
+        Attributes.defineBindableBool ImageButton.IsLoadingProperty
 
     let IsOpaque =
-        Attributes.defineBindable<bool> ImageButton.IsOpaqueProperty
+        Attributes.defineBindableBool ImageButton.IsOpaqueProperty
 
     let IsPressed =
-        Attributes.defineBindable<bool> ImageButton.IsPressedProperty
+        Attributes.defineBindableBool ImageButton.IsPressedProperty
 
     let Padding =
         Attributes.defineBindable<Thickness> ImageButton.PaddingProperty

--- a/src/Fabulous.XamarinForms/Views/Controls/IndicatorView.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/IndicatorView.fs
@@ -22,19 +22,19 @@ module IndicatorView =
             (fun a b -> ScalarAttributeComparers.equalityCompare a.OriginalItems b.OriginalItems)
 
     let HideSingle =
-        Attributes.defineBindable<bool> IndicatorView.HideSingleProperty
+        Attributes.defineBindableBool IndicatorView.HideSingleProperty
 
     let IndicatorColor =
         Attributes.defineAppThemeBindable<Color> IndicatorView.IndicatorColorProperty
 
     let IndicatorSize =
-        Attributes.defineBindable<float> IndicatorView.IndicatorSizeProperty
+        Attributes.defineBindableFloat IndicatorView.IndicatorSizeProperty
 
     let IndicatorsShape =
-        Attributes.defineBindable<IndicatorShape> IndicatorView.IndicatorsShapeProperty
+        Attributes.defineBindableEnum<IndicatorShape> IndicatorView.IndicatorsShapeProperty
 
     let MaximumVisible =
-        Attributes.defineBindable<int> IndicatorView.MaximumVisibleProperty
+        Attributes.defineBindableInt IndicatorView.MaximumVisibleProperty
 
     let SelectedIndicatorColor =
         Attributes.defineAppThemeBindable<Color> IndicatorView.SelectedIndicatorColorProperty

--- a/src/Fabulous.XamarinForms/Views/Controls/Label.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Label.fs
@@ -11,7 +11,7 @@ module Label =
     let WidgetKey = Widgets.register<Label>()
 
     let CharacterSpacing =
-        Attributes.defineBindable<float> Label.CharacterSpacingProperty
+        Attributes.defineBindableFloat Label.CharacterSpacingProperty
 
     let FontAttributes =
         Attributes.defineBindable<Xamarin.Forms.FontAttributes> Label.FontAttributesProperty
@@ -20,19 +20,19 @@ module Label =
         Attributes.defineBindable<string> Label.FontFamilyProperty
 
     let FontSize =
-        Attributes.defineBindable<float> Label.FontSizeProperty
+        Attributes.defineBindableFloat Label.FontSizeProperty
 
     let HorizontalTextAlignment =
-        Attributes.defineBindable<TextAlignment> Label.HorizontalTextAlignmentProperty
+        Attributes.defineBindableEnum<TextAlignment> Label.HorizontalTextAlignmentProperty
 
     let LineBreakMode =
-        Attributes.defineBindable<Xamarin.Forms.LineBreakMode> Label.LineBreakModeProperty
+        Attributes.defineBindableEnum<Xamarin.Forms.LineBreakMode> Label.LineBreakModeProperty
 
     let LineHeight =
-        Attributes.defineBindable<float> Label.LineHeightProperty
+        Attributes.defineBindableFloat Label.LineHeightProperty
 
     let MaxLines =
-        Attributes.defineBindable<int> Label.MaxLinesProperty
+        Attributes.defineBindableInt Label.MaxLinesProperty
 
     let Padding =
         Attributes.defineBindable<Thickness> Label.PaddingProperty
@@ -47,13 +47,13 @@ module Label =
         Attributes.defineBindable<string> Label.TextProperty
 
     let TextTransform =
-        Attributes.defineBindable<TextTransform> Label.TextTransformProperty
+        Attributes.defineBindableEnum<TextTransform> Label.TextTransformProperty
 
     let TextType =
-        Attributes.defineBindable<TextType> Label.TextTypeProperty
+        Attributes.defineBindableEnum<TextType> Label.TextTypeProperty
 
     let VerticalTextAlignment =
-        Attributes.defineBindable<TextAlignment> Label.VerticalTextAlignmentProperty
+        Attributes.defineBindableEnum<TextAlignment> Label.VerticalTextAlignmentProperty
 
 
 [<AutoOpen>]

--- a/src/Fabulous.XamarinForms/Views/Controls/Picker.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Picker.fs
@@ -12,13 +12,13 @@ module Picker =
     let WidgetKey = Widgets.register<CustomPicker>()
 
     let CharacterSpacing =
-        Attributes.defineBindable<float> Picker.CharacterSpacingProperty
+        Attributes.defineSmallBindable<float> Picker.CharacterSpacingProperty SmallScalars.Float.decode
 
     let HorizontalTextAlignment =
-        Attributes.defineBindable<TextAlignment> Picker.HorizontalTextAlignmentProperty
+        Attributes.defineSmallBindable<TextAlignment> Picker.HorizontalTextAlignmentProperty SmallScalars.TextAlignment.decode
 
     let VerticalTextAlignment =
-        Attributes.defineBindable<TextAlignment> Picker.VerticalTextAlignmentProperty
+        Attributes.defineSmallBindable<TextAlignment> Picker.VerticalTextAlignmentProperty SmallScalars.TextAlignment.decode
 
     let FontAttributes =
         Attributes.defineBindable<FontAttributes> Picker.FontAttributesProperty
@@ -27,7 +27,7 @@ module Picker =
         Attributes.defineBindable<string> Picker.FontFamilyProperty
 
     let FontSize =
-        Attributes.defineBindable<float> Picker.FontSizeProperty
+        Attributes.defineSmallBindable<float> Picker.FontSizeProperty SmallScalars.Float.decode
 
     let TextColor =
         Attributes.defineAppThemeBindable<Color> Picker.TextColorProperty
@@ -88,15 +88,15 @@ module PickerBuilders =
 type PickerModifiers =
     [<Extension>]
     static member inline characterSpacing(this: WidgetBuilder<'msg, #IPicker>, value: float) =
-        this.AddScalar(Picker.CharacterSpacing.WithValue(value))
+        this.AddScalar(Picker.CharacterSpacing.WithValue(value, SmallScalars.Float.encode))
 
     [<Extension>]
     static member inline horizontalTextAlignment(this: WidgetBuilder<'msg, #IPicker>, value: TextAlignment) =
-        this.AddScalar(Picker.HorizontalTextAlignment.WithValue(value))
+        this.AddScalar(Picker.HorizontalTextAlignment.WithValue(value, SmallScalars.TextAlignment.encode))
 
     [<Extension>]
     static member inline verticalTextAlignment(this: WidgetBuilder<'msg, #IPicker>, value: TextAlignment) =
-        this.AddScalar(Picker.VerticalTextAlignment.WithValue(value))
+        this.AddScalar(Picker.VerticalTextAlignment.WithValue(value, SmallScalars.TextAlignment.encode))
 
     [<Extension>]
     static member inline font
@@ -112,11 +112,11 @@ type PickerModifiers =
 
         match size with
         | None -> ()
-        | Some v -> res <- res.AddScalar(Picker.FontSize.WithValue(v))
+        | Some v -> res <- res.AddScalar(Picker.FontSize.WithValue(v, SmallScalars.Float.encode))
 
         match namedSize with
         | None -> ()
-        | Some v -> res <- res.AddScalar(Picker.FontSize.WithValue(Device.GetNamedSize(v, typeof<Picker>)))
+        | Some v -> res <- res.AddScalar(Picker.FontSize.WithValue(Device.GetNamedSize(v, typeof<Picker>), SmallScalars.Float.encode))
 
         match attributes with
         | None -> ()

--- a/src/Fabulous.XamarinForms/Views/Controls/Picker.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Picker.fs
@@ -12,13 +12,13 @@ module Picker =
     let WidgetKey = Widgets.register<CustomPicker>()
 
     let CharacterSpacing =
-        Attributes.defineSmallBindable<float> Picker.CharacterSpacingProperty SmallScalars.Float.decode
+        Attributes.defineBindableFloat Picker.CharacterSpacingProperty
 
     let HorizontalTextAlignment =
-        Attributes.defineSmallBindable<TextAlignment> Picker.HorizontalTextAlignmentProperty SmallScalars.TextAlignment.decode
+        Attributes.defineBindableEnum<TextAlignment> Picker.HorizontalTextAlignmentProperty
 
     let VerticalTextAlignment =
-        Attributes.defineSmallBindable<TextAlignment> Picker.VerticalTextAlignmentProperty SmallScalars.TextAlignment.decode
+        Attributes.defineBindableEnum<TextAlignment> Picker.VerticalTextAlignmentProperty
 
     let FontAttributes =
         Attributes.defineBindable<FontAttributes> Picker.FontAttributesProperty
@@ -27,7 +27,7 @@ module Picker =
         Attributes.defineBindable<string> Picker.FontFamilyProperty
 
     let FontSize =
-        Attributes.defineSmallBindable<float> Picker.FontSizeProperty SmallScalars.Float.decode
+        Attributes.defineBindableFloat Picker.FontSizeProperty
 
     let TextColor =
         Attributes.defineAppThemeBindable<Color> Picker.TextColorProperty

--- a/src/Fabulous.XamarinForms/Views/Controls/Picker.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Picker.fs
@@ -88,15 +88,15 @@ module PickerBuilders =
 type PickerModifiers =
     [<Extension>]
     static member inline characterSpacing(this: WidgetBuilder<'msg, #IPicker>, value: float) =
-        this.AddScalar(Picker.CharacterSpacing.WithValue(value, SmallScalars.Float.encode))
+        this.AddScalar(Picker.CharacterSpacing.WithValue(value))
 
     [<Extension>]
     static member inline horizontalTextAlignment(this: WidgetBuilder<'msg, #IPicker>, value: TextAlignment) =
-        this.AddScalar(Picker.HorizontalTextAlignment.WithValue(value, SmallScalars.TextAlignment.encode))
+        this.AddScalar(Picker.HorizontalTextAlignment.WithValue(value))
 
     [<Extension>]
     static member inline verticalTextAlignment(this: WidgetBuilder<'msg, #IPicker>, value: TextAlignment) =
-        this.AddScalar(Picker.VerticalTextAlignment.WithValue(value, SmallScalars.TextAlignment.encode))
+        this.AddScalar(Picker.VerticalTextAlignment.WithValue(value))
 
     [<Extension>]
     static member inline font
@@ -112,11 +112,11 @@ type PickerModifiers =
 
         match size with
         | None -> ()
-        | Some v -> res <- res.AddScalar(Picker.FontSize.WithValue(v, SmallScalars.Float.encode))
+        | Some v -> res <- res.AddScalar(Picker.FontSize.WithValue(v))
 
         match namedSize with
         | None -> ()
-        | Some v -> res <- res.AddScalar(Picker.FontSize.WithValue(Device.GetNamedSize(v, typeof<Picker>), SmallScalars.Float.encode))
+        | Some v -> res <- res.AddScalar(Picker.FontSize.WithValue(Device.GetNamedSize(v, typeof<Picker>)))
 
         match attributes with
         | None -> ()

--- a/src/Fabulous.XamarinForms/Views/Controls/ProgressBar.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/ProgressBar.fs
@@ -22,7 +22,7 @@ module ProgressBar =
         Attributes.defineAppThemeBindable<Color> ProgressBar.ProgressColorProperty
 
     let Progress =
-        Attributes.defineBindable<float> ProgressBar.ProgressProperty
+        Attributes.defineBindableFloat ProgressBar.ProgressProperty
 
     let ProgressTo =
         Attributes.define<ProgressToData>

--- a/src/Fabulous.XamarinForms/Views/Controls/RadioButton.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/RadioButton.fs
@@ -18,13 +18,13 @@ module RadioButton =
         Attributes.defineBindable<string> RadioButton.GroupNameProperty
 
     let BorderWidth =
-        Attributes.defineBindable<float> RadioButton.BorderWidthProperty
+        Attributes.defineBindableFloat RadioButton.BorderWidthProperty
 
     let CharacterSpacing =
-        Attributes.defineBindable<float> RadioButton.CharacterSpacingProperty
+        Attributes.defineBindableFloat RadioButton.CharacterSpacingProperty
 
     let CornerRadius =
-        Attributes.defineBindable<float> RadioButton.CornerRadiusProperty
+        Attributes.defineBindableFloat RadioButton.CornerRadiusProperty
 
     let ContentString =
         Attributes.defineBindable<string> RadioButton.ContentProperty
@@ -39,13 +39,13 @@ module RadioButton =
         Attributes.defineBindable<string> RadioButton.FontFamilyProperty
 
     let FontSize =
-        Attributes.defineBindable<float> RadioButton.FontSizeProperty
+        Attributes.defineBindableFloat RadioButton.FontSizeProperty
 
     let TextColor =
         Attributes.defineAppThemeBindable<Color> RadioButton.TextColorProperty
 
     let TextTransform =
-        Attributes.defineBindable<TextTransform> RadioButton.TextTransformProperty
+        Attributes.defineBindableEnum<TextTransform> RadioButton.TextTransformProperty
 
     let Value =
         Attributes.defineBindable<obj> RadioButton.ValueProperty

--- a/src/Fabulous.XamarinForms/Views/Controls/SearchBar.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/SearchBar.fs
@@ -20,13 +20,13 @@ module SearchBar =
         Attributes.defineBindable<string> SearchBar.FontFamilyProperty
 
     let FontSize =
-        Attributes.defineBindable<float> SearchBar.FontSizeProperty
+        Attributes.defineBindableFloat SearchBar.FontSizeProperty
 
     let HorizontalTextAlignment =
-        Attributes.defineBindable<TextAlignment> SearchBar.HorizontalTextAlignmentProperty
+        Attributes.defineBindableEnum<TextAlignment> SearchBar.HorizontalTextAlignmentProperty
 
     let VerticalTextAlignment =
-        Attributes.defineBindable<TextAlignment> SearchBar.VerticalTextAlignmentProperty
+        Attributes.defineBindableEnum<TextAlignment> SearchBar.VerticalTextAlignmentProperty
 
     let SearchButtonPressed =
         Attributes.defineEventNoArg

--- a/src/Fabulous.XamarinForms/Views/Controls/Span.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Span.fs
@@ -14,7 +14,7 @@ module Span =
         Attributes.defineAppThemeBindable<Color> Span.BackgroundColorProperty
 
     let CharacterSpacing =
-        Attributes.defineBindable<float> Span.CharacterSpacingProperty
+        Attributes.defineBindableFloat Span.CharacterSpacingProperty
 
     let FontAttributes =
         Attributes.defineBindable<FontAttributes> Span.FontAttributesProperty
@@ -23,10 +23,10 @@ module Span =
         Attributes.defineBindable<string> Span.FontFamilyProperty
 
     let FontSize =
-        Attributes.defineBindable<float> Span.FontSizeProperty
+        Attributes.defineBindableFloat Span.FontSizeProperty
 
     let LineHeight =
-        Attributes.defineBindable<float> Span.LineHeightProperty
+        Attributes.defineBindableFloat Span.LineHeightProperty
 
     let Style =
         Attributes.defineBindable<Style> Span.StyleProperty
@@ -35,10 +35,10 @@ module Span =
         Attributes.defineAppThemeBindable<Color> Span.TextColorProperty
 
     let TextDecorations =
-        Attributes.defineBindable<TextDecorations> Span.TextDecorationsProperty
+        Attributes.defineBindableEnum<TextDecorations> Span.TextDecorationsProperty
 
     let TextTransform =
-        Attributes.defineBindable<TextTransform> Span.TextTransformProperty
+        Attributes.defineBindableEnum<TextTransform> Span.TextTransformProperty
 
     let Text =
         Attributes.defineBindable<string> Span.TextProperty

--- a/src/Fabulous.XamarinForms/Views/Controls/Stepper.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Stepper.fs
@@ -11,7 +11,7 @@ module Stepper =
     let WidgetKey = Widgets.register<Stepper>()
 
     let Increment =
-        Attributes.defineBindable<float> Stepper.IncrementProperty
+        Attributes.defineBindableFloat Stepper.IncrementProperty
 
     let MinimumMaximum =
         Attributes.define<struct (float * float)> "Stepper_MinimumMaximum" ViewUpdaters.updateStepperMinMax

--- a/src/Fabulous.XamarinForms/Views/Controls/TimePicker.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/TimePicker.fs
@@ -12,7 +12,7 @@ module TimePicker =
     let WidgetKey = Widgets.register<FabulousTimePicker>()
 
     let CharacterSpacing =
-        Attributes.defineBindable<float> TimePicker.CharacterSpacingProperty
+        Attributes.defineBindableFloat TimePicker.CharacterSpacingProperty
 
     let TimeWithEvent =
         Attributes.defineBindableWithEvent
@@ -27,7 +27,7 @@ module TimePicker =
         Attributes.defineBindable<string> TimePicker.FontFamilyProperty
 
     let FontSize =
-        Attributes.defineBindable<float> TimePicker.FontSizeProperty
+        Attributes.defineBindableFloat TimePicker.FontSizeProperty
 
     let Format =
         Attributes.defineBindable<string> TimePicker.FormatProperty
@@ -36,7 +36,7 @@ module TimePicker =
         Attributes.defineAppThemeBindable<Color> TimePicker.TextColorProperty
 
     let TextTransform =
-        Attributes.defineBindable<Xamarin.Forms.TextTransform> TimePicker.TextTransformProperty
+        Attributes.defineBindableEnum<Xamarin.Forms.TextTransform> TimePicker.TextTransformProperty
 
     let UpdateMode =
         Attributes.define<iOSSpecific.UpdateMode>

--- a/src/Fabulous.XamarinForms/Views/Controls/WebView.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/WebView.fs
@@ -15,10 +15,10 @@ module WebView =
     let WidgetKey = Widgets.register<WebView>()
 
     let CanGoBack =
-        Attributes.defineBindable<bool> WebView.CanGoBackProperty
+        Attributes.defineBindableBool WebView.CanGoBackProperty
 
     let CanGoForward =
-        Attributes.defineBindable<bool> WebView.CanGoForwardProperty
+        Attributes.defineBindableBool WebView.CanGoForwardProperty
 
     let Source =
         Attributes.defineBindable<WebViewSource> WebView.SourceProperty

--- a/src/Fabulous.XamarinForms/Views/Controls/_InputView.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/_InputView.fs
@@ -10,16 +10,16 @@ type IInputView =
 module InputView =
 
     let CharacterSpacing =
-        Attributes.defineBindable<float> InputView.CharacterSpacingProperty
+        Attributes.defineBindableFloat InputView.CharacterSpacingProperty
 
     let IsReadOnly =
-        Attributes.defineBindable<bool> InputView.IsReadOnlyProperty
+        Attributes.defineBindableBool InputView.IsReadOnlyProperty
 
     let IsSpellCheckEnabled =
-        Attributes.defineBindable<bool> InputView.IsSpellCheckEnabledProperty
+        Attributes.defineBindableBool InputView.IsSpellCheckEnabledProperty
 
     let MaxLength =
-        Attributes.defineBindable<int> InputView.MaxLengthProperty
+        Attributes.defineBindableInt InputView.MaxLengthProperty
 
     let Placeholder =
         Attributes.defineBindable<string> InputView.PlaceholderProperty
@@ -34,7 +34,7 @@ module InputView =
         Attributes.defineBindable<Keyboard> InputView.KeyboardProperty
 
     let TextTransform =
-        Attributes.defineBindable<TextTransform> InputView.TextTransformProperty
+        Attributes.defineBindableEnum<TextTransform> InputView.TextTransformProperty
 
     let TextWithEvent =
         Attributes.defineBindableWithEvent<string, TextChangedEventArgs>

--- a/src/Fabulous.XamarinForms/Views/GestureRecognizers/DragGestureRecognizer.fs
+++ b/src/Fabulous.XamarinForms/Views/GestureRecognizers/DragGestureRecognizer.fs
@@ -12,7 +12,7 @@ module DragGestureRecognizer =
         Widgets.register<DragGestureRecognizer>()
 
     let CanDrag =
-        Attributes.defineBindable<bool> DragGestureRecognizer.CanDragProperty
+        Attributes.defineBindableBool DragGestureRecognizer.CanDragProperty
 
     let DragStarting =
         Attributes.defineEvent<DragStartingEventArgs>

--- a/src/Fabulous.XamarinForms/Views/GestureRecognizers/DropGestureRecognizer.fs
+++ b/src/Fabulous.XamarinForms/Views/GestureRecognizers/DropGestureRecognizer.fs
@@ -12,7 +12,7 @@ module DropGestureRecognizer =
         Widgets.register<DropGestureRecognizer>()
 
     let AllowDrop =
-        Attributes.defineBindable<bool> DropGestureRecognizer.AllowDropProperty
+        Attributes.defineBindableBool DropGestureRecognizer.AllowDropProperty
 
     let Drop =
         Attributes.defineEvent<DropEventArgs>

--- a/src/Fabulous.XamarinForms/Views/GestureRecognizers/PanGestureRecognizer.fs
+++ b/src/Fabulous.XamarinForms/Views/GestureRecognizers/PanGestureRecognizer.fs
@@ -11,7 +11,7 @@ module PanGestureRecognizer =
     let WidgetKey = Widgets.register<PanGestureRecognizer>()
 
     let TouchPoints =
-        Attributes.defineSmallBindable<int> PanGestureRecognizer.TouchPointsProperty SmallScalars.Int.decode
+        Attributes.defineBindableInt PanGestureRecognizer.TouchPointsProperty
 
     let PanUpdated =
         Attributes.defineEvent<PanUpdatedEventArgs>

--- a/src/Fabulous.XamarinForms/Views/GestureRecognizers/PanGestureRecognizer.fs
+++ b/src/Fabulous.XamarinForms/Views/GestureRecognizers/PanGestureRecognizer.fs
@@ -11,7 +11,7 @@ module PanGestureRecognizer =
     let WidgetKey = Widgets.register<PanGestureRecognizer>()
 
     let TouchPoints =
-        Attributes.defineBindable<int> PanGestureRecognizer.TouchPointsProperty
+        Attributes.defineSmallBindable<int> PanGestureRecognizer.TouchPointsProperty SmallScalars.Int.decode
 
     let PanUpdated =
         Attributes.defineEvent<PanUpdatedEventArgs>

--- a/src/Fabulous.XamarinForms/Views/GestureRecognizers/SwipeGestureRecognizer.fs
+++ b/src/Fabulous.XamarinForms/Views/GestureRecognizers/SwipeGestureRecognizer.fs
@@ -12,10 +12,10 @@ module SwipeGestureRecognizer =
         Widgets.register<SwipeGestureRecognizer>()
 
     let Direction =
-        Attributes.defineBindable<SwipeDirection> SwipeGestureRecognizer.DirectionProperty
+        Attributes.defineSmallBindable<SwipeDirection> SwipeGestureRecognizer.DirectionProperty SmallScalars.SwipeDirection.decode
 
     let Threshold =
-        Attributes.defineBindable<int> SwipeGestureRecognizer.ThresholdProperty
+        Attributes.defineSmallBindable<int> SwipeGestureRecognizer.ThresholdProperty SmallScalars.Int.decode
 
     let Swiped =
         Attributes.defineEvent<SwipedEventArgs>

--- a/src/Fabulous.XamarinForms/Views/GestureRecognizers/SwipeGestureRecognizer.fs
+++ b/src/Fabulous.XamarinForms/Views/GestureRecognizers/SwipeGestureRecognizer.fs
@@ -12,10 +12,10 @@ module SwipeGestureRecognizer =
         Widgets.register<SwipeGestureRecognizer>()
 
     let Direction =
-        Attributes.defineSmallBindable<SwipeDirection> SwipeGestureRecognizer.DirectionProperty SmallScalars.SwipeDirection.decode
+        Attributes.defineBindableEnum<SwipeDirection> SwipeGestureRecognizer.DirectionProperty
 
     let Threshold =
-        Attributes.defineSmallBindable<int> SwipeGestureRecognizer.ThresholdProperty SmallScalars.Int.decode
+        Attributes.defineBindableInt SwipeGestureRecognizer.ThresholdProperty
 
     let Swiped =
         Attributes.defineEvent<SwipedEventArgs>

--- a/src/Fabulous.XamarinForms/Views/GestureRecognizers/TapGestureRecognizer.fs
+++ b/src/Fabulous.XamarinForms/Views/GestureRecognizers/TapGestureRecognizer.fs
@@ -34,4 +34,4 @@ type TapGestureRecognizerModifiers =
     /// <param name="value">The number of taps required</param>
     [<Extension>]
     static member inline numberOfTapsRequired(this: WidgetBuilder<'msg, #ITapGestureRecognizer>, value: int) =
-        this.AddScalar(TapGestureRecognizer.NumberOfTapsRequired.WithValue(value, SmallScalars.Int.encode))
+        this.AddScalar(TapGestureRecognizer.NumberOfTapsRequired.WithValue(value))

--- a/src/Fabulous.XamarinForms/Views/GestureRecognizers/TapGestureRecognizer.fs
+++ b/src/Fabulous.XamarinForms/Views/GestureRecognizers/TapGestureRecognizer.fs
@@ -16,7 +16,7 @@ module TapGestureRecognizer =
             (fun target -> (target :?> TapGestureRecognizer).Tapped)
 
     let NumberOfTapsRequired =
-        Attributes.defineSmallBindable<int> TapGestureRecognizer.NumberOfTapsRequiredProperty SmallScalars.Int.decode
+        Attributes.defineBindableInt TapGestureRecognizer.NumberOfTapsRequiredProperty
 
 [<AutoOpen>]
 module TapGestureRecognizerBuilders =

--- a/src/Fabulous.XamarinForms/Views/GestureRecognizers/TapGestureRecognizer.fs
+++ b/src/Fabulous.XamarinForms/Views/GestureRecognizers/TapGestureRecognizer.fs
@@ -16,7 +16,7 @@ module TapGestureRecognizer =
             (fun target -> (target :?> TapGestureRecognizer).Tapped)
 
     let NumberOfTapsRequired =
-        Attributes.defineBindable<int> TapGestureRecognizer.NumberOfTapsRequiredProperty
+        Attributes.defineSmallBindable<int> TapGestureRecognizer.NumberOfTapsRequiredProperty SmallScalars.Int.decode
 
 [<AutoOpen>]
 module TapGestureRecognizerBuilders =
@@ -34,4 +34,4 @@ type TapGestureRecognizerModifiers =
     /// <param name="value">The number of taps required</param>
     [<Extension>]
     static member inline numberOfTapsRequired(this: WidgetBuilder<'msg, #ITapGestureRecognizer>, value: int) =
-        this.AddScalar(TapGestureRecognizer.NumberOfTapsRequired.WithValue(value))
+        this.AddScalar(TapGestureRecognizer.NumberOfTapsRequired.WithValue(value, SmallScalars.Int.encode))

--- a/src/Fabulous.XamarinForms/Views/Layouts/AbsoluteLayout.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/AbsoluteLayout.fs
@@ -15,7 +15,7 @@ module AbsoluteLayout =
         Attributes.defineBindable<Rectangle> AbsoluteLayout.LayoutBoundsProperty
 
     let LayoutFlags =
-        Attributes.defineBindable<AbsoluteLayoutFlags> AbsoluteLayout.LayoutFlagsProperty
+        Attributes.defineBindableEnum<AbsoluteLayoutFlags> AbsoluteLayout.LayoutFlagsProperty
 
 [<AutoOpen>]
 module AbsoluteLayoutBuilders =

--- a/src/Fabulous.XamarinForms/Views/Layouts/FlexLayout.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/FlexLayout.fs
@@ -12,37 +12,37 @@ module FlexLayout =
     let WidgetKey = Widgets.register<FlexLayout>()
 
     let AlignContent =
-        Attributes.defineBindable<FlexAlignContent> FlexLayout.AlignContentProperty
+        Attributes.defineBindableEnum<FlexAlignContent> FlexLayout.AlignContentProperty
 
     let AlignItems =
-        Attributes.defineBindable<FlexAlignItems> FlexLayout.AlignItemsProperty
+        Attributes.defineBindableEnum<FlexAlignItems> FlexLayout.AlignItemsProperty
 
     let AlignSelf =
-        Attributes.defineBindable<FlexAlignSelf> FlexLayout.AlignSelfProperty
+        Attributes.defineBindableEnum<FlexAlignSelf> FlexLayout.AlignSelfProperty
 
     let Basis =
         Attributes.defineBindable<FlexBasis> FlexLayout.BasisProperty
 
     let Direction =
-        Attributes.defineBindable<FlexDirection> FlexLayout.DirectionProperty
+        Attributes.defineBindableEnum<FlexDirection> FlexLayout.DirectionProperty
 
     let Grow =
-        Attributes.defineBindable<float> FlexLayout.GrowProperty
+        Attributes.defineBindableFloat FlexLayout.GrowProperty
 
     let JustifyContent =
-        Attributes.defineBindable<FlexJustify> FlexLayout.JustifyContentProperty
+        Attributes.defineBindableEnum<FlexJustify> FlexLayout.JustifyContentProperty
 
     let Order =
-        Attributes.defineBindable<int> FlexLayout.OrderProperty
+        Attributes.defineBindableInt FlexLayout.OrderProperty
 
     let Position =
-        Attributes.defineBindable<FlexPosition> FlexLayout.PositionProperty
+        Attributes.defineBindableEnum<FlexPosition> FlexLayout.PositionProperty
 
     let Shrink =
-        Attributes.defineBindable<float> FlexLayout.ShrinkProperty
+        Attributes.defineBindableFloat FlexLayout.ShrinkProperty
 
     let Wrap =
-        Attributes.defineBindable<FlexWrap> FlexLayout.WrapProperty
+        Attributes.defineBindableEnum<FlexWrap> FlexLayout.WrapProperty
 
 [<AutoOpen>]
 module FlexLayoutBuilders =

--- a/src/Fabulous.XamarinForms/Views/Layouts/Frame.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/Frame.fs
@@ -14,10 +14,10 @@ module Frame =
         Attributes.defineAppThemeBindable<Color> Frame.BorderColorProperty
 
     let CornerRadius =
-        Attributes.defineBindable<float> Frame.CornerRadiusProperty
+        Attributes.defineBindableFloat Frame.CornerRadiusProperty
 
     let HasShadow =
-        Attributes.defineBindable<bool> Frame.HasShadowProperty
+        Attributes.defineBindableBool Frame.HasShadowProperty
 
 [<AutoOpen>]
 module FrameBuilders =

--- a/src/Fabulous.XamarinForms/Views/Layouts/Grid.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/Grid.fs
@@ -27,22 +27,22 @@ module Grid =
             ViewUpdaters.updateGridRowDefinitions
 
     let Column =
-        Attributes.defineBindable<int> Grid.ColumnProperty
+        Attributes.defineBindableInt Grid.ColumnProperty
 
     let Row =
-        Attributes.defineBindable<int> Grid.RowProperty
+        Attributes.defineBindableInt Grid.RowProperty
 
     let ColumnSpacing =
-        Attributes.defineBindable<float> Grid.ColumnSpacingProperty
+        Attributes.defineBindableFloat Grid.ColumnSpacingProperty
 
     let RowSpacing =
-        Attributes.defineBindable<float> Grid.RowSpacingProperty
+        Attributes.defineBindableFloat Grid.RowSpacingProperty
 
     let ColumnSpan =
-        Attributes.defineBindable<int> Grid.ColumnSpanProperty
+        Attributes.defineBindableInt Grid.ColumnSpanProperty
 
     let RowSpan =
-        Attributes.defineBindable<int> Grid.RowSpanProperty
+        Attributes.defineBindableInt Grid.RowSpanProperty
 
 [<AutoOpen>]
 module GridBuilders =

--- a/src/Fabulous.XamarinForms/Views/Layouts/RefreshView.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/RefreshView.fs
@@ -12,7 +12,7 @@ module RefreshView =
     let WidgetKey = Widgets.register<RefreshView>()
 
     let IsRefreshing =
-        Attributes.defineBindable<bool> RefreshView.IsRefreshingProperty
+        Attributes.defineBindableBool RefreshView.IsRefreshingProperty
 
     let RefreshColor =
         Attributes.defineAppThemeBindable<Color> RefreshView.RefreshColorProperty

--- a/src/Fabulous.XamarinForms/Views/Layouts/ScrollView.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/ScrollView.fs
@@ -14,19 +14,19 @@ module ScrollView =
     let WidgetKey = Widgets.register<ScrollView>()
 
     let Orientation =
-        Attributes.defineBindable<ScrollOrientation> ScrollView.OrientationProperty
+        Attributes.defineBindableEnum<ScrollOrientation> ScrollView.OrientationProperty
 
     let ScrollX =
-        Attributes.defineBindable<float> ScrollView.ScrollXProperty
+        Attributes.defineBindableFloat ScrollView.ScrollXProperty
 
     let ScrollY =
-        Attributes.defineBindable<float> ScrollView.ScrollYProperty
+        Attributes.defineBindableFloat ScrollView.ScrollYProperty
 
     let HorizontalScrollBarVisibility =
-        Attributes.defineBindable<ScrollBarVisibility> ScrollView.HorizontalScrollBarVisibilityProperty
+        Attributes.defineBindableEnum<ScrollBarVisibility> ScrollView.HorizontalScrollBarVisibilityProperty
 
     let VerticalScrollBarVisibility =
-        Attributes.defineBindable<ScrollBarVisibility> ScrollView.VerticalScrollBarVisibilityProperty
+        Attributes.defineBindableEnum<ScrollBarVisibility> ScrollView.VerticalScrollBarVisibilityProperty
 
     let Content =
         Attributes.defineWidget

--- a/src/Fabulous.XamarinForms/Views/Layouts/StackLayout.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/StackLayout.fs
@@ -11,10 +11,10 @@ module StackLayout =
     let WidgetKey = Widgets.register<StackLayout>()
 
     let Orientation =
-        Attributes.defineBindable<StackOrientation> StackLayout.OrientationProperty
+        Attributes.defineBindableEnum<StackOrientation> StackLayout.OrientationProperty
 
     let Spacing =
-        Attributes.defineBindable<float> StackLayout.SpacingProperty
+        Attributes.defineBindableFloat StackLayout.SpacingProperty
 
 [<AutoOpen>]
 module StackLayoutBuilders =

--- a/src/Fabulous.XamarinForms/Views/Layouts/SwipeItem.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/SwipeItem.fs
@@ -15,7 +15,7 @@ module SwipeItem =
         Attributes.defineAppThemeBindable<Color> SwipeItem.BackgroundColorProperty
 
     let IsVisible =
-        Attributes.defineBindable<bool> SwipeItem.IsVisibleProperty
+        Attributes.defineBindableBool SwipeItem.IsVisibleProperty
 
     let Clicked =
         Attributes.defineEvent "SwipeItem_Invoked" (fun target -> (target :?> SwipeItem).Invoked)

--- a/src/Fabulous.XamarinForms/Views/Layouts/SwipeItems.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/SwipeItems.fs
@@ -19,10 +19,10 @@ module SwipeItems =
             (fun target -> (target :?> SwipeItems) :> IList<_>)
 
     let SwipeMode =
-        Attributes.defineBindable<SwipeMode> Xamarin.Forms.SwipeItems.ModeProperty
+        Attributes.defineBindableEnum<SwipeMode> Xamarin.Forms.SwipeItems.ModeProperty
 
     let SwipeBehaviorOnInvoked =
-        Attributes.defineBindable<SwipeBehaviorOnInvoked> Xamarin.Forms.SwipeItems.SwipeBehaviorOnInvokedProperty
+        Attributes.defineBindableEnum<SwipeBehaviorOnInvoked> Xamarin.Forms.SwipeItems.SwipeBehaviorOnInvokedProperty
 
 [<AutoOpen>]
 module SwipeItemsBuilders =

--- a/src/Fabulous.XamarinForms/Views/Layouts/SwipeView.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/SwipeView.fs
@@ -24,7 +24,7 @@ module SwipeView =
         Attributes.defineBindableWidget SwipeView.BottomItemsProperty
 
     let SwipeThreshold =
-        Attributes.defineBindable<int> SwipeView.ThresholdProperty
+        Attributes.defineBindableInt SwipeView.ThresholdProperty
 
     let SwipeStarted =
         Attributes.defineEvent<SwipeStartedEventArgs>

--- a/src/Fabulous.XamarinForms/Views/Layouts/_Layout.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/_Layout.fs
@@ -12,10 +12,10 @@ module Layout =
         Attributes.defineBindable<Thickness> Layout.PaddingProperty
 
     let CascadeInputTransparent =
-        Attributes.defineBindable<bool> Layout.CascadeInputTransparentProperty
+        Attributes.defineBindableBool Layout.CascadeInputTransparentProperty
 
     let IsClippedToBounds =
-        Attributes.defineBindable<bool> Layout.IsClippedToBoundsProperty
+        Attributes.defineBindableBool Layout.IsClippedToBoundsProperty
 
     let LayoutChanged =
         Attributes.defineEventNoArg "Layout_LayoutChanged" (fun target -> (target :?> Layout).LayoutChanged)

--- a/src/Fabulous.XamarinForms/Views/MenuItems/MenuItem.fs
+++ b/src/Fabulous.XamarinForms/Views/MenuItems/MenuItem.fs
@@ -19,10 +19,10 @@ module MenuItem =
         Attributes.defineAppThemeBindable<ImageSource> MenuItem.IconImageSourceProperty
 
     let IsDestructive =
-        Attributes.defineBindable<bool> MenuItem.IsDestructiveProperty
+        Attributes.defineBindableBool MenuItem.IsDestructiveProperty
 
     let IsEnabled =
-        Attributes.defineBindable<bool> MenuItem.IsEnabledProperty
+        Attributes.defineBindableBool MenuItem.IsEnabledProperty
 
     let Text =
         Attributes.defineBindable<string> MenuItem.TextProperty

--- a/src/Fabulous.XamarinForms/Views/Pages/FlyoutPage.fs
+++ b/src/Fabulous.XamarinForms/Views/Pages/FlyoutPage.fs
@@ -24,10 +24,10 @@ module FlyoutPage =
                 flyoutPage.CanChangeIsPresented <- value)
 
     let IsGestureEnabled =
-        Attributes.defineBindable<bool> FlyoutPage.IsGestureEnabledProperty
+        Attributes.defineBindableBool FlyoutPage.IsGestureEnabledProperty
 
     let IsPresented =
-        Attributes.defineBindable<bool> FlyoutPage.IsPresentedProperty
+        Attributes.defineBindableBool FlyoutPage.IsPresentedProperty
 
     let Flyout =
         Attributes.defineWidget
@@ -49,7 +49,7 @@ module FlyoutPage =
                 flyoutPage.FlyoutBounds <- value)
 
     let FlyoutLayoutBehavior =
-        Attributes.defineBindable<FlyoutLayoutBehavior> FlyoutPage.FlyoutLayoutBehaviorProperty
+        Attributes.defineBindableEnum<FlyoutLayoutBehavior> FlyoutPage.FlyoutLayoutBehaviorProperty
 
     let Detail =
         Attributes.defineWidget

--- a/src/Fabulous.XamarinForms/Views/Pages/NavigationPage.fs
+++ b/src/Fabulous.XamarinForms/Views/Pages/NavigationPage.fs
@@ -35,10 +35,10 @@ module NavigationPage =
         Attributes.defineAppThemeBindable<Color> NavigationPage.IconColorProperty
 
     let HasNavigationBar =
-        Attributes.defineBindable<bool> NavigationPage.HasNavigationBarProperty
+        Attributes.defineBindableBool NavigationPage.HasNavigationBarProperty
 
     let HasBackButton =
-        Attributes.defineBindable<bool> NavigationPage.HasBackButtonProperty
+        Attributes.defineBindableBool NavigationPage.HasBackButtonProperty
 
     let TitleIconImageSource =
         Attributes.defineAppThemeBindable<ImageSource> NavigationPage.TitleIconImageSourceProperty

--- a/src/Fabulous.XamarinForms/Views/Pages/_Page.fs
+++ b/src/Fabulous.XamarinForms/Views/Pages/_Page.fs
@@ -18,7 +18,7 @@ module Page =
         Attributes.defineAppThemeBindable<ImageSource> Page.IconImageSourceProperty
 
     let IsBusy =
-        Attributes.defineBindable<bool> Page.IsBusyProperty
+        Attributes.defineBindableBool Page.IsBusyProperty
 
     let Padding =
         Attributes.defineBindable<Thickness> Page.PaddingProperty

--- a/src/Fabulous.XamarinForms/Views/Shapes/Geometries/EllipseGeometry.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Geometries/EllipseGeometry.fs
@@ -14,10 +14,10 @@ module EllipseGeometry =
         Attributes.defineBindable<Point> EllipseGeometry.CenterProperty
 
     let RadiusX =
-        Attributes.defineBindable<float> EllipseGeometry.RadiusXProperty
+        Attributes.defineBindableFloat EllipseGeometry.RadiusXProperty
 
     let RadiusY =
-        Attributes.defineBindable<float> EllipseGeometry.RadiusYProperty
+        Attributes.defineBindableFloat EllipseGeometry.RadiusYProperty
 
 [<AutoOpen>]
 module EllipseGeometryBuilders =

--- a/src/Fabulous.XamarinForms/Views/Shapes/Geometries/RoundRectangleGeometry.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Geometries/RoundRectangleGeometry.fs
@@ -14,7 +14,7 @@ module RoundRectangleGeometry =
         Widgets.register<RoundRectangleGeometry>()
 
     let CornerRadius =
-        Attributes.defineBindable<float> RoundRectangleGeometry.CornerRadiusProperty
+        Attributes.defineBindableFloat RoundRectangleGeometry.CornerRadiusProperty
 
     let Rect =
         Attributes.defineBindable<Rect> RoundRectangleGeometry.RectProperty

--- a/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/CompositeTransform.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/CompositeTransform.fs
@@ -67,7 +67,7 @@ module CompositeTransform =
                     line.TranslateY <- y)
 
     let Rotation =
-        Attributes.defineBindable<float> CompositeTransform.RotationProperty
+        Attributes.defineBindableFloat CompositeTransform.RotationProperty
 
 [<AutoOpen>]
 module CompositeTransformBuilders =

--- a/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/RotateTransform.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/RotateTransform.fs
@@ -10,13 +10,13 @@ module RotateTransform =
     let WidgetKey = Widgets.register<RotateTransform>()
 
     let Angle =
-        Attributes.defineBindable<float> RotateTransform.AngleProperty
+        Attributes.defineBindableFloat RotateTransform.AngleProperty
 
     let CenterX =
-        Attributes.defineBindable<float> RotateTransform.CenterXProperty
+        Attributes.defineBindableFloat RotateTransform.CenterXProperty
 
     let CenterY =
-        Attributes.defineBindable<float> RotateTransform.CenterYProperty
+        Attributes.defineBindableFloat RotateTransform.CenterYProperty
 
 [<AutoOpen>]
 module RotateTransformBuilders =

--- a/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/ScaleTransform.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/ScaleTransform.fs
@@ -24,10 +24,10 @@ module ScaleTransform =
                     line.ScaleY <- y)
 
     let CenterX =
-        Attributes.defineBindable<float> ScaleTransform.CenterXProperty
+        Attributes.defineBindableFloat ScaleTransform.CenterXProperty
 
     let CenterY =
-        Attributes.defineBindable<float> ScaleTransform.CenterYProperty
+        Attributes.defineBindableFloat ScaleTransform.CenterYProperty
 
 [<AutoOpen>]
 module ScaleTransformBuilders =

--- a/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/SkewTransform.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/SkewTransform.fs
@@ -24,10 +24,10 @@ module SkewTransform =
                     line.AngleY <- y)
 
     let CenterX =
-        Attributes.defineBindable<float> ScaleTransform.CenterXProperty
+        Attributes.defineBindableFloat ScaleTransform.CenterXProperty
 
     let CenterY =
-        Attributes.defineBindable<float> ScaleTransform.CenterYProperty
+        Attributes.defineBindableFloat ScaleTransform.CenterYProperty
 
 [<AutoOpen>]
 module SkewTransformBuilders =

--- a/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/TranslateTransform.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/TranslateTransform.fs
@@ -10,10 +10,10 @@ module TranslateTransform =
     let WidgetKey = Widgets.register<TranslateTransform>()
 
     let X =
-        Attributes.defineBindable<float> TranslateTransform.XProperty
+        Attributes.defineBindableFloat TranslateTransform.XProperty
 
     let Y =
-        Attributes.defineBindable<float> TranslateTransform.YProperty
+        Attributes.defineBindableFloat TranslateTransform.YProperty
 
 [<AutoOpen>]
 module TranslateTransformBuilders =

--- a/src/Fabulous.XamarinForms/Views/Shapes/Rectangle.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Rectangle.fs
@@ -13,10 +13,10 @@ module Rectangle =
     let WidgetKey = Widgets.register<Rectangle>()
 
     let RadiusX =
-        Attributes.defineBindable<float> Rectangle.RadiusXProperty
+        Attributes.defineBindableFloat Rectangle.RadiusXProperty
 
     let RadiusY =
-        Attributes.defineBindable<float> Rectangle.RadiusYProperty
+        Attributes.defineBindableFloat Rectangle.RadiusYProperty
 
 [<AutoOpen>]
 module RectangleBuilders =

--- a/src/Fabulous.XamarinForms/Views/Shapes/Segments/ArcSegment.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Segments/ArcSegment.fs
@@ -12,19 +12,19 @@ module ArcSegment =
     let WidgetKey = Widgets.register<ArcSegment>()
 
     let IsLargeArc =
-        Attributes.defineSmallBindable<bool> ArcSegment.IsLargeArcProperty SmallScalars.Bool.decode
+        Attributes.defineBindableBool ArcSegment.IsLargeArcProperty
 
     let Point =
         Attributes.defineBindable<Point> ArcSegment.SizeProperty
 
     let RotationAngle =
-        Attributes.defineSmallBindable<float> ArcSegment.RotationAngleProperty SmallScalars.Float.decode
+        Attributes.defineBindableFloat ArcSegment.RotationAngleProperty
 
     let Size =
         Attributes.defineBindable<Size> ArcSegment.SizeProperty
 
     let SweepDirection =
-        Attributes.defineBindable<SweepDirection> ArcSegment.SweepDirectionProperty
+        Attributes.defineBindableEnum<SweepDirection> ArcSegment.SweepDirectionProperty
 
 [<AutoOpen>]
 module ArcSegmentBuilders =

--- a/src/Fabulous.XamarinForms/Views/Shapes/Segments/ArcSegment.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Segments/ArcSegment.fs
@@ -12,13 +12,13 @@ module ArcSegment =
     let WidgetKey = Widgets.register<ArcSegment>()
 
     let IsLargeArc =
-        Attributes.defineBindable<bool> ArcSegment.IsLargeArcProperty
+        Attributes.defineSmallBindable<bool> ArcSegment.IsLargeArcProperty SmallScalars.Bool.decode
 
     let Point =
         Attributes.defineBindable<Point> ArcSegment.SizeProperty
 
     let RotationAngle =
-        Attributes.defineBindable<float> ArcSegment.RotationAngleProperty
+        Attributes.defineSmallBindable<float> ArcSegment.RotationAngleProperty SmallScalars.Float.decode
 
     let Size =
         Attributes.defineBindable<Size> ArcSegment.SizeProperty

--- a/src/Fabulous.XamarinForms/Views/Shapes/Segments/PathFigure.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Segments/PathFigure.fs
@@ -22,10 +22,10 @@ module PathFigure =
         Attributes.defineBindable<Point> PathFigure.StartPointProperty
 
     let IsClosed =
-        Attributes.defineBindable<bool> PathFigure.IsClosedProperty
+        Attributes.defineBindableBool PathFigure.IsClosedProperty
 
     let IsFilled =
-        Attributes.defineBindable<bool> PathFigure.IsFilledProperty
+        Attributes.defineBindableBool PathFigure.IsFilledProperty
 
 [<AutoOpen>]
 module PathFigureBuilders =

--- a/src/Fabulous.XamarinForms/Views/Shapes/_Shape.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/_Shape.fs
@@ -17,7 +17,7 @@ module Shape =
         Attributes.defineAppThemeBindable<Brush> Shape.StrokeProperty
 
     let StrokeThickness =
-        Attributes.defineBindable<float> Shape.StrokeThicknessProperty
+        Attributes.defineBindableFloat Shape.StrokeThicknessProperty
 
     let StrokeDashArrayString =
         Attributes.define<string>
@@ -48,7 +48,7 @@ module Shape =
                     target.SetValue(Shape.StrokeDashArrayProperty, coll))
 
     let StrokeDashOffset =
-        Attributes.defineBindable<float> Shape.StrokeDashOffsetProperty
+        Attributes.defineBindableFloat Shape.StrokeDashOffsetProperty
 
     let StrokeLineCap =
         Attributes.defineBindable<PenLineCap> Shape.StrokeLineCapProperty
@@ -57,7 +57,7 @@ module Shape =
         Attributes.defineBindable<PenLineJoin> Shape.StrokeLineJoinProperty
 
     let StrokeMiterLimit =
-        Attributes.defineBindable<float> Shape.StrokeMiterLimitProperty
+        Attributes.defineBindableFloat Shape.StrokeMiterLimitProperty
 
     let Aspect =
         Attributes.defineBindable<Stretch> Shape.AspectProperty

--- a/src/Fabulous.XamarinForms/Views/_View.fs
+++ b/src/Fabulous.XamarinForms/Views/_View.fs
@@ -34,10 +34,10 @@ type RotateToData =
 
 module XFView =
     let HorizontalOptions =
-        Attributes.defineBindable<LayoutOptions> View.HorizontalOptionsProperty
+        Attributes.defineSmallBindable<LayoutOptions> View.HorizontalOptionsProperty SmallScalars.LayoutOptions.decode
 
     let VerticalOptions =
-        Attributes.defineBindable<LayoutOptions> View.VerticalOptionsProperty
+        Attributes.defineSmallBindable<LayoutOptions> View.VerticalOptionsProperty SmallScalars.LayoutOptions.decode
 
     let Margin =
         Attributes.defineBindable<Thickness> View.MarginProperty
@@ -154,11 +154,11 @@ module XFView =
 type ViewModifiers =
     [<Extension>]
     static member inline horizontalOptions(this: WidgetBuilder<'msg, #IView>, value: LayoutOptions) =
-        this.AddScalar(XFView.HorizontalOptions.WithValue(value))
+        this.AddScalar(XFView.HorizontalOptions.WithValue(value, SmallScalars.LayoutOptions.encode))
 
     [<Extension>]
     static member inline verticalOptions(this: WidgetBuilder<'msg, #IView>, value: LayoutOptions) =
-        this.AddScalar(XFView.VerticalOptions.WithValue(value))
+        this.AddScalar(XFView.VerticalOptions.WithValue(value, SmallScalars.LayoutOptions.encode))
 
     [<Extension>]
     static member inline center(this: WidgetBuilder<'msg, #IView>, ?expand: bool) =
@@ -169,8 +169,8 @@ type ViewModifiers =
             | Some true -> LayoutOptions.CenterAndExpand
 
         this
-            .AddScalar(XFView.HorizontalOptions.WithValue(options))
-            .AddScalar(XFView.VerticalOptions.WithValue(options))
+            .AddScalar(XFView.HorizontalOptions.WithValue(options, SmallScalars.LayoutOptions.encode))
+            .AddScalar(XFView.VerticalOptions.WithValue(options, SmallScalars.LayoutOptions.encode))
 
 
     [<Extension>]
@@ -181,7 +181,7 @@ type ViewModifiers =
             | Some false -> LayoutOptions.Center
             | Some true -> LayoutOptions.CenterAndExpand
 
-        this.AddScalar(XFView.HorizontalOptions.WithValue(options))
+        this.AddScalar(XFView.HorizontalOptions.WithValue(options, SmallScalars.LayoutOptions.encode))
 
     [<Extension>]
     static member inline centerVertical(this: WidgetBuilder<'msg, #IView>, ?expand: bool) =
@@ -191,7 +191,7 @@ type ViewModifiers =
             | Some false -> LayoutOptions.Center
             | Some true -> LayoutOptions.CenterAndExpand
 
-        this.AddScalar(XFView.VerticalOptions.WithValue(options))
+        this.AddScalar(XFView.VerticalOptions.WithValue(options, SmallScalars.LayoutOptions.encode))
 
     [<Extension>]
     static member inline alignStartHorizontal(this: WidgetBuilder<'msg, #IView>, ?expand: bool) =
@@ -201,7 +201,7 @@ type ViewModifiers =
             | Some false -> LayoutOptions.Start
             | Some true -> LayoutOptions.StartAndExpand
 
-        this.AddScalar(XFView.HorizontalOptions.WithValue(options))
+        this.AddScalar(XFView.HorizontalOptions.WithValue(options, SmallScalars.LayoutOptions.encode))
 
     [<Extension>]
     static member inline alignStartVertical(this: WidgetBuilder<'msg, #IView>, ?expand: bool) =
@@ -211,7 +211,7 @@ type ViewModifiers =
             | Some false -> LayoutOptions.Start
             | Some true -> LayoutOptions.StartAndExpand
 
-        this.AddScalar(XFView.VerticalOptions.WithValue(options))
+        this.AddScalar(XFView.VerticalOptions.WithValue(options, SmallScalars.LayoutOptions.encode))
 
     [<Extension>]
     static member inline alignEndHorizontal(this: WidgetBuilder<'msg, #IView>, ?expand: bool) =
@@ -221,7 +221,7 @@ type ViewModifiers =
             | Some false -> LayoutOptions.End
             | Some true -> LayoutOptions.EndAndExpand
 
-        this.AddScalar(XFView.HorizontalOptions.WithValue(options))
+        this.AddScalar(XFView.HorizontalOptions.WithValue(options, SmallScalars.LayoutOptions.encode))
 
     [<Extension>]
     static member inline alignEndVertical(this: WidgetBuilder<'msg, #IView>, ?expand: bool) =
@@ -231,7 +231,7 @@ type ViewModifiers =
             | Some false -> LayoutOptions.End
             | Some true -> LayoutOptions.EndAndExpand
 
-        this.AddScalar(XFView.VerticalOptions.WithValue(options))
+        this.AddScalar(XFView.VerticalOptions.WithValue(options, SmallScalars.LayoutOptions.encode))
 
     [<Extension>]
     static member inline fillHorizontal(this: WidgetBuilder<'msg, #IView>, ?expand: bool) =
@@ -241,7 +241,7 @@ type ViewModifiers =
             | Some false -> LayoutOptions.Fill
             | Some true -> LayoutOptions.FillAndExpand
 
-        this.AddScalar(XFView.HorizontalOptions.WithValue(options))
+        this.AddScalar(XFView.HorizontalOptions.WithValue(options, SmallScalars.LayoutOptions.encode))
 
     [<Extension>]
     static member inline fillVertical(this: WidgetBuilder<'msg, #IView>, ?expand: bool) =
@@ -251,7 +251,7 @@ type ViewModifiers =
             | Some false -> LayoutOptions.Fill
             | Some true -> LayoutOptions.FillAndExpand
 
-        this.AddScalar(XFView.VerticalOptions.WithValue(options))
+        this.AddScalar(XFView.VerticalOptions.WithValue(options, SmallScalars.LayoutOptions.encode))
 
     [<Extension>]
     static member inline margin(this: WidgetBuilder<'msg, #IView>, value: Thickness) =

--- a/src/Fabulous.XamarinForms/Views/_View.fs
+++ b/src/Fabulous.XamarinForms/Views/_View.fs
@@ -154,11 +154,11 @@ module XFView =
 type ViewModifiers =
     [<Extension>]
     static member inline horizontalOptions(this: WidgetBuilder<'msg, #IView>, value: LayoutOptions) =
-        this.AddScalar(XFView.HorizontalOptions.WithValue(value, SmallScalars.LayoutOptions.encode))
+        this.AddScalar(XFView.HorizontalOptions.WithValue(value))
 
     [<Extension>]
     static member inline verticalOptions(this: WidgetBuilder<'msg, #IView>, value: LayoutOptions) =
-        this.AddScalar(XFView.VerticalOptions.WithValue(value, SmallScalars.LayoutOptions.encode))
+        this.AddScalar(XFView.VerticalOptions.WithValue(value))
 
     [<Extension>]
     static member inline center(this: WidgetBuilder<'msg, #IView>, ?expand: bool) =
@@ -169,8 +169,8 @@ type ViewModifiers =
             | Some true -> LayoutOptions.CenterAndExpand
 
         this
-            .AddScalar(XFView.HorizontalOptions.WithValue(options, SmallScalars.LayoutOptions.encode))
-            .AddScalar(XFView.VerticalOptions.WithValue(options, SmallScalars.LayoutOptions.encode))
+            .AddScalar(XFView.HorizontalOptions.WithValue(options))
+            .AddScalar(XFView.VerticalOptions.WithValue(options))
 
 
     [<Extension>]
@@ -181,7 +181,7 @@ type ViewModifiers =
             | Some false -> LayoutOptions.Center
             | Some true -> LayoutOptions.CenterAndExpand
 
-        this.AddScalar(XFView.HorizontalOptions.WithValue(options, SmallScalars.LayoutOptions.encode))
+        this.AddScalar(XFView.HorizontalOptions.WithValue(options))
 
     [<Extension>]
     static member inline centerVertical(this: WidgetBuilder<'msg, #IView>, ?expand: bool) =
@@ -191,7 +191,7 @@ type ViewModifiers =
             | Some false -> LayoutOptions.Center
             | Some true -> LayoutOptions.CenterAndExpand
 
-        this.AddScalar(XFView.VerticalOptions.WithValue(options, SmallScalars.LayoutOptions.encode))
+        this.AddScalar(XFView.VerticalOptions.WithValue(options))
 
     [<Extension>]
     static member inline alignStartHorizontal(this: WidgetBuilder<'msg, #IView>, ?expand: bool) =
@@ -201,7 +201,7 @@ type ViewModifiers =
             | Some false -> LayoutOptions.Start
             | Some true -> LayoutOptions.StartAndExpand
 
-        this.AddScalar(XFView.HorizontalOptions.WithValue(options, SmallScalars.LayoutOptions.encode))
+        this.AddScalar(XFView.HorizontalOptions.WithValue(options))
 
     [<Extension>]
     static member inline alignStartVertical(this: WidgetBuilder<'msg, #IView>, ?expand: bool) =
@@ -211,7 +211,7 @@ type ViewModifiers =
             | Some false -> LayoutOptions.Start
             | Some true -> LayoutOptions.StartAndExpand
 
-        this.AddScalar(XFView.VerticalOptions.WithValue(options, SmallScalars.LayoutOptions.encode))
+        this.AddScalar(XFView.VerticalOptions.WithValue(options))
 
     [<Extension>]
     static member inline alignEndHorizontal(this: WidgetBuilder<'msg, #IView>, ?expand: bool) =
@@ -221,7 +221,7 @@ type ViewModifiers =
             | Some false -> LayoutOptions.End
             | Some true -> LayoutOptions.EndAndExpand
 
-        this.AddScalar(XFView.HorizontalOptions.WithValue(options, SmallScalars.LayoutOptions.encode))
+        this.AddScalar(XFView.HorizontalOptions.WithValue(options))
 
     [<Extension>]
     static member inline alignEndVertical(this: WidgetBuilder<'msg, #IView>, ?expand: bool) =
@@ -231,7 +231,7 @@ type ViewModifiers =
             | Some false -> LayoutOptions.End
             | Some true -> LayoutOptions.EndAndExpand
 
-        this.AddScalar(XFView.VerticalOptions.WithValue(options, SmallScalars.LayoutOptions.encode))
+        this.AddScalar(XFView.VerticalOptions.WithValue(options))
 
     [<Extension>]
     static member inline fillHorizontal(this: WidgetBuilder<'msg, #IView>, ?expand: bool) =
@@ -241,7 +241,7 @@ type ViewModifiers =
             | Some false -> LayoutOptions.Fill
             | Some true -> LayoutOptions.FillAndExpand
 
-        this.AddScalar(XFView.HorizontalOptions.WithValue(options, SmallScalars.LayoutOptions.encode))
+        this.AddScalar(XFView.HorizontalOptions.WithValue(options))
 
     [<Extension>]
     static member inline fillVertical(this: WidgetBuilder<'msg, #IView>, ?expand: bool) =
@@ -251,7 +251,7 @@ type ViewModifiers =
             | Some false -> LayoutOptions.Fill
             | Some true -> LayoutOptions.FillAndExpand
 
-        this.AddScalar(XFView.VerticalOptions.WithValue(options, SmallScalars.LayoutOptions.encode))
+        this.AddScalar(XFView.VerticalOptions.WithValue(options))
 
     [<Extension>]
     static member inline margin(this: WidgetBuilder<'msg, #IView>, value: Thickness) =

--- a/src/Fabulous.XamarinForms/Views/_VisualElement.fs
+++ b/src/Fabulous.XamarinForms/Views/_VisualElement.fs
@@ -9,10 +9,10 @@ type IVisualElement =
 
 module VisualElement =
     let AnchorX =
-        Attributes.defineBindable<float> VisualElement.AnchorXProperty
+        Attributes.defineSmallBindable<float> VisualElement.AnchorXProperty SmallScalars.Float.decode
 
     let AnchorY =
-        Attributes.defineBindable<float> VisualElement.AnchorYProperty
+        Attributes.defineSmallBindable<float> VisualElement.AnchorYProperty SmallScalars.Float.decode
 
     let BackgroundColor =
         Attributes.defineAppThemeBindable<Color> VisualElement.BackgroundColorProperty
@@ -24,61 +24,61 @@ module VisualElement =
         Attributes.defineBindableWidget VisualElement.ClipProperty
 
     let FlowDirection =
-        Attributes.defineBindable<FlowDirection> VisualElement.FlowDirectionProperty
+        Attributes.defineSmallBindable<FlowDirection> VisualElement.FlowDirectionProperty SmallScalars.FlowDirection.decode
 
     let HeightRequest =
-        Attributes.defineBindable<float> VisualElement.HeightRequestProperty
+        Attributes.defineSmallBindable<float> VisualElement.HeightRequestProperty SmallScalars.Float.decode
 
     let WidthRequest =
-        Attributes.defineBindable<float> VisualElement.WidthRequestProperty
+        Attributes.defineSmallBindable<float> VisualElement.WidthRequestProperty SmallScalars.Float.decode
 
     let InputTransparent =
-        Attributes.defineBindable<bool> VisualElement.InputTransparentProperty
+        Attributes.defineSmallBindable<bool> VisualElement.InputTransparentProperty SmallScalars.Bool.decode
 
     let IsEnabled =
-        Attributes.defineBindable<bool> VisualElement.IsEnabledProperty
+        Attributes.defineSmallBindable<bool> VisualElement.IsEnabledProperty SmallScalars.Bool.decode
 
     let IsTabStop =
-        Attributes.defineBindable<bool> VisualElement.IsTabStopProperty
+        Attributes.defineSmallBindable<bool> VisualElement.IsTabStopProperty SmallScalars.Bool.decode
 
     let IsVisible =
-        Attributes.defineBindable<bool> VisualElement.IsVisibleProperty
+        Attributes.defineSmallBindable<bool> VisualElement.IsVisibleProperty SmallScalars.Bool.decode
 
     let MinimumHeightRequest =
-        Attributes.defineBindable<float> VisualElement.MinimumHeightRequestProperty
+        Attributes.defineSmallBindable<float> VisualElement.MinimumHeightRequestProperty SmallScalars.Float.decode
 
     let MinimumWidthRequest =
-        Attributes.defineBindable<float> VisualElement.MinimumWidthRequestProperty
+        Attributes.defineSmallBindable<float> VisualElement.MinimumWidthRequestProperty SmallScalars.Float.decode
 
     let Opacity =
-        Attributes.defineBindable<float> VisualElement.OpacityProperty
+        Attributes.defineSmallBindable<float> VisualElement.OpacityProperty SmallScalars.Float.decode
 
     let Rotation =
-        Attributes.defineBindable<float> VisualElement.RotationProperty
+        Attributes.defineSmallBindable<float> VisualElement.RotationProperty SmallScalars.Float.decode
 
     let RotationX =
-        Attributes.defineBindable<float> VisualElement.RotationXProperty
+        Attributes.defineSmallBindable<float> VisualElement.RotationXProperty SmallScalars.Float.decode
 
     let RotationY =
-        Attributes.defineBindable<float> VisualElement.RotationYProperty
+        Attributes.defineSmallBindable<float> VisualElement.RotationYProperty SmallScalars.Float.decode
 
     let Scale =
-        Attributes.defineBindable<float> VisualElement.ScaleProperty
+        Attributes.defineSmallBindable<float> VisualElement.ScaleProperty SmallScalars.Float.decode
 
     let ScaleX =
-        Attributes.defineBindable<float> VisualElement.ScaleXProperty
+        Attributes.defineSmallBindable<float> VisualElement.ScaleXProperty SmallScalars.Float.decode
 
     let ScaleY =
-        Attributes.defineBindable<float> VisualElement.ScaleYProperty
+        Attributes.defineSmallBindable<float> VisualElement.ScaleYProperty SmallScalars.Float.decode
 
     let TabIndex =
-        Attributes.defineBindable<int> VisualElement.TabIndexProperty
+        Attributes.defineSmallBindable<int> VisualElement.TabIndexProperty SmallScalars.Int.decode
 
     let TranslationX =
-        Attributes.defineBindable<float> VisualElement.TranslationXProperty
+        Attributes.defineSmallBindable<float> VisualElement.TranslationXProperty SmallScalars.Float.decode
 
     let TranslationY =
-        Attributes.defineBindable<float> VisualElement.TranslationYProperty
+        Attributes.defineSmallBindable<float> VisualElement.TranslationYProperty SmallScalars.Float.decode
 
     let Visual =
         Attributes.defineBindable<IVisual> VisualElement.VisualProperty

--- a/src/Fabulous.XamarinForms/Views/_VisualElement.fs
+++ b/src/Fabulous.XamarinForms/Views/_VisualElement.fs
@@ -9,10 +9,10 @@ type IVisualElement =
 
 module VisualElement =
     let AnchorX =
-        Attributes.defineSmallBindable<float> VisualElement.AnchorXProperty SmallScalars.Float.decode
+        Attributes.defineBindableFloat VisualElement.AnchorXProperty
 
     let AnchorY =
-        Attributes.defineSmallBindable<float> VisualElement.AnchorYProperty SmallScalars.Float.decode
+        Attributes.defineBindableFloat VisualElement.AnchorYProperty
 
     let BackgroundColor =
         Attributes.defineAppThemeBindable<Color> VisualElement.BackgroundColorProperty
@@ -24,61 +24,61 @@ module VisualElement =
         Attributes.defineBindableWidget VisualElement.ClipProperty
 
     let FlowDirection =
-        Attributes.defineSmallBindable<FlowDirection> VisualElement.FlowDirectionProperty SmallScalars.FlowDirection.decode
+        Attributes.defineBindableEnum<FlowDirection> VisualElement.FlowDirectionProperty
 
     let HeightRequest =
-        Attributes.defineSmallBindable<float> VisualElement.HeightRequestProperty SmallScalars.Float.decode
+        Attributes.defineBindableFloat VisualElement.HeightRequestProperty
 
     let WidthRequest =
-        Attributes.defineSmallBindable<float> VisualElement.WidthRequestProperty SmallScalars.Float.decode
+        Attributes.defineBindableFloat VisualElement.WidthRequestProperty
 
     let InputTransparent =
-        Attributes.defineSmallBindable<bool> VisualElement.InputTransparentProperty SmallScalars.Bool.decode
+        Attributes.defineBindableBool VisualElement.InputTransparentProperty
 
     let IsEnabled =
-        Attributes.defineSmallBindable<bool> VisualElement.IsEnabledProperty SmallScalars.Bool.decode
+        Attributes.defineBindableBool VisualElement.IsEnabledProperty
 
     let IsTabStop =
-        Attributes.defineSmallBindable<bool> VisualElement.IsTabStopProperty SmallScalars.Bool.decode
+        Attributes.defineBindableBool VisualElement.IsTabStopProperty
 
     let IsVisible =
-        Attributes.defineSmallBindable<bool> VisualElement.IsVisibleProperty SmallScalars.Bool.decode
+        Attributes.defineBindableBool VisualElement.IsVisibleProperty
 
     let MinimumHeightRequest =
-        Attributes.defineSmallBindable<float> VisualElement.MinimumHeightRequestProperty SmallScalars.Float.decode
+        Attributes.defineBindableFloat VisualElement.MinimumHeightRequestProperty
 
     let MinimumWidthRequest =
-        Attributes.defineSmallBindable<float> VisualElement.MinimumWidthRequestProperty SmallScalars.Float.decode
+        Attributes.defineBindableFloat VisualElement.MinimumWidthRequestProperty
 
     let Opacity =
-        Attributes.defineSmallBindable<float> VisualElement.OpacityProperty SmallScalars.Float.decode
+        Attributes.defineBindableFloat VisualElement.OpacityProperty
 
     let Rotation =
-        Attributes.defineSmallBindable<float> VisualElement.RotationProperty SmallScalars.Float.decode
+        Attributes.defineBindableFloat VisualElement.RotationProperty
 
     let RotationX =
-        Attributes.defineSmallBindable<float> VisualElement.RotationXProperty SmallScalars.Float.decode
+        Attributes.defineBindableFloat VisualElement.RotationXProperty
 
     let RotationY =
-        Attributes.defineSmallBindable<float> VisualElement.RotationYProperty SmallScalars.Float.decode
+        Attributes.defineBindableFloat VisualElement.RotationYProperty
 
     let Scale =
-        Attributes.defineSmallBindable<float> VisualElement.ScaleProperty SmallScalars.Float.decode
+        Attributes.defineBindableFloat VisualElement.ScaleProperty
 
     let ScaleX =
-        Attributes.defineSmallBindable<float> VisualElement.ScaleXProperty SmallScalars.Float.decode
+        Attributes.defineBindableFloat VisualElement.ScaleXProperty
 
     let ScaleY =
-        Attributes.defineSmallBindable<float> VisualElement.ScaleYProperty SmallScalars.Float.decode
+        Attributes.defineBindableFloat VisualElement.ScaleYProperty
 
     let TabIndex =
-        Attributes.defineSmallBindable<int> VisualElement.TabIndexProperty SmallScalars.Int.decode
+        Attributes.defineBindableInt VisualElement.TabIndexProperty
 
     let TranslationX =
-        Attributes.defineSmallBindable<float> VisualElement.TranslationXProperty SmallScalars.Float.decode
+        Attributes.defineBindableFloat VisualElement.TranslationXProperty
 
     let TranslationY =
-        Attributes.defineSmallBindable<float> VisualElement.TranslationYProperty SmallScalars.Float.decode
+        Attributes.defineBindableFloat VisualElement.TranslationYProperty
 
     let Visual =
         Attributes.defineBindable<IVisual> VisualElement.VisualProperty

--- a/src/Fabulous/Attributes.fs
+++ b/src/Fabulous/Attributes.fs
@@ -10,8 +10,7 @@ module Helpers =
     let canReuse<'T when 'T: equality> (prev: 'T) (curr: 'T) = prev = curr
 
     let inline createViewForWidget (parent: IViewNode) (widget: Widget) =
-        let widgetDefinition =
-            WidgetDefinitionStore.get widget.Key
+        let widgetDefinition = WidgetDefinitionStore.get widget.Key
 
         widgetDefinition.CreateView(widget, parent.TreeContext, ValueSome parent)
 
@@ -30,19 +29,24 @@ module SmallScalars =
         let inline decode (encoded: uint64) : bool = encoded = 1UL
 
     module Float =
-        let inline encode (v: float) : uint64 = BitConverter.DoubleToInt64Bits v |> uint64
-        let inline decode (encoded: uint64) : float = encoded |> int64 |> BitConverter.Int64BitsToDouble 
+        let inline encode (v: float) : uint64 =
+            BitConverter.DoubleToInt64Bits v |> uint64
+
+        let inline decode (encoded: uint64) : float =
+            encoded |> int64 |> BitConverter.Int64BitsToDouble
 
     // TODO is there a better conversion algorithm?
     module Int =
         let inline encode (v: int) : uint64 = uint64 v
 
         let inline decode (encoded: uint64) : int = int encoded
-        
+
     module IntEnum =
-        let inline encode< ^T when ^T: enum<int> and ^T: (static member op_Explicit: ^T -> uint64)> (v: ^T) : uint64 = uint64 v
-        let inline decode< ^T when ^T: enum<int>> (encoded: uint64) : ^T = enum< ^T>(int encoded) 
-        
+        let inline encode< ^T when ^T: enum<int> and ^T: (static member op_Explicit: ^T -> uint64)> (v: ^T) : uint64 =
+            uint64 v
+
+        let inline decode< ^T when ^T: enum<int>> (encoded: uint64) : ^T = enum< ^T>(int encoded)
+
 
 [<Extension>]
 type SmallScalarExtensions() =
@@ -169,8 +173,7 @@ module Attributes =
             match newValueOpt with
             | ValueNone -> set node.Target null
             | ValueSome widget ->
-                let struct (_, view) =
-                    Helpers.createViewForWidget node widget
+                let struct (_, view) = Helpers.createViewForWidget node widget
 
                 set node.Target (unbox view)
 
@@ -188,8 +191,7 @@ module Attributes =
             for diff in diffs do
                 match diff with
                 | WidgetCollectionItemChange.Remove (index, widget) ->
-                    let itemNode =
-                        getViewNode targetColl.[index]
+                    let itemNode = getViewNode targetColl.[index]
 
                     // Trigger the unmounted event
                     Dispatcher.dispatchEventForAllChildren itemNode widget Lifecycle.Unmounted
@@ -203,8 +205,7 @@ module Attributes =
             for diff in diffs do
                 match diff with
                 | WidgetCollectionItemChange.Insert (index, widget) ->
-                    let struct (itemNode, view) =
-                        Helpers.createViewForWidget node widget
+                    let struct (itemNode, view) = Helpers.createViewForWidget node widget
 
                     // Insert the new child into the UI tree
                     targetColl.Insert(index, unbox view)
@@ -219,8 +220,7 @@ module Attributes =
                     childNode.ApplyDiff(&widgetDiff)
 
                 | WidgetCollectionItemChange.Replace (index, oldWidget, newWidget) ->
-                    let prevItemNode =
-                        getViewNode targetColl.[index]
+                    let prevItemNode = getViewNode targetColl.[index]
 
                     let struct (nextItemNode, view) =
                         Helpers.createViewForWidget node newWidget
@@ -245,8 +245,7 @@ module Attributes =
             | ValueNone -> ()
             | ValueSome widgets ->
                 for widget in ArraySlice.toSpan widgets do
-                    let struct (_, view) =
-                        Helpers.createViewForWidget node widget
+                    let struct (_, view) = Helpers.createViewForWidget node widget
 
                     targetColl.Add(unbox view)
 
@@ -311,9 +310,10 @@ module Attributes =
 
                     | ValueSome fn ->
                         let handler =
-                            EventHandler<'args> (fun _ args ->
-                                let r = fn args
-                                Dispatcher.dispatch node r)
+                            EventHandler<'args>
+                                (fun _ args ->
+                                    let r = fn args
+                                    Dispatcher.dispatch node r)
 
                         node.SetHandler(name, ValueSome handler)
                         event.AddHandler handler)

--- a/src/Fabulous/Attributes.fs
+++ b/src/Fabulous/Attributes.fs
@@ -1,6 +1,7 @@
 ﻿namespace Fabulous
 
 open System
+open System.Runtime.CompilerServices
 open Fabulous.ScalarAttributeDefinitions
 open Fabulous.WidgetAttributeDefinitions
 open Fabulous.WidgetCollectionAttributeDefinitions
@@ -27,7 +28,7 @@ module SmallScalars =
     module Bool =
         let inline encode (v: bool) : uint64 = if v then 1UL else 0UL
         let inline decode (encoded: uint64) : bool = encoded = 1UL
-
+        
     module Float =
         let inline encode (v: float) : uint64 = BitConverter.DoubleToUInt64Bits v
         let inline decode (encoded: uint64) : float = BitConverter.UInt64BitsToDouble encoded
@@ -39,9 +40,22 @@ module SmallScalars =
 
         let inline decode (encoded: uint64) : int =
             int encoded
-
+    
+[<Extension>]
+type SmallScalarExtensions () =
+    [<Extension>]
+    static member inline WithValue (this: SmallScalarAttributeDefinition<bool>, value) =
+        this.WithValue(value, SmallScalars.Bool.encode)
+        
+    [<Extension>]
+    static member inline WithValue (this: SmallScalarAttributeDefinition<float>, value) =
+        this.WithValue(value, SmallScalars.Float.encode)
+        
+    [<Extension>]
+    static member inline WithValue (this: SmallScalarAttributeDefinition<int>, value) =
+        this.WithValue(value, SmallScalars.Int.encode)
+        
 module Attributes =
-
     /// Define a custom attribute storing any value
     let inline defineScalarWithConverter<'inputType, 'modelType, 'valueType>
         name


### PR DESCRIPTION
Converted small scalars to use 8 bytes encoding when possible

I'm not 100% sure what is the best API is but I think this is a reasonable place to merge.

specifically I'm skeptical of names like these

```fsharp
Attributes.defineBool name update
Attributes.defineBindableBool attribute
```

But I haven't found a better design yet.

Converted all XF attributes to work with small scalars. I'm super happy that I found out a way to generalize working with enums

```fsharp
Attributes.defineBindableEnum<MyEnum> bindableProp
```

We have a gazzilion of those ^_^

I couldn't run sample apps (yet) but I believe everything should just work (famous last words)