### PR TITLE
Don't add attribute for optional wrap in FlexLayout ctor

### DIFF
--- a/src/Fabulous.XamarinForms/Views/Layouts/FlexLayout.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/FlexLayout.fs
@@ -50,16 +50,15 @@ module FlexLayout =
 module FlexLayoutBuilders =
     type Fabulous.XamarinForms.View with
         static member inline FlexLayout<'msg>(?wrap: FlexWrap) =
-            let wrap =
-                match wrap with
-                | None -> FlexWrap.NoWrap
-                | Some v -> v
+            match wrap with
+            | None -> CollectionBuilder<'msg, IFlexLayout, IView>(FlexLayout.WidgetKey, LayoutOfView.Children)
 
-            CollectionBuilder<'msg, IFlexLayout, IView>(
-                FlexLayout.WidgetKey,
-                LayoutOfView.Children,
-                FlexLayout.Wrap.WithValue(wrap)
-            )
+            | Some v ->
+                CollectionBuilder<'msg, IFlexLayout, IView>(
+                    FlexLayout.WidgetKey,
+                    LayoutOfView.Children,
+                    FlexLayout.Wrap.WithValue(v)
+                )
 
 [<Extension>]
 type FlexLayoutModifiers =


### PR DESCRIPTION
Fixes https://github.com/fsprojects/Fabulous/pull/965#discussion_r907623556
@twop I was wondering if I should use a default value or not add the attribute at all. But I'm changing it based on your comment.

Just wondering how it scales if there is several optional args?