### PR TITLE
Don't eat exceptions thrown in MVU functions

### DIFF
--- a/src/Fabulous.XamarinForms/Program.fs
+++ b/src/Fabulous.XamarinForms/Program.fs
@@ -89,11 +89,10 @@ module ViewHelpers =
 
             Trace.WriteLine(message, traceLevel)
 
-        let logException (ex: exn) = Trace.WriteLine(ex.ToString(), "Error")
-
         { Log = log
-          LogException = logException
           MinLogLevel = LogLevel.Error }
+
+    let defaultOnException _exn = false
 
 module Program =
     let inline private define
@@ -107,7 +106,8 @@ module Program =
           View = view
           CanReuseView = ViewHelpers.canReuseView
           SyncAction = Device.BeginInvokeOnMainThread
-          Logger = ViewHelpers.defaultLogger() }
+          Logger = ViewHelpers.defaultLogger()
+          OnException = ViewHelpers.defaultOnException }
 
     /// Create a program for a static view
     let stateless (view: unit -> WidgetBuilder<unit, 'marker>) =

--- a/src/Fabulous.XamarinForms/Program.fs
+++ b/src/Fabulous.XamarinForms/Program.fs
@@ -89,7 +89,10 @@ module ViewHelpers =
 
             Trace.WriteLine(message, traceLevel)
 
+        let logException (ex: exn) = Trace.WriteLine(ex.ToString(), "Error")
+
         { Log = log
+          LogException = logException
           MinLogLevel = LogLevel.Error }
 
 module Program =

--- a/src/Fabulous/Logger.fs
+++ b/src/Fabulous/Logger.fs
@@ -14,7 +14,6 @@ type LogLevel =
 [<Struct>]
 type Logger =
     { Log: LogLevel * string -> unit
-      LogException: Exception -> unit
       MinLogLevel: LogLevel }
 
 [<Extension>]
@@ -39,6 +38,6 @@ type LoggerExtensions =
     static member inline Error(this: Logger, format: string, [<ParamArray>] args: obj []) =
         LoggerExtensions.Log(this, LogLevel.Error, format, args)
 
-    [<Extension; Obsolete("Use Logger.LogException(exn) instead")>]
+    [<Extension>]
     static member inline Fatal(this: Logger, ex: exn) =
         LoggerExtensions.Log(this, LogLevel.Fatal, "{0}", ex.ToString())

--- a/src/Fabulous/Logger.fs
+++ b/src/Fabulous/Logger.fs
@@ -14,6 +14,7 @@ type LogLevel =
 [<Struct>]
 type Logger =
     { Log: LogLevel * string -> unit
+      LogException: Exception -> unit
       MinLogLevel: LogLevel }
 
 [<Extension>]
@@ -38,6 +39,6 @@ type LoggerExtensions =
     static member inline Error(this: Logger, format: string, [<ParamArray>] args: obj []) =
         LoggerExtensions.Log(this, LogLevel.Error, format, args)
 
-    [<Extension>]
+    [<Extension; Obsolete("Use Logger.LogException(exn) instead")>]
     static member inline Fatal(this: Logger, ex: exn) =
         LoggerExtensions.Log(this, LogLevel.Fatal, "{0}", ex.ToString())


### PR DESCRIPTION
This PR introduces a `LogException` function in the Logger available inside the Program.
It also rethrows exceptions after calling LogException.

We use a Mailbox to process new messages and it makes it hard to rethrow an exception with the proper stacktrace.
I noticed Elmish moved away from MailboxProcessor, maybe we need something similar.