### PR TITLE
Add Async.executeOnMainThread

### DIFF
--- a/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/AboutPage.fs
+++ b/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/AboutPage.fs
@@ -40,13 +40,14 @@ module AboutPage =
                 Browser.OpenAsync(Uri url, BrowserLaunchMode.SystemPreferred)
                 |> Async.AwaitTask
         }
-        |> Helpers.executeOnMainThread
+        |> Async.executeOnMainThread
+        |> Cmd.performAsync
 
     let init () = ()
 
     let update msg model =
         match msg with
-        | OpenBrowser url -> model, Cmd.performAsync(openBrowserCmd url)
+        | OpenBrowser url -> model, openBrowserCmd url
 
     let aboutFabulousContacts (openBrowser: string -> Msg) =
         VStack() {

--- a/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/DetailPage.fs
+++ b/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/DetailPage.fs
@@ -45,7 +45,8 @@ module DetailPage =
                     )
             | _ -> do! displayAlert(Strings.DetailPage_DialNumberFailed, Strings.Common_Error, Strings.Common_OK)
         }
-        |> executeOnMainThread
+        |> Async.executeOnMainThread
+        |> Cmd.performAsync
 
     let tryComposeSmsAsync (phoneNumber: string) =
         async {
@@ -62,7 +63,8 @@ module DetailPage =
                     )
             | _ -> do! displayAlert(Strings.DetailPage_ComposeSmsFailed, Strings.Common_Error, Strings.Common_OK)
         }
-        |> executeOnMainThread
+        |> Async.executeOnMainThread
+        |> Cmd.performAsync
 
     let tryComposeEmailAsync emailAddress =
         async {
@@ -79,7 +81,8 @@ module DetailPage =
                     )
             | _ -> do! displayAlert(Strings.DetailPage_ComposeEmailFailed, Strings.Common_Error, Strings.Common_OK)
         }
-        |> executeOnMainThread
+        |> Async.executeOnMainThread
+        |> Cmd.performAsync
 
     // Lifecycle
     let init (contact: Contact) = { Contact = contact }, Cmd.none
@@ -88,19 +91,13 @@ module DetailPage =
         match msg with
         | EditTapped -> model, Cmd.none, ExternalMsg.EditContact model.Contact
         | CallTapped ->
-            let dialCmd =
-                Cmd.performAsync(tryDialNumberAsync model.Contact.Phone)
-
+            let dialCmd = tryDialNumberAsync model.Contact.Phone
             model, dialCmd, ExternalMsg.NoOp
         | SmsTapped ->
-            let smsCmd =
-                Cmd.performAsync(tryComposeSmsAsync model.Contact.Phone)
-
+            let smsCmd = tryComposeSmsAsync model.Contact.Phone
             model, smsCmd, ExternalMsg.NoOp
         | EmailTapped ->
-            let emailCmd =
-                Cmd.performAsync(tryComposeEmailAsync model.Contact.Email)
-
+            let emailCmd = tryComposeEmailAsync model.Contact.Email
             model, emailCmd, ExternalMsg.NoOp
         | ContactUpdated contact -> { model with Contact = contact }, Cmd.none, ExternalMsg.NoOp
 

--- a/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/EditPage.fs
+++ b/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/EditPage.fs
@@ -73,6 +73,8 @@ module EditPage =
             else
                 return None
         }
