### PR TITLE
AppLinkEntry  Support

### DIFF
--- a/samples/Xamarin.Forms/CounterApp/CounterApp/App.fs
+++ b/samples/Xamarin.Forms/CounterApp/CounterApp/App.fs
@@ -30,32 +30,12 @@ module App =
         }
         |> Cmd.ofAsyncMsg
 
-    let init () = initModel, Cmd.none
-    
-    let applicationRef = ViewRef<CustomApplication>()
-    
-    let createLink =
-        let pageLink = new Xamarin.Forms.AppLinkEntry()
-        pageLink.Title <- "Im a deep link"
-        pageLink.Description <- "Counter App"
-        pageLink.AppLinkUri <- Uri("https://www.xamarin.com/platform")
-        pageLink.IsLinkActive <- true
-
-        pageLink.KeyValues.Add("contentType", "TodoItemPage");
-        pageLink.KeyValues.Add("appName", "");
-        pageLink.KeyValues.Add("companyName", "Xamarin");
-
-        pageLink
+    let init () = initModel, Cmd.none   
         
     let update msg model =
         match msg with
         | Increment ->
             let model = { model with Count = model.Count + model.Step }
-            Xamarin.Forms.Device.BeginInvokeOnMainThread(
-                fun _ ->
-                    match applicationRef.TryValue with
-                    | Some target -> target.AppLinks.RegisterLink(createLink)
-                    | None -> failwith "No application ref")
             model, Cmd.none
         | Decrement ->
             { model with
@@ -104,6 +84,10 @@ module App =
                     .centerVertical()
             )
         ).onLinkReceived(fun args -> LinkReceived args.Uri)
-         .reference(applicationRef)
+         .appLinks(){
+             AppLinkEntry("Im a deep link", "https://www.xamarin.com/platform")
+                .description("Im a deep link")
+                .thumbnail("https://www.xamarin.com/images/xamarin-logo.png")
+         }
 
     let program = Program.statefulWithCmd init update view

--- a/samples/Xamarin.Forms/CounterApp/CounterApp/App.fs
+++ b/samples/Xamarin.Forms/CounterApp/CounterApp/App.fs
@@ -1,6 +1,7 @@
 namespace CounterApp
 
 open System
+open System.Collections.Generic
 open Fabulous
 open Fabulous.XamarinForms
 
@@ -92,6 +93,10 @@ module App =
             AppLinkEntry("Im a deep link", "https://www.xamarin.com/platform")
                 .description("Im a deep link")
                 .thumbnail("https://www.xamarin.com/images/xamarin-logo.png")
+                .keyValues(
+                    [ KeyValuePair("key1", "value1")
+                      KeyValuePair("key2", "value2") ]
+                )
         }
 
     let program = Program.statefulWithCmd init update view

--- a/samples/Xamarin.Forms/CounterApp/CounterApp/App.fs
+++ b/samples/Xamarin.Forms/CounterApp/CounterApp/App.fs
@@ -30,12 +30,15 @@ module App =
         }
         |> Cmd.ofAsyncMsg
 
-    let init () = initModel, Cmd.none   
-        
+    let init () = initModel, Cmd.none
+
     let update msg model =
         match msg with
         | Increment ->
-            let model = { model with Count = model.Count + model.Step }
+            let model =
+                { model with
+                      Count = model.Count + model.Step }
+
             model, Cmd.none
         | Decrement ->
             { model with
@@ -78,16 +81,17 @@ module App =
                         .centerTextHorizontal()
 
                     Button("Reset", Reset)
-                        
+
                  })
                     .padding(30.)
                     .centerVertical()
             )
-        ).onLinkReceived(fun args -> LinkReceived args.Uri)
-         .appLinks(){
-             AppLinkEntry("Im a deep link", "https://www.xamarin.com/platform")
+        )
+            .onLinkReceived(fun args -> LinkReceived args.Uri)
+            .appLinks() {
+            AppLinkEntry("Im a deep link", "https://www.xamarin.com/platform")
                 .description("Im a deep link")
                 .thumbnail("https://www.xamarin.com/images/xamarin-logo.png")
-         }
+        }
 
     let program = Program.statefulWithCmd init update view

