### PR TITLE
Fix "goals" link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Fabulous allows you to combine the power of functional programming and the simpl
 
 ## Documentation
 
-See also the [goals](docs/goals-of-v2.md) for the future of Fabulous v2.
+See also the [goals](https://fsprojects.github.io/Fabulous/docs/v2/architecture/goals-of-v2/) for the future of Fabulous v2.
 
 ## About Fabulous
 


### PR DESCRIPTION
I guess it is better to link to the docs page rather than to the .md file itself?
Either way the current link is a 404