### PR TITLE
Fix NullReferenceException when dispatching Mounted event

### DIFF
--- a/src/Fabulous/Dispatch.fs
+++ b/src/Fabulous/Dispatch.fs
@@ -59,9 +59,7 @@ module Dispatcher =
             | ValueNone -> ()
             | ValueSome widgetCollAttrs ->
                 for widgetCollAttr in widgetCollAttrs do
-                    let struct (_, widgets) = widgetCollAttr.Value
-
-                    for childWidget in widgets do
+                    for childWidget in ArraySlice.toSpan widgetCollAttr.Value do
                         dispatchAndVisitChildren false dispatch childWidget
 
         let struct (canDispatch, mapMsg) = getCanDispatchAndMapMsg node


### PR DESCRIPTION
When dispatching a message to the children of a node (e.g. Mounted event), we were incorrectly enumerating the WidgetCollection ArraySlice.

The ArraySlice allocates 4 uninitialized items and has a size property to let us know how many items are actually initialized.

Except here we were enumerating all items including those uninitialized leading to a Null Reference Exception