--- a/src/Fabulous.XamarinForms/CollectionBuilderExtensions.fs
+++ b/src/Fabulous.XamarinForms/CollectionBuilderExtensions.fs
@@ -79,6 +79,14 @@ type CollectionBuilderExtensions =
         { Widgets = MutStackArray1.One(x.Compile()) }
 
     [<Extension>]
+    static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IAppLinkEntry>
+        (
+            _: AttributeCollectionBuilder<'msg, 'marker, IAppLinkEntry>,
+            x: WidgetBuilder<'msg, 'itemType>
+        ) : Content<'msg> =
+        { Widgets = MutStackArray1.One(x.Compile()) }
+
+    [<Extension>]
     static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IToolbarItem>
         (
             _: AttributeCollectionBuilder<'msg, 'marker, IToolbarItem>,
@@ -155,6 +163,14 @@ type CollectionBuilderExtensions =
     static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IGestureRecognizer>
         (
             _: AttributeCollectionBuilder<'msg, 'marker, IGestureRecognizer>,
+            x: WidgetBuilder<'msg, Memo.Memoized<'itemType>>
+        ) : Content<'msg> =
+        { Widgets = MutStackArray1.One(x.Compile()) }
+
+    [<Extension>]
+    static member inline Yield<'msg, 'marker, 'itemType when 'itemType :> IAppLinkEntry>
+        (
+            _: AttributeCollectionBuilder<'msg, 'marker, IAppLinkEntry>,
             x: WidgetBuilder<'msg, Memo.Memoized<'itemType>>
         ) : Content<'msg> =
         { Widgets = MutStackArray1.One(x.Compile()) }

--- a/src/Fabulous.XamarinForms/Controls.fs
+++ b/src/Fabulous.XamarinForms/Controls.fs
@@ -162,8 +162,8 @@ type CustomApplication() =
     
     let linkRequestReceived =
         Event<EventHandler<LinkRequestReceivedEventArgs>, _>()
-        
-    member val AppLinks: IAppLinks =
+
+    member val AppLinks =
         DependencyService.Get<IAppLinks>() with get
         
     interface IAppIndexingProvider with

--- a/src/Fabulous.XamarinForms/Controls.fs
+++ b/src/Fabulous.XamarinForms/Controls.fs
@@ -147,3 +147,19 @@ type CustomFlyoutPage() as this =
 
     member _.OnIsPresentedChanged(_) =
         isPresentedChanged.Trigger(this, this.IsPresented)
+            
+type LinkRequestReceivedEventArgs(uri: Uri) =
+    inherit EventArgs()
+    member _.Uri = uri
+            
+type CustomApplication() =
+    inherit Application()
+    
+    let linkRequestReceived = Event<EventHandler<LinkRequestReceivedEventArgs>, _>()
+    
+    [<CLIEvent>]
+    member _.LinkRequestReceived = linkRequestReceived.Publish
+    
+    override this.OnAppLinkRequestReceived(uri : Uri)=
+        linkRequestReceived.Trigger(this, LinkRequestReceivedEventArgs(uri))
+        base.OnAppLinkRequestReceived(uri)

--- a/src/Fabulous.XamarinForms/Controls.fs
+++ b/src/Fabulous.XamarinForms/Controls.fs
@@ -159,9 +159,15 @@ type LinkRequestReceivedEventArgs(uri: Uri) =
 
 type CustomApplication() =
     inherit Application()
-
+    
     let linkRequestReceived =
         Event<EventHandler<LinkRequestReceivedEventArgs>, _>()
+        
+    member val AppLinks: IAppLinks =
+        DependencyService.Get<IAppLinks>() with get
+        
+    interface IAppIndexingProvider with
+        member this.AppLinks = this.AppLinks
 
     [<CLIEvent>]
     member _.LinkRequestReceived = linkRequestReceived.Publish

--- a/src/Fabulous.XamarinForms/Controls.fs
+++ b/src/Fabulous.XamarinForms/Controls.fs
@@ -52,6 +52,7 @@ type FabulousTimePicker() =
 
     override this.OnPropertyChanged(propertyName) =
         base.OnPropertyChanged(propertyName)
+
         if propertyName = TimePicker.TimeProperty.PropertyName then
             timeSelected.Trigger(this, TimeSelectedEventArgs(this.Time))
 
@@ -73,11 +74,13 @@ type CustomEntryCell() =
 
     override this.OnPropertyChanged(propertyName) =
         base.OnPropertyChanged(propertyName)
+
         if propertyName = EntryCell.TextProperty.PropertyName then
             textChanged.Trigger(this, TextChangedEventArgs(oldText, this.Text))
 
     override this.OnPropertyChanging(propertyName) =
         base.OnPropertyChanging(propertyName)
+
         if propertyName = EntryCell.TextProperty.PropertyName then
             oldText <- this.Text
 
@@ -95,11 +98,13 @@ type CustomPicker() =
 
     override this.OnPropertyChanged(propertyName) =
         base.OnPropertyChanged(propertyName)
+
         if propertyName = Picker.SelectedIndexProperty.PropertyName then
             selectedIndexChanged.Trigger(this, PositionChangedEventArgs(oldSelectedIndex, this.SelectedIndex))
 
     override this.OnPropertyChanging(propertyName) =
         base.OnPropertyChanging(propertyName)
+
         if propertyName = Picker.SelectedIndexProperty.PropertyName then
             oldSelectedIndex <- this.SelectedIndex
 
@@ -147,19 +152,20 @@ type CustomFlyoutPage() as this =
 
     member _.OnIsPresentedChanged(_) =
         isPresentedChanged.Trigger(this, this.IsPresented)
-            
+
 type LinkRequestReceivedEventArgs(uri: Uri) =
     inherit EventArgs()
     member _.Uri = uri
-            
+
 type CustomApplication() =
     inherit Application()
-    
-    let linkRequestReceived = Event<EventHandler<LinkRequestReceivedEventArgs>, _>()
-    
+
+    let linkRequestReceived =
+        Event<EventHandler<LinkRequestReceivedEventArgs>, _>()
+
     [<CLIEvent>]
     member _.LinkRequestReceived = linkRequestReceived.Publish
-    
-    override this.OnAppLinkRequestReceived(uri : Uri)=
+
+    override this.OnAppLinkRequestReceived(uri: Uri) =
         linkRequestReceived.Trigger(this, LinkRequestReceivedEventArgs(uri))
         base.OnAppLinkRequestReceived(uri)

--- a/src/Fabulous.XamarinForms/Fabulous.XamarinForms.fsproj
+++ b/src/Fabulous.XamarinForms/Fabulous.XamarinForms.fsproj
@@ -117,6 +117,7 @@
     <Compile Include="Views\Shapes\Line.fs" />
     <Compile Include="Views\Shapes\Polygon.fs" />
     <Compile Include="Views\Shapes\Polyline.fs" />
+    <Compile Include="Views\AppLinkEntry.fs" />
     <Compile Include="Views\Application.fs" />
     <Compile Include="Views\Any.fs" />
     <Compile Include="CollectionBuilderExtensions.fs" />

--- a/src/Fabulous.XamarinForms/Views/AppLinkEntry.fs
+++ b/src/Fabulous.XamarinForms/Views/AppLinkEntry.fs
@@ -9,51 +9,54 @@ open Xamarin.Forms
 type IAppLinkEntry =
     inherit IElement
 
-// TODO No used for now as it can not be with Application.Current.AppLinks.RegisterLink (appLink).
 module AppLinkEntry =
     let WidgetKey = Widgets.register<AppLinkEntry>()
 
     let AppLinkUri =
         Attributes.defineSimpleScalarWithEquality<Uri>
             "AppLinkEntry_AppLinkUri"
-                (fun _ newValueOpt node ->
-                    let appLinkEntry = node.Target :?> AppLinkEntry
-                    match newValueOpt with
-                    | ValueNone -> appLinkEntry.AppLinkUri <- null
-                    | ValueSome data ->
-                        appLinkEntry.AppLinkUri <- data)
+            (fun _ newValueOpt node ->
+                let appLinkEntry = node.Target :?> AppLinkEntry
+
+                match newValueOpt with
+                | ValueNone -> appLinkEntry.AppLinkUri <- null
+                | ValueSome data -> appLinkEntry.AppLinkUri <- data)
 
     let Description =
         Attributes.defineBindableWithEquality<string> AppLinkEntry.DescriptionProperty
 
-    let IsLinkActive = 
+    let IsLinkActive =
         Attributes.defineBindableWithEquality AppLinkEntry.IsLinkActiveProperty
 
-    let Thumbnail = Attributes.defineBindableWithEquality<ImageSource> AppLinkEntry.ThumbnailProperty
-        
-    let Title = Attributes.defineBindableWithEquality<string> AppLinkEntry.TitleProperty
-                
+    let Thumbnail =
+        Attributes.defineBindableWithEquality<ImageSource> AppLinkEntry.ThumbnailProperty
+
+    let Title =
+        Attributes.defineBindableWithEquality<string> AppLinkEntry.TitleProperty
+
 [<AutoOpen>]
 module AppLinkEntryBuilders =
     type Fabulous.XamarinForms.View with
         static member inline AppLinkEntry<'msg>(title: string, uri: Uri) =
             WidgetBuilder<'msg, IAppLinkEntry>(
-                AppLinkEntry.WidgetKey, AppLinkEntry.Title.WithValue(title),
-                AppLinkEntry.AppLinkUri.WithValue(uri))
+                AppLinkEntry.WidgetKey,
+                AppLinkEntry.Title.WithValue(title),
+                AppLinkEntry.AppLinkUri.WithValue(uri)
+            )
 
         static member inline AppLinkEntry<'msg>(title: string, url: string) =
             View.AppLinkEntry<'msg>(title, Uri(url))
 
 [<Extension>]
