### PR TITLE
Make sure navigation events are not triggered by Fabulous

### DIFF
--- a/src/Fabulous.XamarinForms/Views/Pages/NavigationPage.fs
+++ b/src/Fabulous.XamarinForms/Views/Pages/NavigationPage.fs
@@ -48,10 +48,17 @@ module NavigationPageUpdaters =
 
                 let page = page :?> Page
 
-                if index = pagesLength - 1 then
+                if index = 0 && pagesLength = 1 then
+                    // We are trying to replace the root page
+                    // First we push the new page, then we remove the old one
+                    navigationPage.Push(page, false)
+                    navigationPage.Navigation.RemovePage(pages.[index])
+
+                elif index = pagesLength - 1 then
                     // Last page, we pop it and push the new one
                     navigationPage.Pop()
                     navigationPage.Push(page)
+
                 else
                     // Page is not visible, we just replace it
                     let nextPage = pages.[index + 1]


### PR DESCRIPTION
Fixes #947 

This PR does a couple things:
- Mark NavigationPage's `onPopped`, `onPushed` and `onPoppedToRoot` as obsolete
- Introduce NavigationPage `onBackNavigated`
- Allow Fabulous to catch up with XF NavigationPage in case NavPage already popped a page Fabulous was not aware of

The main issue with #947 was all NavigationPage events were both triggered by user actions and programmatic changes made by Fabulous. There was no way to differentiate who was triggering the events to be able to react only to the user's actions.

To prevent this, I created `CustomNavigationPage` which has an internal counter for the number of times Fabulous pops pages. This counter is used to suppress the `Popped` events triggered programmatically by Fabulous.
If the pop has been done by the user, then `BackNavigated` is triggered instead.