### PR TITLE
Fix GetViewNode call to use passed parameter

### DIFF
--- a/src/Fabulous/Attributes.fs
+++ b/src/Fabulous/Attributes.fs
@@ -234,8 +234,8 @@ module Attributes =
                     Dispatcher.dispatchEventForAllChildren itemNode widget Lifecycle.Mounted
 
                 | WidgetCollectionItemChange.Update (index, widgetDiff) ->
-                    let childNode =
-                        node.TreeContext.GetViewNode(box targetColl.[index])
+                    let childNode = getViewNode (box targetColl.[index])
+//                        node.TreeContext.GetViewNode(box targetColl.[index])
 
                     childNode.ApplyDiff(&widgetDiff)
 


### PR DESCRIPTION
I encountered a bug while attempting to create a view node tree using another kind of object in the tree (other than the BindableObject base).

The bug is that this method forces view node collections to use the root tree's GetViewNode. Instead it should use the passed parameter as the other branches of the function do.

I tried to create a unit test to show the bug, however I could not get the view collection to trigger the condition. If this is still wanted I can commit those files and would gladly accept guidance on triggering the affected code from the Sketch tests. 