### PR TITLE
Prefer TreeContext.GetViewNode instead of direct use of ViewNode.get

### DIFF
--- a/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/Controls/Map.fs
+++ b/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/Controls/Map.fs
@@ -39,7 +39,7 @@ module Map =
                 | ValueSome mapSpan -> map.MoveToRegion(mapSpan))
 
     let Pins =
-        Attributes.defineListWidgetCollection<Pin> "Map_Pins" (fun target -> (target :?> Map).Pins)
+        Attributes.defineListWidgetCollection "Map_Pins" (fun target -> (target :?> Map).Pins)
 
     let HasZoomEnabled =
         Attributes.defineBindableBool Map.HasZoomEnabledProperty

--- a/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/Controls/Map.fs
+++ b/samples/Xamarin.Forms/FabulousContacts/FabulousContacts/Controls/Map.fs
@@ -39,7 +39,7 @@ module Map =
                 | ValueSome mapSpan -> map.MoveToRegion(mapSpan))
 
     let Pins =
-        Attributes.defineListWidgetCollection<Pin> "Map_Pins" ViewNode.get (fun target -> (target :?> Map).Pins)
+        Attributes.defineListWidgetCollection<Pin> "Map_Pins" (fun target -> (target :?> Map).Pins)
 
     let HasZoomEnabled =
         Attributes.defineBindableBool Map.HasZoomEnabledProperty

--- a/src/Fabulous.Tests/APISketchTests/TestUI.Attributes.fs
+++ b/src/Fabulous.Tests/APISketchTests/TestUI.Attributes.fs
@@ -57,7 +57,6 @@ module TestUI_Attributes =
             let Children =
                 Attributes.defineListWidgetCollection
                     "Container_Children"
-                    TestUI_ViewNode.ViewNode.getViewNode
                     (fun target -> (target :?> IContainer).Children :> System.Collections.Generic.IList<_>)
 
         module Button =

