### PR TITLE
Fix combined view map

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       run: dotnet test --no-build --configuration Release ${SLN_FILE}
     - name: Pack
       run: |
-        sed -i bak "s/FABULOUS_PKG_VERSION/2.0.1-nightly-${GITHUB_RUN_ID}/g" "templates/content/*/.template.config/template.json"
+        sed -i bak "s/FABULOUS_PKG_VERSION/2.0.1-nightly-${GITHUB_RUN_ID}/g" templates/content/**/.template.config/template.json
         dotnet pack --configuration Release --output nupkgs --version-suffix "nightly-${GITHUB_RUN_ID}" ${SLN_FILE}
         dotnet pack -p:IsNightlyBuild=true --configuration Release --output nupkgs --version-suffix "nightly-${GITHUB_RUN_ID}" templates/Fabulous.XamarinForms.Templates.proj
     - name: Push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       run: dotnet test --no-build --configuration Release ${SLN_FILE}
     - name: Pack
       run: |
-        sed -i bak "s/FABULOUS_PKG_VERSION/${MAJOR}.${MINOR}.${PATCH}/g" "templates/content/*/.template.config/template.json"
+        sed -i bak "s/FABULOUS_PKG_VERSION/${MAJOR}.${MINOR}.${PATCH}/g" templates/content/**/.template.config/template.json
         dotnet pack --configuration Release --output nupkgs ${SLN_FILE}
         dotnet pack --configuration Release --output nupkgs templates/Fabulous.XamarinForms.Templates.proj
     # - name: Push

--- a/Fabulous.sln
+++ b/Fabulous.sln
@@ -26,8 +26,9 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_Solution files", "_Solution files", "{FC0E5AD7-D8E8-4DC1-B80D-4E80CCBBBC26}"
 	ProjectSection(SolutionItems) = preProject
 		.gitignore = .gitignore
-		dotnet.yml = .github\workflows\dotnet.yml
-		dotnet.yml = .github\workflows\dotnet_pull_request.yml
+		pull_request.yml = .github\workflows\pull_request.yml
+		build.yml = .github\workflows\build.yml
+		release.yml = .github\workflows\release.yml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "FabulousContacts", "FabulousContacts", "{1F8DA9C3-3BFA-46AB-AE36-F0FFD6E480B0}"

--- a/src/Fabulous/Array.fs
+++ b/src/Fabulous/Array.fs
@@ -182,6 +182,7 @@ module StackAllocatedCollections =
                             ValueNone
                         else
                             let struct (v0, v1, v2) = items
+
                             match (size - 1us) % 3us with
                             | i when i >= 0us && predicate v0 -> ValueSome v0
                             | i when i >= 1us && predicate v1 -> ValueSome v1
@@ -193,6 +194,7 @@ module StackAllocatedCollections =
                         | Empty -> ValueNone
                         | Filled (items, before) ->
                             let struct (v0, v1, v2) = items
+
                             if predicate v0 then ValueSome v0
                             elif predicate v1 then ValueSome v1
                             elif predicate v2 then ValueSome v2