+        |> Async.executeOnMainThread
+        |> Cmd.ofAsyncMsgOption
 
     let doAsync<'a when 'a: (new: unit -> 'a) and 'a :> BasePermission> action =
         async {
@@ -126,6 +128,8 @@ module EditPage =
                 return setPicture bytes
             | _ -> return None
         }
+        |> Async.executeOnMainThread
+        |> Cmd.ofAsyncMsgOption
 
     let sayContactNotValidAsync () =
         async {
@@ -173,6 +177,8 @@ module EditPage =
                 let! msg = createOrUpdateAsync dbPath newContact
                 return Some msg
         }
+        |> Async.executeOnMainThread
+        |> Cmd.ofAsyncMsgOption
 
     // Validations
     let validateFirstName = not << String.IsNullOrWhiteSpace
@@ -234,23 +240,17 @@ module EditPage =
         | UpdateIsFavorite isFavorite -> { model with IsFavorite = isFavorite }, Cmd.none, ExternalMsg.NoOp
 
         | UpdatePicture ->
-            let cmd =
-                Cmd.ofAsyncMsgOption(tryUpdatePictureAsync model.Picture)
-
+            let cmd = tryUpdatePictureAsync model.Picture
             model, cmd, ExternalMsg.NoOp
 
         | SetPicture picture -> { model with Picture = picture }, Cmd.none, ExternalMsg.NoOp
 
         | SaveContact ->
-            let cmd =
-                Cmd.ofAsyncMsgOption(trySaveAsync model dbPath)
-
+            let cmd = trySaveAsync model dbPath
             model, cmd, ExternalMsg.NoOp
 
         | DeleteContact contact ->
-            let cmd =
-                Cmd.ofAsyncMsgOption(tryDeleteAsync dbPath contact)
-
+            let cmd = tryDeleteAsync dbPath contact
             model, cmd, ExternalMsg.NoOp
 
         | ContactAdded contact -> model, Cmd.none, ExternalMsg.GoBackAfterContactAdded contact

--- a/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/Helpers.fs
+++ b/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/Helpers.fs
@@ -12,19 +12,13 @@ open Fabulous.XamarinForms
 open type Fabulous.XamarinForms.View
 
 module Helpers =
-    let executeOnMainThread (action: Async<'T>) : Async<'T> =
-        Device.InvokeOnMainThreadAsync(funcTask = fun () -> task { return! action })
-        |> Async.AwaitTask
-
     let displayAlert (title, message, cancel) =
         Application.Current.MainPage.DisplayAlert(title, message, cancel)
         |> Async.AwaitTask
-        |> executeOnMainThread
 
     let displayAlertWithConfirm (title, message, accept, cancel) =
         Application.Current.MainPage.DisplayAlert(title = title, message = message, accept = accept, cancel = cancel)
         |> Async.AwaitTask
-        |> executeOnMainThread
 
     let displayActionSheet (title, cancel, destruction, buttons) =
         let title = Option.toObj title
@@ -34,7 +28,6 @@ module Helpers =
 
         Application.Current.MainPage.DisplayActionSheet(title, cancel, destruction, buttons)
         |> Async.AwaitTask
-        |> executeOnMainThread
 
     let requestPermissionAsync<'a when 'a: (new: unit -> 'a) and 'a :> BasePermission> () =
         async {
@@ -49,7 +42,6 @@ module Helpers =
             with
             | _ -> return false
         }
-        |> executeOnMainThread
 
     let askPermissionAsync<'a when 'a: (new: unit -> 'a) and 'a :> BasePermission> () =
         async {
@@ -77,7 +69,6 @@ module Helpers =
 
             return picture |> Option.ofObj
         }
-        |> executeOnMainThread
 
     let pickPictureAsync () =
         async {
@@ -90,7 +81,6 @@ module Helpers =
 
             return picture |> Option.ofObj
         }
-        |> executeOnMainThread
 
     let readBytesAsync (file: MediaFile) =
         async {
@@ -111,9 +101,7 @@ module Helpers =
 
 module Cmd =
     let performAsync asyncUnit =
-        Cmd.ofAsyncMsgOption(
-            async {
-                do! asyncUnit
-                return None
-            }
+        Cmd.ofMsgOption(
+            Async.Start asyncUnit
+            None
         )

--- a/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/MapPage.fs
+++ b/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/MapPage.fs
@@ -46,6 +46,7 @@ module MapPage =
             with
             | _ -> return None
         }
+        |> Cmd.ofAsyncMsgOption
 
     let loadPinsAsync (contacts: Contact list) =
         async {
@@ -91,6 +92,8 @@ module MapPage =
                 do! displayAlert(Strings.MapPage_MapLoadFailed, exn.Message, Strings.Common_OK)
                 return None
         }
+        |> Async.executeOnMainThread
+        |> Cmd.ofAsyncMsgOption
 
     let paris = Position(48.8566, 2.3522)
 
@@ -106,13 +109,9 @@ module MapPage =
 
     let update msg model =
         match msg with
-        | LoadPins contacts ->
-            let msg = loadPinsAsync contacts
-            model, Cmd.ofAsyncMsgOption msg
+        | LoadPins contacts -> model, loadPinsAsync contacts
 
-        | RetrieveUserPosition ->
-            let msg = tryGetUserPositionAsync()
-            model, Cmd.ofAsyncMsgOption msg
+        | RetrieveUserPosition -> model, tryGetUserPositionAsync()
 
         | PinsLoaded pins -> { model with Pins = Some pins }, Cmd.none
 

--- a/src/Fabulous.XamarinForms/Async.fs
+++ b/src/Fabulous.XamarinForms/Async.fs
@@ -1,0 +1,12 @@
+namespace Fabulous.XamarinForms
+
+open Xamarin.Forms
+
+module Async =
+    /// Execute the async computation on the device main thread
+    let executeOnMainThread (action: Async<'T>) : Async<'T> =
+        async {
+            return!
+                Device.InvokeOnMainThreadAsync(funcTask = fun () -> Async.StartImmediateAsTask action)
+                |> Async.AwaitTask
+        }

--- a/src/Fabulous.XamarinForms/Fabulous.XamarinForms.fsproj
+++ b/src/Fabulous.XamarinForms/Fabulous.XamarinForms.fsproj
@@ -121,6 +121,7 @@
     <Compile Include="Views\Any.fs" />
     <Compile Include="CollectionBuilderExtensions.fs" />
     <Compile Include="Program.fs" />
+    <Compile Include="Async.fs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="6.0.0" />


### PR DESCRIPTION
Fixes #946 

By default, Cmds in Fabulous 2.0 are not executed on the main UI thread for performance reasons.
If you need to execute some logic on the UI thread, you can use the new `Async.executeOnMainThread`.

```fs
let showAlertCmd =
    async {
        do! Application.Current.MainPage.DisplayAlert("An alert!", "OK")
        return AlertShown
    }
    |> Async.executeOnMainThread
    |> Cmd.ofAsyncMsg
```