--- a/src/Fabulous.XamarinForms/Attributes.fs
+++ b/src/Fabulous.XamarinForms/Attributes.fs
@@ -201,11 +201,8 @@ module Attributes =
         Attributes.definePropertyWidget
             bindableProperty.PropertyName
             (fun target ->
-                let childTarget =
-                    (target :?> BindableObject)
-                        .GetValue(bindableProperty)
-
-                ViewNode.get childTarget)
+                (target :?> BindableObject)
+                    .GetValue(bindableProperty))
             (fun target value ->
                 let bindableObject = target :?> BindableObject
 

--- a/src/Fabulous.XamarinForms/Views/Application.fs
+++ b/src/Fabulous.XamarinForms/Views/Application.fs
@@ -13,7 +13,7 @@ module Application =
     let MainPage =
         Attributes.definePropertyWidget
             "Application_MainPage"
-            (fun target -> (target :?> Application).MainPage)
+            (fun target -> (target :?> Application).MainPage :> obj)
             (fun target value -> (target :?> Application).MainPage <- value)
 
     let Resources =

--- a/src/Fabulous.XamarinForms/Views/Application.fs
+++ b/src/Fabulous.XamarinForms/Views/Application.fs
@@ -13,7 +13,7 @@ module Application =
     let MainPage =
         Attributes.definePropertyWidget
             "Application_MainPage"
-            (fun target -> ViewNode.get (target :?> Application).MainPage)
+            (fun target -> (target :?> Application).MainPage)
             (fun target value -> (target :?> Application).MainPage <- value)
 
     let Resources =

--- a/src/Fabulous.XamarinForms/Views/Cells/ViewCell.fs
+++ b/src/Fabulous.XamarinForms/Views/Cells/ViewCell.fs
@@ -13,7 +13,7 @@ module ViewCell =
     let View =
         Attributes.definePropertyWidget
             "ViewCell_View"
-            (fun target -> ViewNode.get (target :?> ViewCell).View)
+            (fun target -> (target :?> ViewCell).View)
             (fun target value -> (target :?> ViewCell).View <- value)
 
 [<AutoOpen>]

--- a/src/Fabulous.XamarinForms/Views/Cells/ViewCell.fs
+++ b/src/Fabulous.XamarinForms/Views/Cells/ViewCell.fs
@@ -13,7 +13,7 @@ module ViewCell =
     let View =
         Attributes.definePropertyWidget
             "ViewCell_View"
-            (fun target -> (target :?> ViewCell).View)
+            (fun target -> (target :?> ViewCell).View :> obj)
             (fun target value -> (target :?> ViewCell).View <- value)
 
 [<AutoOpen>]

--- a/src/Fabulous.XamarinForms/Views/Controls/FormattedLabel.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/FormattedLabel.fs
@@ -13,7 +13,6 @@ module FormattedLabel =
     let Spans =
         Attributes.defineListWidgetCollection
             "FormattedString_Spans"
-            ViewNode.get
             (fun target ->
                 let label = target :?> Label
 

--- a/src/Fabulous.XamarinForms/Views/Controls/Span.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Span.fs
@@ -46,7 +46,6 @@ module Span =
     let GestureRecognizers =
         Attributes.defineListWidgetCollection<IGestureRecognizer>
             "Span_GestureRecognizers"
-            ViewNode.get
             (fun target -> (target :?> Span).GestureRecognizers)
 
 [<AutoOpen>]

--- a/src/Fabulous.XamarinForms/Views/Layouts/ScrollView.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/ScrollView.fs
@@ -31,7 +31,7 @@ module ScrollView =
     let Content =
         Attributes.definePropertyWidget
             "ScrollView_Content"
-            (fun target -> (target :?> ScrollView).Content)
+            (fun target -> (target :?> ScrollView).Content :> obj)
             (fun target value -> (target :?> ScrollView).Content <- value)
 
     let Scrolled =

--- a/src/Fabulous.XamarinForms/Views/Layouts/ScrollView.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/ScrollView.fs
@@ -31,7 +31,7 @@ module ScrollView =
     let Content =
         Attributes.definePropertyWidget
             "ScrollView_Content"
-            (fun target -> ViewNode.get (target :?> ScrollView).Content)
+            (fun target -> (target :?> ScrollView).Content)
             (fun target value -> (target :?> ScrollView).Content <- value)
 
     let Scrolled =

--- a/src/Fabulous.XamarinForms/Views/Layouts/SwipeItems.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/SwipeItems.fs
@@ -15,7 +15,6 @@ module SwipeItems =
     let SwipeItems =
         Attributes.defineListWidgetCollection
             "SwipeItems_SwipeItems"
-            ViewNode.get
             (fun target -> (target :?> SwipeItems) :> IList<_>)
 
     let SwipeMode =

--- a/src/Fabulous.XamarinForms/Views/Layouts/_LayoutOfView.fs
+++ b/src/Fabulous.XamarinForms/Views/Layouts/_LayoutOfView.fs
@@ -10,5 +10,4 @@ module LayoutOfView =
     let Children =
         Attributes.defineListWidgetCollection
             "LayoutOfWidget_Children"
-            ViewNode.get
             (fun target -> (target :?> Xamarin.Forms.Layout<View>).Children)

--- a/src/Fabulous.XamarinForms/Views/Pages/FlyoutPage.fs
+++ b/src/Fabulous.XamarinForms/Views/Pages/FlyoutPage.fs
@@ -37,7 +37,7 @@ module FlyoutPage =
     let Flyout =
         Attributes.definePropertyWidget
             "FlyoutPage_Flyout"
-            (fun target -> ViewNode.get (target :?> FlyoutPage).Flyout)
+            (fun target -> (target :?> FlyoutPage).Flyout)
             (fun target value -> (target :?> FlyoutPage).Flyout <- value)
 
     let FlyoutBounds =
@@ -59,7 +59,7 @@ module FlyoutPage =
     let Detail =
         Attributes.definePropertyWidget
             "FlyoutPage_Detail"
-            (fun target -> ViewNode.get (target :?> FlyoutPage).Detail)
+            (fun target -> (target :?> FlyoutPage).Detail)
             (fun target value -> (target :?> FlyoutPage).Detail <- value)
 
     let DetailBounds =

--- a/src/Fabulous.XamarinForms/Views/Pages/FlyoutPage.fs
+++ b/src/Fabulous.XamarinForms/Views/Pages/FlyoutPage.fs
@@ -37,7 +37,7 @@ module FlyoutPage =
     let Flyout =
         Attributes.definePropertyWidget
             "FlyoutPage_Flyout"
-            (fun target -> (target :?> FlyoutPage).Flyout)
+            (fun target -> (target :?> FlyoutPage).Flyout :> obj)
             (fun target value -> (target :?> FlyoutPage).Flyout <- value)
 
     let FlyoutBounds =
@@ -59,7 +59,7 @@ module FlyoutPage =
     let Detail =
         Attributes.definePropertyWidget
             "FlyoutPage_Detail"
-            (fun target -> (target :?> FlyoutPage).Detail)
+            (fun target -> (target :?> FlyoutPage).Detail :> obj)
             (fun target value -> (target :?> FlyoutPage).Detail <- value)
 
     let DetailBounds =

--- a/src/Fabulous.XamarinForms/Views/Pages/_MultiPageOfPage.fs
+++ b/src/Fabulous.XamarinForms/Views/Pages/_MultiPageOfPage.fs
@@ -9,10 +9,7 @@ type IMultiPageOfPage =
 
 module MultiPageOfPage =
     let Children =
-        Attributes.defineListWidgetCollection
-            "MultiPageOfPage"
-            ViewNode.get
-            (fun target -> (target :?> MultiPage<Page>).Children)
+        Attributes.defineListWidgetCollection "MultiPageOfPage" (fun target -> (target :?> MultiPage<Page>).Children)
 
     let CurrentPageChanged =
         Attributes.defineEventNoArg

--- a/src/Fabulous.XamarinForms/Views/Pages/_Page.fs
+++ b/src/Fabulous.XamarinForms/Views/Pages/_Page.fs
@@ -29,7 +29,6 @@ module Page =
     let ToolbarItems =
         Attributes.defineListWidgetCollection<ToolbarItem>
             "Page_ToolbarItems"
-            ViewNode.get
             (fun target -> (target :?> Page).ToolbarItems)
 
     let Appearing =

--- a/src/Fabulous.XamarinForms/Views/Shapes/Geometries/GeometryGroup.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Geometries/GeometryGroup.fs
@@ -14,7 +14,6 @@ module GeometryGroup =
     let Children =
         Attributes.defineListWidgetCollection
             "GeometryGroup_Children"
-            ViewNode.get
             (fun target -> (target :?> GeometryGroup).Children :> IList<_>)
 
     let FillRule =

--- a/src/Fabulous.XamarinForms/Views/Shapes/Geometries/PathGeometry.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Geometries/PathGeometry.fs
@@ -14,7 +14,6 @@ module PathGeometry =
     let FiguresWidgets =
         Attributes.defineListWidgetCollection
             "PathGeometry_FiguresWidgets"
-            ViewNode.get
             (fun target -> (target :?> PathGeometry).Figures :> IList<_>)
 
     let FiguresString =

--- a/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/TransformGroup.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/PathTransforms/TransformGroup.fs
@@ -14,7 +14,6 @@ module TransformGroup =
     let Children =
         Attributes.defineListWidgetCollection
             "TransformGroup_Children"
-            ViewNode.get
             (fun target -> (target :?> TransformGroup).Children :> IList<_>)
 
 [<AutoOpen>]

--- a/src/Fabulous.XamarinForms/Views/Shapes/Segments/PathFigure.fs
+++ b/src/Fabulous.XamarinForms/Views/Shapes/Segments/PathFigure.fs
@@ -15,7 +15,6 @@ module PathFigure =
     let Segments =
         Attributes.defineListWidgetCollection
             "PathGeometry_Segments"
-            ViewNode.get
             (fun target -> (target :?> PathFigure).Segments :> IList<_>)
 
     let StartPoint =

--- a/src/Fabulous.XamarinForms/Views/_View.fs
+++ b/src/Fabulous.XamarinForms/Views/_View.fs
@@ -20,7 +20,6 @@ module XFView =
     let GestureRecognizers =
         Attributes.defineListWidgetCollection<IGestureRecognizer>
             "View_GestureRecognizers"
-            ViewNode.get
             (fun target -> (target :?> View).GestureRecognizers)
 
 [<Extension>]

--- a/src/Fabulous.XamarinForms/VirtualizedCollection.fs
+++ b/src/Fabulous.XamarinForms/VirtualizedCollection.fs
@@ -7,7 +7,7 @@ open Xamarin.Forms
 
 module BindableHelpers =
     /// On BindableContextChanged triggered, call the Reconciler to update the cell
-    let createOnBindingContextChanged canReuseView templateFn (target: BindableObject) =
+    let createOnBindingContextChanged canReuseView (getViewNode: obj -> IViewNode) templateFn (target: BindableObject) =
         let mutable prevWidgetOpt: Widget voption = ValueNone
 
         let onBindingContextChanged () =
@@ -16,7 +16,7 @@ module BindableHelpers =
             | value ->
                 let currWidget = templateFn value
 
-                let node = ViewNode.get target
+                let node = getViewNode target
                 Reconciler.update canReuseView prevWidgetOpt currWidget node
                 prevWidgetOpt <- ValueSome currWidget
 
@@ -35,7 +35,11 @@ type WidgetDataTemplate(parent: IViewNode, ``type``: Type, templateFn: obj -> Wi
         bindableObject.SetValue(ViewNode.ViewNodeProperty, viewNode)
 
         let onBindingContextChanged =
-            BindableHelpers.createOnBindingContextChanged parent.TreeContext.CanReuseView templateFn bindableObject
+            BindableHelpers.createOnBindingContextChanged
+                parent.TreeContext.CanReuseView
+                parent.TreeContext.GetViewNode
+                templateFn
+                bindableObject
 
         bindableObject.BindingContextChanged.Add(fun _ -> onBindingContextChanged())
 

--- a/src/Fabulous/Attributes.fs
+++ b/src/Fabulous/Attributes.fs
@@ -179,16 +179,15 @@ module Attributes =
         { Key = key; Name = name }
 
     /// Define an attribute storing a Widget for a CLR property
-    let inline definePropertyWidget<'T, 'view when 'T: null>
+    let inline definePropertyWidget<'T when 'T: null>
         (name: string)
-        ([<InlineIfLambda>] get: obj -> 'view)
+        ([<InlineIfLambda>] get: obj -> obj)
         ([<InlineIfLambda>] set: obj -> 'T -> unit)
         =
         let applyDiff (diff: WidgetDiff) (node: IViewNode) =
             let childView = get node.Target
 
-            let childNode =
-                node.TreeContext.GetViewNode(box childView)
+            let childNode = node.TreeContext.GetViewNode(childView)
 
             childNode.ApplyDiff(&diff)
 


### PR DESCRIPTION
Supersedes #961 

For better consistency and flexibility, remove direct use of `ViewNode.get` inside Fabulous.XamarinForms and only access it through the TreeContext.
This allows to swap the `GetViewNode` implementation used throughout Fabulous in a single place: https://github.com/fsprojects/Fabulous/blob/cdfd2451361326c7a6868cb8844227993515ea6f/src/Fabulous.XamarinForms/Program.fs#L147