### PR TITLE
Add onBackButtonPressed modifier to NavigationPage

### DIFF
--- a/src/Fabulous.XamarinForms/Controls.fs
+++ b/src/Fabulous.XamarinForms/Controls.fs
@@ -3,6 +3,28 @@
 open System
 open Xamarin.Forms
 
+// https://stackoverflow.com/a/2113902
+type RequiresSubscriptionEvent() = 
+    let evt = Event<EventHandler, EventArgs>()
+    let mutable counter = 0
+    let published = 
+        { new IEvent<EventHandler, EventArgs> with
+            member x.AddHandler(h) = 
+                evt.Publish.AddHandler(h)
+                counter <- counter + 1; 
+            member x.RemoveHandler(h) = 
+                evt.Publish.RemoveHandler(h)
+                counter <- counter - 1; 
+            member x.Subscribe(s) = 
+                let h = EventHandler(fun _ -> s.OnNext)
+                x.AddHandler(h)
+                { new IDisposable with 
+                    member y.Dispose() = x.RemoveHandler(h) } }
+        
+    member x.Trigger(v) = evt.Trigger(v)
+    member x.Publish = published
+    member x.HasListeners = counter > 0
+
 /// Represents a dimension for either the row or column definition of a Grid
 type Dimension =
     /// Use a size that fits the children of the row or column.
@@ -112,6 +134,7 @@ type CustomNavigationPage() as this =
     inherit NavigationPage()
 
     let backNavigated = Event<EventHandler, EventArgs>()
+    let backButtonPressed = RequiresSubscriptionEvent()
 
     let mutable popCount = 0
 
@@ -119,6 +142,9 @@ type CustomNavigationPage() as this =
 
     [<CLIEvent>]
     member _.BackNavigated = backNavigated.Publish
+    
+    [<CLIEvent>]
+    member _.BackButtonPressed = backButtonPressed.Publish
 
     member this.Push(page, ?animated) =
         let animated =
@@ -138,6 +164,15 @@ type CustomNavigationPage() as this =
             popCount <- popCount - 1
         else
             backNavigated.Trigger(this, EventArgs())
+            
+    /// If we are listening to the BackButtonPressed event, cancel the automatic back navigation and trigger the event;
+    /// otherwise just let the automatic back navigation happen
+    override this.OnBackButtonPressed() =
+        if backButtonPressed.HasListeners then
+            backButtonPressed.Trigger(this, EventArgs())
+            true
+        else
+            false
 
 /// FlyoutPage doesn't say if the Flyout is visible or not on IsPresentedChanged, so we implement it
 type CustomFlyoutPage() as this =

--- a/src/Fabulous.XamarinForms/Controls.fs
+++ b/src/Fabulous.XamarinForms/Controls.fs
@@ -4,23 +4,27 @@ open System
 open Xamarin.Forms
 
 // https://stackoverflow.com/a/2113902
-type RequiresSubscriptionEvent() = 
+type RequiresSubscriptionEvent() =
     let evt = Event<EventHandler, EventArgs>()
     let mutable counter = 0
