### PR TITLE
WIP: Style support

### DIFF
--- a/samples/Xamarin.Forms/CounterApp/CounterApp/App.fs
+++ b/samples/Xamarin.Forms/CounterApp/CounterApp/App.fs
@@ -2,6 +2,7 @@ namespace CounterApp
 
 open Fabulous
 open Fabulous.XamarinForms
+open Xamarin.Forms
 
 open type Fabulous.XamarinForms.View
 
@@ -51,12 +52,19 @@ module App =
             else
                 model, Cmd.none
 
+    let sharedStyle () =
+        LabelStyle()
+            .textColor(Color.Red)
+            .textDecorations(TextDecorations.Underline)
+
     let view model =
         Application(
             ContentPage(
                 "CounterApp",
                 (VStack() {
-                    Label($"%d{model.Count}").centerTextHorizontal()
+                    Label($"%d{model.Count}")
+                        .centerTextHorizontal()
+                        .style(sharedStyle())
 
                     Button("Increment", Increment)
 
@@ -64,6 +72,15 @@ module App =
 
                     (HStack() {
                         Label("Timer")
+                            .style(
+                                LabelStyle()
+                                    .textColor(
+                                        if model.TimerOn then
+                                            Color.Green
+                                        else
+                                            Color.Red
+                                    )
+                            )
 
                         Switch(model.TimerOn, TimerToggled)
                      })
@@ -74,6 +91,7 @@ module App =
 
                     Label($"Step size: %d{model.Step}")
                         .centerTextHorizontal()
+                        .style(sharedStyle())
 
                     Button("Reset", Reset)
                  })

--- a/src/Fabulous.XamarinForms/Fabulous.XamarinForms.fsproj
+++ b/src/Fabulous.XamarinForms/Fabulous.XamarinForms.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="Controls.fs" />
     <Compile Include="VirtualizedCollection.fs" />
     <Compile Include="Widgets.fs" />
+    <Compile Include="Styles\Label.fs" />
     <Compile Include="Views\_Element.fs" />
     <Compile Include="Views\_Geometry.fs" />
     <Compile Include="Views\_NavigableElement.fs" />

--- a/src/Fabulous.XamarinForms/Styles/Label.fs
+++ b/src/Fabulous.XamarinForms/Styles/Label.fs
@@ -1,0 +1,122 @@
+namespace Fabulous.XamarinForms
+
+open System
+open System.Runtime.CompilerServices
+open Fabulous
+open Fabulous.ScalarAttributeDefinitions
+open Fabulous.StackAllocatedCollections.StackList
+open Xamarin.Forms
+
+type IStyle =
+    interface
+    end
+
+type IElementStyle =
+    interface
+    end
+
+type INavigableElementStyle =
+    inherit IElementStyle
+
+type IVisualElementStyle =
+    inherit INavigableElementStyle
+
+type IViewStyle =
+    inherit IVisualElementStyle
+
+type ILabelStyle =
+    inherit IViewStyle
+
+module LabelStyle =
+    let registerStyle<'T> () =
+        let key = WidgetDefinitionStore.getNextKey()
+
+        let definition =
+            { Key = key
+              Name = $"Style<{typeof<'T>}>"
+              TargetType = typeof<Style>
+              CreateView =
+                  fun (widget, treeContext, parentNode) ->
+                      treeContext.Logger.Debug("Creating style for {0}", typeof<'T>.Name)
+
+                      let style = Style(typeof<'T>)
+                      let weakReference = WeakReference(style)
+
+                      let parentNode =
+                          match parentNode with
+                          | ValueNone -> None
+                          | ValueSome node -> Some node
+
+                      let node =
+                          ViewNode(parentNode, treeContext, weakReference)
+
+                      StyleViewNode.set node style
+
+                      Reconciler.update treeContext.CanReuseView ValueNone widget node
+                      struct (node :> IViewNode, box style) }
+
+        WidgetDefinitionStore.set key definition
+        key
+
+    let defineSetter<'T when 'T: equality> (bindableProperty: BindableProperty) : SimpleScalarAttributeDefinition<'T> =
+        let updateNode (_prevOpt: 'T voption) (currOpt: 'T voption) (node: IViewNode) =
+            let style = node.Target :?> Style
+
+            let index =
+                let mutable found = -1
+
+                for i = 0 to style.Setters.Count - 1 do
+                    let setter = style.Setters.[i]
+
+                    if setter.Property = bindableProperty then
+                        found <- i
+
+                found
+
+            match struct (currOpt, index) with
+            | struct (ValueNone, -1) -> ()
+            | struct (ValueNone, index) -> style.Setters.RemoveAt(index)
+
+            | struct (ValueSome curr, -1) ->
+                let setter =
+                    Setter(Property = bindableProperty, Value = curr)
+
+                style.Setters.Add(setter)
+
+            | struct (ValueSome curr, index) ->
+                let setter = style.Setters.[index]
+                setter.Value <- curr
+
+        let key =
+            SimpleScalarAttributeDefinition.CreateAttributeData(ScalarAttributeComparers.equalityCompare, updateNode)
+            |> AttributeDefinitionStore.registerScalar
+
+        { Key = key
+          Name = bindableProperty.PropertyName }
+
+    let WidgetKey = registerStyle<Label>()
+
+    let TextColor =
+        defineSetter<Color> Label.TextColorProperty
+
+    let TextDecorations =
+        defineSetter<TextDecorations> Label.TextDecorationsProperty
+
+[<AutoOpen>]
+module LabelStyleBuilders =
+    type Fabulous.XamarinForms.View with
+        static member inline LabelStyle<'msg>() =
+            WidgetBuilder<'msg, ILabelStyle>(
+                LabelStyle.WidgetKey,
+                AttributesBundle(StackList.empty(), ValueNone, ValueNone)
+            )
+
+[<Extension>]
+type LabelStyleModifiers =
+    [<Extension>]
+    static member inline textColor(this: WidgetBuilder<'msg, #ILabelStyle>, value: Color) =
+        this.AddScalar(LabelStyle.TextColor.WithValue(value))
+
+    [<Extension>]
+    static member inline textDecorations(this: WidgetBuilder<'msg, #ILabelStyle>, value: TextDecorations) =
+        this.AddScalar(LabelStyle.TextDecorations.WithValue(value))

--- a/src/Fabulous.XamarinForms/ViewNode.fs
+++ b/src/Fabulous.XamarinForms/ViewNode.fs
@@ -1,9 +1,11 @@
 ﻿namespace Fabulous.XamarinForms
 
+open System
+open System.Collections.Generic
 open Fabulous
 open Xamarin.Forms
 
-module ViewNode =
+module BindableViewNode =
     let ViewNodeProperty =
         BindableProperty.Create("ViewNode", typeof<ViewNode>, typeof<View>, null)
 
@@ -15,3 +17,29 @@ module ViewNode =
     let set (node: IViewNode) (target: obj) =
         (target :?> BindableObject)
             .SetValue(ViewNodeProperty, node)
+
+module StyleViewNode =
+    let private registrar = Dictionary<WeakReference, IViewNode>()
+
+    let get (target: obj) =
+        let mutable node: IViewNode = Unchecked.defaultof<_>
+        let keys = registrar.Keys |> Seq.toArray
+
+        for key in keys do
+            if key.IsAlive = false then
+                registrar.Remove(key) |> ignore
+            elif key.Target = target then
+                node <- registrar.[key]
+
+        node
+
+    let set (node: IViewNode) (target: obj) =
+        let weakRef = WeakReference(target)
+        registrar.[weakRef] <- node
+
+module ViewNode =
+    let get (target: obj) =
+        if target.GetType().IsAssignableFrom(typeof<Style>) then
+            StyleViewNode.get target
+        else
+            BindableViewNode.get target

--- a/src/Fabulous.XamarinForms/Views/Controls/Label.fs
+++ b/src/Fabulous.XamarinForms/Views/Controls/Label.fs
@@ -166,3 +166,7 @@ type LabelModifiers =
     [<Extension>]
     static member inline reference(this: WidgetBuilder<'msg, ILabel>, value: ViewRef<Label>) =
         this.AddScalar(ViewRefAttributes.ViewRef.WithValue(value.Unbox))
+
+    [<Extension>]
+    static member inline style(this: WidgetBuilder<'msg, #INavigableElement>, style: WidgetBuilder<'msg, ILabelStyle>) =
+        this.AddWidget(NavigableElement.StyleWidget.WithValue(style.Compile()))

--- a/src/Fabulous.XamarinForms/Views/_NavigableElement.fs
+++ b/src/Fabulous.XamarinForms/Views/_NavigableElement.fs
@@ -11,6 +11,9 @@ module NavigableElement =
     let Style =
         Attributes.defineBindableWithEquality<Xamarin.Forms.Style> NavigableElement.StyleProperty
 
+    let StyleWidget =
+        Attributes.defineBindableWidget NavigableElement.StyleProperty
+
 [<Extension>]
 type NavigableElementModifiers =
 

--- a/src/Fabulous.XamarinForms/VirtualizedCollection.fs
+++ b/src/Fabulous.XamarinForms/VirtualizedCollection.fs
@@ -32,7 +32,7 @@ type WidgetDataTemplate(parent: IViewNode, ``type``: Type, templateFn: obj -> Wi
         let viewNode =
             ViewNode(Some parent, parent.TreeContext, WeakReference(bindableObject))
 
-        bindableObject.SetValue(ViewNode.ViewNodeProperty, viewNode)
+        BindableViewNode.set viewNode bindableObject
 
         let onBindingContextChanged =
             BindableHelpers.createOnBindingContextChanged

--- a/src/Fabulous.XamarinForms/Widgets.fs
+++ b/src/Fabulous.XamarinForms/Widgets.fs
@@ -39,7 +39,7 @@ module Widgets =
                       let node =
                           ViewNode(parentNode, treeContext, weakReference)
 
-                      ViewNode.set node view
+                      BindableViewNode.set node view
 
                       additionalSetup view node
 


### PR DESCRIPTION
In Xamarin.Forms, it is possible to declare styles that can be applied to either one or more controls of the same type.
```xml
<Label>
    <Label.Style>
        <Style TargetType="Label">
            <Setter Property="TextColor" Value="Blue" />
       </Style>
    </Label.Style>
</Label>
```

I have been trying to add support for it with the following syntax
```fs
// Direct style
Label("Hello world")
    .style(
        LabelStyle()
            .textColor(Color.Blue)
    )

// Shared style
let sharedStyle =
    LabelStyle()
        .textColor(Color.Blue)

Label("Hello")
    .style(sharedStyle)

Label("World")
    .style(sharedStyle)
```

It does work, even if I'm not currently 100% sure the code I wrote is of good quality.
For now, it's still quite limited. Also Style doesn't react to changes, so making a dynamic style won't work.

<img height="500" src="https://user-images.githubusercontent.com/6429007/179790618-d54743bc-0f12-48ca-b7a3-74e26904e217.png" />
