### PR TITLE
Fix pop anim when removing several pages at once from NavigationPage

### DIFF
--- a/src/Fabulous.XamarinForms/Views/Pages/NavigationPage.fs
+++ b/src/Fabulous.XamarinForms/Views/Pages/NavigationPage.fs
@@ -23,6 +23,8 @@ module NavigationPageUpdaters =
             let struct (size, _) = prev
             int size
 
+        let mutable popLastWithAnimation = false
+
         for diff in diffs do
             match diff with
             | WidgetCollectionItemChange.Insert (index, widget) ->
@@ -72,13 +74,21 @@ module NavigationPageUpdaters =
                 elif index > pagesLength - 1 then
                     () // Do nothing, page has already been popped
                 elif index = pagesLength - 1 then
-                    // Last page, we pop it the right way to get an animation
-                    navigationPage.Pop()
+
+                    // Pop with an animation if it's the last page of the NavigationPage
+                    if index = pages.Length - 1 then
+                        popLastWithAnimation <- true
+                    else
+                        navigationPage.Navigation.RemovePage(pages.[index])
+
                     pagesLength <- pagesLength - 1
                 else
                     // Page is not visible, we just remove it
                     navigationPage.Navigation.RemovePage(pages.[index])
                     pagesLength <- pagesLength - 1
+
+        if popLastWithAnimation then
+            navigationPage.Pop()
 
     let updateNavigationPagePages
         (oldValueOpt: ArraySlice<Widget> voption)


### PR DESCRIPTION
Today when popping several pages at once in a NavigationPage, Fabulous plays the pop animation for each one of them.
Except we would expect to have an animation on the current page and directly see the target page. (no animation played for pages in between).

This PR fixes this