@@ -206,9 +208,10 @@ module StackAllocatedCollections =
                 static member replace(data: StackList<'v> inref, predicate: 'v -> bool, v: 'v) =
                     let tryReplaceInItems (items: Items<'v>) (size: uint16) predicate v : struct (bool * Items<'v>) =
                         if size = 0us then
-                            struct(false, items)
+                            struct (false, items)
                         else
                             let struct (v0, v1, v2) = items
+
                             match (size - 1us) % 3us with
                             | 0us when predicate v0 -> struct (true, Items.one v)
                             | 1us when predicate v0 -> struct (true, Items.two(v, v1))

--- a/src/Fabulous/Array.fs
+++ b/src/Fabulous/Array.fs
@@ -203,7 +203,6 @@ module StackAllocatedCollections =
                     | ValueNone -> tryFindInPart data.before predicate
 
                 /// Try replacing an existing value inside a StackList.
-                /// Returns true if the value was replaced, false if it was not found.
                 static member replace(data: StackList<'v> inref, predicate: 'v -> bool, v: 'v) =
                     let tryReplaceInItems (items: Items<'v>) (size: uint16) predicate v : struct (bool * Items<'v>) =
                         let struct (v0, v1, v2) = items

--- a/src/Fabulous/Array.fs
+++ b/src/Fabulous/Array.fs
@@ -179,7 +179,7 @@ module StackAllocatedCollections =
                 static member tryFind<'v>(data: StackList<'v> inref, predicate: 'v -> bool) : 'v voption =
                     let tryFindInItems (items: Items<'v>) (size: uint16) predicate : 'v voption =
                         let struct (v0, v1, v2) = items
-                        let constrainedSize = size % 3us
+                        let constrainedSize = size % 4us
 
                         match constrainedSize with
                         | i when i >= 1us && predicate v0 -> ValueSome v0
@@ -206,7 +206,7 @@ module StackAllocatedCollections =
                 static member replace(data: StackList<'v> inref, predicate: 'v -> bool, v: 'v) =
                     let tryReplaceInItems (items: Items<'v>) (size: uint16) predicate v : struct (bool * Items<'v>) =
                         let struct (v0, v1, v2) = items
-                        let constrainedSize = size % 3us
+                        let constrainedSize = size % 4us
 
                         match constrainedSize with
                         | 1us when predicate v0 -> struct (true, Items.one v)

--- a/src/Fabulous/Array.fs
+++ b/src/Fabulous/Array.fs
@@ -175,7 +175,74 @@ module StackAllocatedCollections =
 
                         // 2 items filled
                         | _ -> StackList(size + 1us, Items(v0, v1, v), data.before)
+
+                static member tryFind<'v>(data: StackList<'v> inref, predicate: 'v -> bool) : 'v voption =
+                    let tryFindInItems (items: Items<'v>) (size: uint16) predicate : 'v voption =
+                        let struct (v0, v1, v2) = items
+                        let constrainedSize = size % 3us
+
+                        match constrainedSize with
+                        | i when i >= 1us && predicate v0 -> ValueSome v0
+                        | i when i >= 2us && predicate v1 -> ValueSome v1
+                        | i when i >= 3us && predicate v2 -> ValueSome v2
+                        | _ -> ValueNone
+
+                    let rec tryFindInPart (part: Part<'v>) (predicate: 'v -> bool) : 'v voption =
+                        match part with
+                        | Empty -> ValueNone
+                        | Filled (items, before) ->
+                            let struct (v0, v1, v2) = items
+
+                            if predicate v0 then ValueSome v0
+                            elif predicate v1 then ValueSome v1
+                            elif predicate v2 then ValueSome v2
+                            else tryFindInPart before predicate
+
+                    match tryFindInItems data.items data.size predicate with
+                    | ValueSome v -> ValueSome v
+                    | ValueNone -> tryFindInPart data.before predicate
+
+                /// Try replacing an existing value inside a StackList.
+                /// Returns true if the value was replaced, false if it was not found.
+                static member replace(data: StackList<'v> inref, predicate: 'v -> bool, v: 'v) =
+                    let tryReplaceInItems (items: Items<'v>) (size: uint16) predicate v : struct (bool * Items<'v>) =
+                        let struct (v0, v1, v2) = items
+                        let constrainedSize = size % 3us
+
+                        match constrainedSize with
+                        | 1us when predicate v0 -> struct (true, Items.one v)
+                        | 2us when predicate v0 -> struct (true, Items.two(v, v1))
+                        | 2us when predicate v1 -> struct (true, Items.two(v0, v))
+                        | 3us when predicate v0 -> struct (true, Items(v, v1, v2))
+                        | 3us when predicate v1 -> struct (true, Items(v0, v, v2))
+                        | 3us when predicate v2 -> struct (true, Items(v0, v1, v))
+                        | _ -> struct (false, items)
+
+                    let rec tryReplaceInPart (part: Part<'v>) predicate v : struct (bool * Part<'v>) =
+                        match part with
+                        | Empty -> struct (false, Empty)
+                        | Filled (items, before) ->
+                            let struct (v0, v1, v2) = items
+
+                            if predicate v0 then
+                                struct (true, Filled(Items(v, v1, v2), before))
+                            elif predicate v1 then
+                                struct (true, Filled(Items(v0, v, v2), before))
+                            elif predicate v2 then
+                                struct (true, Filled(Items(v0, v1, v), before))
+                            else
+                                match tryReplaceInPart before predicate v with
+                                | struct (true, newBefore) -> struct (true, Filled(items, newBefore))
+                                | struct (false, _) -> struct (false, part)
+
+                    match tryReplaceInItems data.items data.size predicate v with
+                    | struct (true, newItems) -> StackList(data.size, newItems, data.before)
+                    | struct (false, _) ->
+                        match tryReplaceInPart data.before predicate v with
+                        | struct (true, newBefore) -> StackList(data.size, data.items, newBefore)
+                        | struct (false, _) -> data
             end
+
 
 
 

--- a/src/Fabulous/Builders.fs
+++ b/src/Fabulous/Builders.fs
@@ -59,7 +59,7 @@ type WidgetBuilder<'msg, 'marker> =
             )
 
         [<EditorBrowsable(EditorBrowsableState.Never)>]
-        member inline x.TryAddOrReplace
+        member inline x.TryAddOrReplaceScalar
             (
                 attrKey: ScalarAttributeKey,
                 [<InlineIfLambda>] replaceWith: ScalarAttribute -> ScalarAttribute,

--- a/src/Fabulous/Builders.fs
+++ b/src/Fabulous/Builders.fs
@@ -59,7 +59,7 @@ type WidgetBuilder<'msg, 'marker> =
             )
 
         [<EditorBrowsable(EditorBrowsableState.Never)>]
-        member inline x.TryAddOrReplaceScalar
+        member inline x.AddOrReplaceScalar
             (
                 attrKey: ScalarAttributeKey,
                 [<InlineIfLambda>] replaceWith: ScalarAttribute -> ScalarAttribute,

--- a/src/Fabulous/View.fs
+++ b/src/Fabulous/View.fs
@@ -42,7 +42,7 @@ module View =
             MapMsg.MapMsg.WithValue(unbox<'oldMsg> >> fn >> box)
 
         let builder =
-            x.TryAddOrReplaceScalar(MapMsg.MapMsg.Key, replaceWith, defaultWith)
+            x.AddOrReplaceScalar(MapMsg.MapMsg.Key, replaceWith, defaultWith)
 
         WidgetBuilder<'newMsg, 'marker>(builder.Key, builder.Attributes)
 

--- a/src/Fabulous/View.fs
+++ b/src/Fabulous/View.fs
@@ -42,7 +42,7 @@ module View =
             MapMsg.MapMsg.WithValue(unbox<'oldMsg> >> fn >> box)
 
         let builder =
-            x.TryAddOrReplace(MapMsg.MapMsg.Key, replaceWith, defaultWith)
+            x.TryAddOrReplaceScalar(MapMsg.MapMsg.Key, replaceWith, defaultWith)
 
         WidgetBuilder<'newMsg, 'marker>(builder.Key, builder.Attributes)
 


### PR DESCRIPTION
Fixes an invalid cast exception happening when chaining `View.map` / `View.lazyMap` on a same Widget.

```fs
type GrandChildMsg = Clicked
type ChildMsg = GrandChildMsg of GrandChildMsg
type ParentMsg = ChildMsg of ChildMsg

View.map ChildMsg (View.map GrandChildMsg (Button("Click me", Clicked)))
:> WidgetBuilder<ParentMsg, IButton)
```