### PR TITLE
Use fully qualify namespace to prevent from using XF one

### DIFF
--- a/src/Fabulous.XamarinForms/Views/Layouts/SwipeItems.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/SwipeItems.fs
@@ -29,7 +29,7 @@ module SwipeItemsBuilders =
 
     type Fabulous.XamarinForms.View with
         static member inline SwipeItems<'msg>() =
-            CollectionBuilder<'msg, ISwipeItems, ISwipeItem>(SwipeItems.WidgetKey, SwipeItems.SwipeItems)
+            CollectionBuilder<'msg, ISwipeItems, Fabulous.XamarinForms.ISwipeItem>(SwipeItems.WidgetKey, SwipeItems.SwipeItems)
 
 [<Extension>]
 type SwipeItemsModifiers() =

--- a/src/Fabulous.XamarinForms/Views/Layouts/SwipeItems.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/SwipeItems.fs
@@ -29,7 +29,10 @@ module SwipeItemsBuilders =
 
     type Fabulous.XamarinForms.View with
         static member inline SwipeItems<'msg>() =
-            CollectionBuilder<'msg, ISwipeItems, Fabulous.XamarinForms.ISwipeItem>(SwipeItems.WidgetKey, SwipeItems.SwipeItems)
+            CollectionBuilder<'msg, ISwipeItems, Fabulous.XamarinForms.ISwipeItem>(
+                SwipeItems.WidgetKey,
+                SwipeItems.SwipeItems
+            )
 
 [<Extension>]
 type SwipeItemsModifiers() =


### PR DESCRIPTION
We need to use the fully qualified namespace Fabulous.XamarinForms.ISwipeItem to prevent from using the XF one

**BEFORE**

<img width="461" alt="Screenshot 2022-06-23 at 18 50 36" src="https://user-images.githubusercontent.com/31915729/175352882-0303705e-0e5e-4892-b397-e7fc6dc90732.png">

**AFTER**

<img width="584" alt="Screenshot 2022-06-23 at 18 50 49" src="https://user-images.githubusercontent.com/31915729/175352916-cdb19579-7aa9-4dfc-b7b9-af8bf749dd10.png">