-    let published = 
+
+    let published =
         { new IEvent<EventHandler, EventArgs> with
-            member x.AddHandler(h) = 
+            member x.AddHandler(h) =
                 evt.Publish.AddHandler(h)
-                counter <- counter + 1; 
-            member x.RemoveHandler(h) = 
+                counter <- counter + 1
+
+            member x.RemoveHandler(h) =
                 evt.Publish.RemoveHandler(h)
-                counter <- counter - 1; 
-            member x.Subscribe(s) = 
+                counter <- counter - 1
+
+            member x.Subscribe(s) =
                 let h = EventHandler(fun _ -> s.OnNext)
                 x.AddHandler(h)
-                { new IDisposable with 
+
+                { new IDisposable with
                     member y.Dispose() = x.RemoveHandler(h) } }
-        
+
     member x.Trigger(v) = evt.Trigger(v)
     member x.Publish = published
     member x.HasListeners = counter > 0
@@ -142,7 +146,7 @@ type CustomNavigationPage() as this =
 
     [<CLIEvent>]
     member _.BackNavigated = backNavigated.Publish
-    
+
     [<CLIEvent>]
     member _.BackButtonPressed = backButtonPressed.Publish
 
@@ -164,7 +168,7 @@ type CustomNavigationPage() as this =
             popCount <- popCount - 1
         else
             backNavigated.Trigger(this, EventArgs())
-            
+
     /// If we are listening to the BackButtonPressed event, cancel the automatic back navigation and trigger the event;
     /// otherwise just let the automatic back navigation happen
     override this.OnBackButtonPressed() =

--- a/src/Fabulous.XamarinForms/Views/Pages/NavigationPage.fs
+++ b/src/Fabulous.XamarinForms/Views/Pages/NavigationPage.fs
@@ -160,6 +160,11 @@ module NavigationPage =
             "NavigationPage_BackNavigated"
             (fun target -> (target :?> CustomNavigationPage).BackNavigated)
 
+    let BackButtonPressed =
+        Attributes.defineEventNoArg
+            "NavigationPage_BackButtonPressed"
+            (fun target -> (target :?> CustomNavigationPage).BackButtonPressed)
+
     [<Obsolete("Use BackNavigated instead")>]
     let Popped =
         Attributes.defineEvent<NavigationEventArgs>
@@ -255,10 +260,17 @@ type NavigationPageModifiers =
         this.AddScalar(NavigationPage.BarTextColor.WithValue(AppTheme.create light dark))
 
     /// <summary>Event that is fired when the user back navigated.</summary>
-    /// <param name="onPopped">Msg to dispatch when the user back navigated.</param>
+    /// <param name="onBackNavigated">Msg to dispatch when the user back navigated.</param>
     [<Extension>]
     static member inline onBackNavigated(this: WidgetBuilder<'msg, #INavigationPage>, onBackNavigated: 'msg) =
         this.AddScalar(NavigationPage.BackNavigated.WithValue(onBackNavigated))
+
+    /// <summary>Event that is fired when the user pressed the system back button. Doesn't support the iOS back button</summary>
+    /// <param name="onBackButtonPressed">Msg to dispatch when the user presses the system back button.</param>
+    /// <remarks>Setting this modifier will prevent the default behavior of the system back button. It's up to you to update the navigation stack.</remarks>
+    [<Extension>]
+    static member inline onBackButtonPressed(this: WidgetBuilder<'msg, #INavigationPage>, onBackButtonPressed: 'msg) =
+        this.AddScalar(NavigationPage.BackButtonPressed.WithValue(onBackButtonPressed))
 
     /// <summary>Event that is fired when the page is popped.</summary>
     /// <param name="onPopped">Msg to dispatch when then page is popped.</param>

--- a/src/Fabulous.XamarinForms/Views/Pages/NavigationPage.fs
+++ b/src/Fabulous.XamarinForms/Views/Pages/NavigationPage.fs
@@ -265,7 +265,7 @@ type NavigationPageModifiers =
     static member inline onBackNavigated(this: WidgetBuilder<'msg, #INavigationPage>, onBackNavigated: 'msg) =
         this.AddScalar(NavigationPage.BackNavigated.WithValue(onBackNavigated))
 
-    /// <summary>Event that is fired when the user pressed the system back button. Doesn't support the iOS back button</summary>
+    /// <summary>Event that is fired when the user presses the system back button. Doesn't support the iOS back button</summary>
     /// <param name="onBackButtonPressed">Msg to dispatch when the user presses the system back button.</param>
     /// <remarks>Setting this modifier will prevent the default behavior of the system back button. It's up to you to update the navigation stack.</remarks>
     [<Extension>]

--- a/src/Fabulous.XamarinForms/Views/Pages/NavigationPage.fs
+++ b/src/Fabulous.XamarinForms/Views/Pages/NavigationPage.fs
@@ -163,7 +163,9 @@ module NavigationPage =
     let BackButtonPressed =
         Attributes.defineEventNoArg
             "NavigationPage_BackButtonPressed"
-            (fun target -> (target :?> CustomNavigationPage).BackButtonPressed)
+            (fun target ->
+                (target :?> CustomNavigationPage)
+                    .BackButtonPressed)
 
     [<Obsolete("Use BackNavigated instead")>]
     let Popped =


### PR DESCRIPTION
If we are listening to the BackButtonPressed event, cancel the automatic back navigation and trigger the event;
otherwise just let the automatic back navigation happen