-type AppLinkEntryModifiers =      
+type AppLinkEntryModifiers =
     [<Extension>]
     static member inline description(this: WidgetBuilder<'msg, #IAppLinkEntry>, value: string) =
         this.AddScalar(AppLinkEntry.Description.WithValue(value))
-        
+
     [<Extension>]
     static member inline isLinkActive(this: WidgetBuilder<'msg, #IAppLinkEntry>, value: bool) =
         this.AddScalar(AppLinkEntry.IsLinkActive.WithValue(value))
-        
+
     [<Extension>]
     static member inline thumbnail(this: WidgetBuilder<'msg, #IAppLinkEntry>, source: ImageSource) =
         this.AddScalar(AppLinkEntry.Thumbnail.WithValue(source))

--- a/src/Fabulous.XamarinForms/Views/AppLinkEntry.fs
+++ b/src/Fabulous.XamarinForms/Views/AppLinkEntry.fs
@@ -1,0 +1,74 @@
+namespace Fabulous.XamarinForms
+
+open System
+open System.IO
+open System.Runtime.CompilerServices
+open Fabulous
+open Xamarin.Forms
+
+type IAppLinkEntry =
+    inherit IElement
+
+// TODO No used for now as it can not be with Application.Current.AppLinks.RegisterLink (appLink).
+module AppLinkEntry =
+    let WidgetKey = Widgets.register<AppLinkEntry>()
+
+    let AppLinkUri =
+        Attributes.defineSimpleScalarWithEquality<Uri>
+            "AppLinkEntry_AppLinkUri"
+                (fun _ newValueOpt node ->
+                    let appLinkEntry = node.Target :?> AppLinkEntry
+                    match newValueOpt with
+                    | ValueNone -> appLinkEntry.AppLinkUri <- null
+                    | ValueSome data ->
+                        appLinkEntry.AppLinkUri <- data)
+
+    let Description =
+        Attributes.defineBindableWithEquality<string> AppLinkEntry.DescriptionProperty
+
+    let IsLinkActive = 
+        Attributes.defineBindableWithEquality AppLinkEntry.IsLinkActiveProperty
+
+    let Thumbnail = Attributes.defineBindableWithEquality<ImageSource> AppLinkEntry.ThumbnailProperty
+        
+    let Title = Attributes.defineBindableWithEquality<string> AppLinkEntry.TitleProperty
+                
+[<AutoOpen>]
+module AppLinkEntryBuilders =
+    type Fabulous.XamarinForms.View with
+        static member inline AppLinkEntry<'msg>(title: string, uri: Uri) =
+            WidgetBuilder<'msg, IAppLinkEntry>(
+                AppLinkEntry.WidgetKey, AppLinkEntry.Title.WithValue(title),
+                AppLinkEntry.AppLinkUri.WithValue(uri))
+
+        static member inline AppLinkEntry<'msg>(title: string, url: string) =
+            View.AppLinkEntry<'msg>(title, Uri(url))
+
+[<Extension>]
+type AppLinkEntryModifiers =      
+    [<Extension>]
+    static member inline description(this: WidgetBuilder<'msg, #IAppLinkEntry>, value: string) =
+        this.AddScalar(AppLinkEntry.Description.WithValue(value))
+        
+    [<Extension>]
+    static member inline isLinkActive(this: WidgetBuilder<'msg, #IAppLinkEntry>, value: bool) =
+        this.AddScalar(AppLinkEntry.IsLinkActive.WithValue(value))
+        
+    [<Extension>]
+    static member inline thumbnail(this: WidgetBuilder<'msg, #IAppLinkEntry>, source: ImageSource) =
+        this.AddScalar(AppLinkEntry.Thumbnail.WithValue(source))
+
+    [<Extension>]
+    static member inline thumbnail(this: WidgetBuilder<'msg, #IAppLinkEntry>, source: string) =
+        let source = ImageSource.FromFile(source)
+        AppLinkEntryModifiers.thumbnail(this, source)
+
+    [<Extension>]
+    static member inline thumbnail(this: WidgetBuilder<'msg, #IAppLinkEntry>, uri: Uri) =
+        let source = ImageSource.FromUri(uri)
+        AppLinkEntryModifiers.thumbnail(this, source)
+
+    [<Extension>]
+    static member inline thumbnail(this: WidgetBuilder<'msg, #IAppLinkEntry>, stream: Stream) =
+        let source = ImageSource.FromStream(fun () -> stream)
+        AppLinkEntryModifiers.thumbnail(this, source)

--- a/src/Fabulous.XamarinForms/Views/AppLinkEntry.fs
+++ b/src/Fabulous.XamarinForms/Views/AppLinkEntry.fs
@@ -1,6 +1,7 @@
 namespace Fabulous.XamarinForms
 
 open System
+open System.Collections.Generic
 open System.IO
 open System.Runtime.CompilerServices
 open Fabulous
@@ -21,6 +22,20 @@ module AppLinkEntry =
                 match newValueOpt with
                 | ValueNone -> appLinkEntry.AppLinkUri <- null
                 | ValueSome data -> appLinkEntry.AppLinkUri <- data)
+
+    let KeyValues =
+        Attributes.defineSimpleScalarWithEquality<KeyValuePair<string, string> list>
+            "AppLinkEntry_KeyValues"
+            (fun _ newValueOpt node ->
+                let appLinkEntry = node.Target :?> AppLinkEntry
+
+                let values =
+                    match newValueOpt with
+                    | ValueNone -> []
+                    | ValueSome v -> v
+
+                for pair in values do
+                    appLinkEntry.KeyValues.Add(pair))
 
     let Description =
         Attributes.defineBindableWithEquality<string> AppLinkEntry.DescriptionProperty
@@ -56,6 +71,14 @@ type AppLinkEntryModifiers =
     [<Extension>]
     static member inline isLinkActive(this: WidgetBuilder<'msg, #IAppLinkEntry>, value: bool) =
         this.AddScalar(AppLinkEntry.IsLinkActive.WithValue(value))
+
+    [<Extension>]
+    static member inline keyValues
+        (
+            this: WidgetBuilder<'msg, #IAppLinkEntry>,
+            value: KeyValuePair<string, string> list
+        ) =
+        this.AddScalar(AppLinkEntry.KeyValues.WithValue(value))
 
     [<Extension>]
     static member inline thumbnail(this: WidgetBuilder<'msg, #IAppLinkEntry>, source: ImageSource) =

--- a/src/Fabulous.XamarinForms/Views/Application.fs
+++ b/src/Fabulous.XamarinForms/Views/Application.fs
@@ -38,20 +38,18 @@ module AppLinkUpdaters =
         let application = node.Target :?> CustomApplication
 
         match newValueOpt with
-        | ValueNone -> failwith "Application AppLinks requires its Pages modifier to be set"
+        | ValueNone -> failwith "Application AppLinks requires its AppLinks modifier to be set"
 
         | ValueSome widgets ->
-            // Push all new pages but only animate the last one
             let span = ArraySlice.toSpan widgets
 
             for widget in span do
                 let struct (_, appLink) = Helpers.createViewForWidget node widget
                 let link = appLink :?> AppLinkEntry
-                
+
                 if application.AppLinks <> null then
                     application.AppLinks.RegisterLink(link)
 
-            // Silently remove all old pages
             match oldValueOpt with
             | ValueNone -> ()
             | ValueSome oldWidgets ->
@@ -224,7 +222,11 @@ type ApplicationModifiers =
     static member inline onResume(this: WidgetBuilder<'msg, #IApplication>, onResume: 'msg) =
         this.AddScalar(Application.Resume.WithValue(fun () -> box onResume))
 
-    /// Link a ViewRef to access the direct Application instance
+    /// <summary>Link a ViewRef to access the direct Application instance</summary>
+    [<Extension>]
+    static member inline reference(this: WidgetBuilder<'msg, IApplication>, value: ViewRef<CustomApplication>) =
+        this.AddScalar(ViewRefAttributes.ViewRef.WithValue(value.Unbox))
+
     [<Extension>]
     static member inline onLinkReceived
         (
@@ -232,11 +234,6 @@ type ApplicationModifiers =
             fn: LinkRequestReceivedEventArgs -> 'msg
         ) =
         this.AddScalar(Application.LinkRequestReceived.WithValue(fn >> box))
-
-    /// <summary>Link a ViewRef to access the direct Application instance</summary>
-    [<Extension>]
-    static member inline reference(this: WidgetBuilder<'msg, IApplication>, value: ViewRef<CustomApplication>) =
-        this.AddScalar(ViewRefAttributes.ViewRef.WithValue(value.Unbox))
 
     [<Extension>]
     static member inline appLinks<'msg, 'marker when 'marker :> IApplication>(this: WidgetBuilder<'msg, 'marker>) =

--- a/src/Fabulous.XamarinForms/Views/Application.fs
+++ b/src/Fabulous.XamarinForms/Views/Application.fs
@@ -231,9 +231,9 @@ type ApplicationModifiers =
     static member inline onLinkReceived
         (
             this: WidgetBuilder<'msg, #IApplication>,
-            fn: LinkRequestReceivedEventArgs -> 'msg
+            onLinkReceived: LinkRequestReceivedEventArgs -> 'msg
         ) =
-        this.AddScalar(Application.LinkRequestReceived.WithValue(fn >> box))
+        this.AddScalar(Application.LinkRequestReceived.WithValue(onLinkReceived >> box))
 
     [<Extension>]
     static member inline appLinks<'msg, 'marker when 'marker :> IApplication>(this: WidgetBuilder<'msg, 'marker>) =

--- a/src/Fabulous.XamarinForms/Views/Application.fs
+++ b/src/Fabulous.XamarinForms/Views/Application.fs
@@ -6,7 +6,6 @@ open Fabulous.XamarinForms
 open Xamarin.Forms
 
 module AppLinkUpdaters =
-    // TODO Update the implementation to use the correct type for the AppLinkEntry
     let applyDiffApplicationLinks (prev: ArraySlice<Widget>) (diffs: WidgetCollectionItemChanges) (node: IViewNode) =
         let application = node.Target :?> CustomApplication
         let appLinks = application.AppLinks
@@ -31,7 +30,6 @@ module AppLinkUpdaters =
                 let link = appLink :?> AppLinkEntry
                 appLinks.DeregisterLink(link)
 
-    // TODO Update the implementation to use the correct type for the AppLinkEntry
     let updateAppLinks
         (oldValueOpt: ArraySlice<Widget> voption)
         (newValueOpt: ArraySlice<Widget> voption)
@@ -49,8 +47,9 @@ module AppLinkUpdaters =
             for widget in span do
                 let struct (_, appLink) = Helpers.createViewForWidget node widget
                 let link = appLink :?> AppLinkEntry
-
-                application.AppLinks.RegisterLink(link)
+                
+                if application.AppLinks <> null then
+                    application.AppLinks.RegisterLink(link)
 
             // Silently remove all old pages
             match oldValueOpt with

--- a/src/Fabulous.XamarinForms/Views/Application.fs
+++ b/src/Fabulous.XamarinForms/Views/Application.fs
@@ -14,15 +14,10 @@ module AppLinkUpdaters =
             match diff with
             | WidgetCollectionItemChange.Insert (_, widget) ->
                 let struct (_, appLink) = Helpers.createViewForWidget node widget
-                let page = appLink :?> AppLinkEntry
-                appLinks.RegisterLink(page)
-            | WidgetCollectionItemChange.Update _ -> ()
-            | WidgetCollectionItemChange.Replace (_, _, newWidget) ->
-                let struct (_, appLink) =
-                    Helpers.createViewForWidget node newWidget
-
                 let link = appLink :?> AppLinkEntry
-                appLinks.DeregisterLink(link)
+                appLinks.RegisterLink(link)
+            | WidgetCollectionItemChange.Update _
+            | WidgetCollectionItemChange.Replace _ -> ()
             | WidgetCollectionItemChange.Remove (_, newWidget) ->
                 let struct (_, appLink) =
                     Helpers.createViewForWidget node newWidget
@@ -38,7 +33,7 @@ module AppLinkUpdaters =
         let application = node.Target :?> CustomApplication
 
         match newValueOpt with
-        | ValueNone -> failwith "Application AppLinks requires its AppLinks modifier to be set"
+        | ValueNone -> failwith "Application requires AppLinks"
 
         | ValueSome widgets ->
             let span = ArraySlice.toSpan widgets
@@ -56,9 +51,7 @@ module AppLinkUpdaters =
                 let appLinks = application.AppLinks
                 let span = ArraySlice.toSpan oldWidgets
 
-                for i = 0 to span.Length - 1 do
-                    let linkArr = span.ToArray()
-                    let widget = linkArr.[i]
+                for widget in span do
                     let struct (_, appLink) = Helpers.createViewForWidget node widget
                     appLinks.DeregisterLink(appLink :?> AppLinkEntry)
 


### PR DESCRIPTION
Implementation of  #960

In order to support Deep linking a Indexing we need to: 

- Create a Fabulous CustomApplication so we can override  the relevant method and expose a Event so we can add a method extension.

```fsharp
type CustomApplication() =
    inherit Application()
    
    let linkRequestReceived = Event<EventHandler<LinkRequestReceivedEventArgs>, _>()
    
    [<CLIEvent>]
    member _.LinkRequestReceived = linkRequestReceived.Publish
    
    override this.OnAppLinkRequestReceived(uri : Uri)=
        linkRequestReceived.Trigger(this, LinkRequestReceivedEventArgs(uri))
        base.OnAppLinkRequestReceived(uri)

```

- Adds and extension method fore the event : 
```fsharp
let LinkRequestReceived =
Attributes.defineEvent<LinkRequestReceivedEventArgs>
    "Application_LinkRequestReceived"
    (fun target -> (target :?> CustomApplication).LinkRequestReceived)

[<Extension>]
static member inline onLinkReceived(this: WidgetBuilder<'msg, #IApplication>, fn: LinkRequestReceivedEventArgs -> 'msg) =
    this.AddScalar(Application.LinkRequestReceived.WithValue(fn >> box))

```

## Limitation

- The initial idea was to have a DSL like : 
```fsharp
Application(...)
    .onAppLinkReceived(NavigateDeepInAppMsg)
        .appLinks {
            AppLink(...)
            AppLink(...)
        }
```
**BUT**  AppLinks is not a List of AppLink is just and Intercase [AppLinks](https://docs.microsoft.com/en-us/dotnet/api/xamarin.forms.application.applinks?view=xamarin-forms#xamarin-forms-application-applinksl) . So can not use a widget collection.

##  Workaround 

- Use **ViewRef** to to get access to the Register and DeRegister methods 
```fsharp
let applicationRef = ViewRef<Application>()
let createLink =
     let pageLink = new Xamarin.Forms.AppLinkEntry()
     pageLink.Title <- "Im a deep link"
     pageLink.Description <- "Counter App"
     pageLink.AppLinkUri <- Uri("https://www.xamarin.com/platform")
     pageLink.IsLinkActive <- true

     pageLink.KeyValues.Add("contentType", "TodoItemPage");
     pageLink.KeyValues.Add("appName", "");
     pageLink.KeyValues.Add("companyName", "Xamarin");

     pageLink

match applicationRef.TryValue with
| Some target -> target.AppLinks.RegisterLink(createLink)
| None -> failwith "No application ref")

```
