### PR TITLE
Implemented taking only the latest attribute for a property

### DIFF
--- a/src/Fabulous.Tests/APISketchTests/APISketchTests.fs
+++ b/src/Fabulous.Tests/APISketchTests/APISketchTests.fs
@@ -803,7 +803,7 @@ module Attributes =
         Assert.AreEqual(MyEnum.MinusOne, SmallScalars.IntEnum.decode<MyEnum> minusOne.NumericValue)
 
 
-    
+
     /// In WidgetBuilders we can easily have duplicate attributes
     /// like Label("aha!").color("red").color("blue")
     /// Diffing algorithm already uses stable sort for diffing attributes
@@ -843,7 +843,7 @@ module Attributes =
         let label = find<TestLabel> tree "text" :> IText
 
         Assert.AreEqual(label.TextColor, "blue")
-        
+
         instance.ProcessMessage(())
-        
+
         Assert.AreEqual(label.TextColor, "red")

--- a/src/Fabulous/WidgetDiff.fs
+++ b/src/Fabulous/WidgetDiff.fs
@@ -45,17 +45,18 @@ module private SkipRepeatingScalars =
     /// but still might be interesting to tinker about it more
     let inline skip (scalars: ScalarAttribute array) (pos: int) =
         let length = scalars.Length
-        // either the last element or out of bounds 
+        // either the last element or out of bounds
         if pos >= length - 1 then
             pos
         else
             // that means that there is at least one more element ahead
-            let key = scalars[pos].Key
+            let key = scalars.[pos].Key
             let mutable resultingIndex = pos
-            
-            while (length - 1 > resultingIndex) && (scalars[resultingIndex + 1].Key = key) do
+
+            while (length - 1 > resultingIndex)
+                  && (scalars.[resultingIndex + 1].Key = key) do
                 resultingIndex <- resultingIndex + 1
-                
+
             resultingIndex
 
 [<Struct; IsByRefLike; RequireQualifiedAccess>]
@@ -203,8 +204,11 @@ and [<Struct; IsByRefLike>] ScalarChangesEnumerator
                 false
 
         | EnumerationMode.ActualDiff (prev, next) ->
-            let mutable prevIndex = SkipRepeatingScalars.skip prev e.prevIndex
-            let mutable nextIndex = SkipRepeatingScalars.skip next e.nextIndex
+            let mutable prevIndex =
+                SkipRepeatingScalars.skip prev e.prevIndex
+
+            let mutable nextIndex =
+                SkipRepeatingScalars.skip next e.nextIndex
 
             let prevLength = prev.Length
             let nextLength = next.Length
@@ -266,7 +270,7 @@ and [<Struct; IsByRefLike>] ScalarChangesEnumerator
                                     res <- ValueSome true
 
                             // move both pointers
-                            prevIndex <- SkipRepeatingScalars.skip prev (prevIndex + 1) 
+                            prevIndex <- SkipRepeatingScalars.skip prev (prevIndex + 1)
                             nextIndex <- SkipRepeatingScalars.skip next (nextIndex + 1)
 
                 else
@@ -564,6 +568,3 @@ and [<Struct; IsByRefLike>] WidgetCollectionItemChangesEnumerator
         else
             // means that we are done iterating
             false
-
-
-


### PR DESCRIPTION
## Context
In WidgetBuilders we can easily have duplicate attributes
like Label("aha!").color("red").color("blue")
Diffing algorithm already uses stable sort for diffing attributes
Thus we need to leverage that fact

In particular we might have a bug in this context
prev:  `Label("aha!").color("red").color("blue")`
next:  `Label("aha!").color("red")`

After the diffing the resulting color should be "red", but previously
it was interpreted as "removed color property" instead

## Solution
I implemented `SkipRepeatingScalars.skip` functions that skips `color("red") from `color("red").color("blue")`
Effectively taking only the latest attribute for a particular property.

I used in `ScalarChangesEnumerator` but only for actual diff. It Is possible that it should be used for "AllRemoved" and "AllAdded" but it is unlikely to cause any problems (possible a field will be set twice for example)