### PR TITLE
Fix namespaces in Fabulous.MauiControls

### DIFF
--- a/src/Fabulous.MauiControls/Controls.fs
+++ b/src/Fabulous.MauiControls/Controls.fs
@@ -45,7 +45,7 @@ type SizeAllocatedEventArgs = { Width: float; Height: float }
 /// Set UseSafeArea to true by default because View DSL only shows `ignoreSafeArea`
 type FabulousContentPage() as this =
     inherit ContentPage()
-    //do Microsoft.Maui.PlatformConfiguration.iOSSpecific.Page.SetUseSafeArea(this, true)
+    do Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.Page.SetUseSafeArea(this, true)
 
     let sizeAllocated =
         Event<EventHandler<SizeAllocatedEventArgs>, _>()

--- a/src/Fabulous.MauiControls/Views/Collections/CarouselView.fs
+++ b/src/Fabulous.MauiControls/Views/Collections/CarouselView.fs
@@ -85,7 +85,7 @@ module CarouselView =
 [<AutoOpen>]
 module CarouselViewBuilders =
     type Fabulous.Maui.View with
-        static member inline CarouselView<'msg, 'itemData, 'itemMarker when 'itemMarker :> IView>
+        static member inline CarouselView<'msg, 'itemData, 'itemMarker when 'itemMarker :> Fabulous.Maui.IView>
             (items: seq<'itemData>)
             =
             WidgetHelpers.buildItems<'msg, ICarouselView, 'itemData, 'itemMarker>

--- a/src/Fabulous.MauiControls/Views/Controls/DatePicker.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/DatePicker.fs
@@ -5,7 +5,7 @@ open System.Runtime.CompilerServices
 open Fabulous
 open Microsoft.Maui
 open Microsoft.Maui.Controls
-//open Microsoft.Maui.PlatformConfiguration
+open Microsoft.Maui.Controls.PlatformConfiguration
 
 type IDatePicker =
     inherit Fabulous.Maui.IView
@@ -46,18 +46,18 @@ module DatePicker =
             DatePicker.DateProperty
             (fun target -> (target :?> DatePicker).DateSelected)
 
-// let UpdateMode =
-//     Attributes.defineSimpleScalarWithEquality<iOSSpecific.UpdateMode>
-//         "DatePicker_UpdateMode"
-//         (fun _ newValueOpt node ->
-//             let datePicker = node.Target :?> DatePicker
-//
-//             let value =
-//                 match newValueOpt with
-//                 | ValueNone -> iOSSpecific.UpdateMode.Immediately
-//                 | ValueSome v -> v
-//
-//             iOSSpecific.DatePicker.SetUpdateMode(datePicker, value))
+    let UpdateMode =
+        Attributes.defineSimpleScalarWithEquality<iOSSpecific.UpdateMode>
+            "DatePicker_UpdateMode"
+            (fun _ newValueOpt node ->
+                let datePicker = node.Target :?> DatePicker
+
+                let value =
+                    match newValueOpt with
+                    | ValueNone -> iOSSpecific.UpdateMode.Immediately
+                    | ValueSome v -> v
+
+                iOSSpecific.DatePicker.SetUpdateMode(datePicker, value))
 
 [<AutoOpen>]
 module DatePickerBuilders =
@@ -130,11 +130,11 @@ type DatePickerModifiers =
     [<Extension>]
     static member inline reference(this: WidgetBuilder<'msg, IDatePicker>, value: ViewRef<DatePicker>) =
         this.AddScalar(ViewRefAttributes.ViewRef.WithValue(value.Unbox))
-//
-// [<Extension>]
-// type DatePickerPlatformModifiers =
-//     /// <summary>iOS platform specific. Sets a value that controls whether elements in the date picker are continuously updated while scrolling or updated once after scrolling has completed.</summary>
-//     /// <param name="mode">The new property value to assign.</param>
-//     [<Extension>]
-//     static member inline updateMode(this: WidgetBuilder<'msg, #IDatePicker>, mode: iOSSpecific.UpdateMode) =
-//         this.AddScalar(DatePicker.UpdateMode.WithValue(mode))
+
+[<Extension>]
+type DatePickerPlatformModifiers =
+    /// <summary>iOS platform specific. Sets a value that controls whether elements in the date picker are continuously updated while scrolling or updated once after scrolling has completed.</summary>
+    /// <param name="mode">The new property value to assign.</param>
+    [<Extension>]
+    static member inline updateMode(this: WidgetBuilder<'msg, #IDatePicker>, mode: iOSSpecific.UpdateMode) =
+        this.AddScalar(DatePicker.UpdateMode.WithValue(mode))

--- a/src/Fabulous.MauiControls/Views/Controls/Entry.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Entry.fs
@@ -4,7 +4,7 @@ open System.Runtime.CompilerServices
 open Fabulous
 open Microsoft.Maui
 open Microsoft.Maui.Controls
-//open Microsoft.Maui.PlatformConfiguration
+open Microsoft.Maui.Controls.PlatformConfiguration
 
 type IEntry =
     inherit Fabulous.Maui.IInputView
@@ -48,19 +48,19 @@ module Entry =
     let Completed =
         Attributes.defineEventNoArg "Entry_Completed" (fun target -> (target :?> Entry).Completed)
 
-// let CursorColor =
-//     Attributes.defineSmallScalar<FabColor>
-//         "Entry_CursorColor"
-//         SmallScalars.FabColor.decode
-//         (fun _ newValueOpt node ->
-//             let entry = node.Target :?> Entry
-//
-//             let value =
-//                 match newValueOpt with
-//                 | ValueNone -> Color.Default
-//                 | ValueSome x -> x.ToXFColor()
-//
-//             iOSSpecific.Entry.SetCursorColor(entry, value))
+    let CursorColor =
+        Attributes.defineSmallScalar<FabColor>
+            "Entry_CursorColor"
+            SmallScalars.FabColor.decode
+            (fun _ newValueOpt node ->
+                let entry = node.Target :?> Entry
+
+                let value =
+                    match newValueOpt with
+                    | ValueNone -> null
+                    | ValueSome x -> x.ToXFColor()
+
+                iOSSpecific.Entry.SetCursorColor(entry, value))
 
 [<AutoOpen>]
 module EntryBuilders =

--- a/src/Fabulous.MauiControls/Views/Controls/Picker.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Picker.fs
@@ -4,7 +4,7 @@ open System.Runtime.CompilerServices
 open Fabulous
 open Microsoft.Maui
 open Microsoft.Maui.Controls
-// open Microsoft.Maui.PlatformConfiguration
+open Microsoft.Maui.Controls.PlatformConfiguration
 
 type IPicker =
     inherit Fabulous.Maui.IView
@@ -60,18 +60,18 @@ module Picker =
                 (target :?> CustomPicker)
                     .CustomSelectedIndexChanged)
 
-// let UpdateMode =
-//     Attributes.defineEnum<iOSSpecific.UpdateMode>
-//         "Picker_UpdateMode"
-//         (fun _ newValueOpt node ->
-//             let picker = node.Target :?> Picker
-//
-//             let value =
-//                 match newValueOpt with
-//                 | ValueNone -> iOSSpecific.UpdateMode.Immediately
-//                 | ValueSome v -> v
-//
-//             iOSSpecific.Picker.SetUpdateMode(picker, value))
+    let UpdateMode =
+        Attributes.defineEnum<iOSSpecific.UpdateMode>
+            "Picker_UpdateMode"
+            (fun _ newValueOpt node ->
+                let picker = node.Target :?> Picker
+
+                let value =
+                    match newValueOpt with
+                    | ValueNone -> iOSSpecific.UpdateMode.Immediately
+                    | ValueSome v -> v
+
+                iOSSpecific.Picker.SetUpdateMode(picker, value))
 
 [<AutoOpen>]
 module PickerBuilders =
@@ -156,10 +156,10 @@ type PickerModifiers =
     static member inline reference(this: WidgetBuilder<'msg, IPicker>, value: ViewRef<Picker>) =
         this.AddScalar(ViewRefAttributes.ViewRef.WithValue(value.Unbox))
 
-// [<Extension>]
-// type PickerPlatformModifiers =
-//     /// <summary>iOS platform specific. Sets a value that controls whether elements in the picker are continuously updated while scrolling or updated once after scrolling has completed.</summary>
-//     /// <param name="mode">The new property value to assign.</param>
-//     [<Extension>]
-//     static member inline updateMode(this: WidgetBuilder<'msg, #IPicker>, mode: iOSSpecific.UpdateMode) =
-//         this.AddScalar(Picker.UpdateMode.WithValue(mode))
+[<Extension>]
+type PickerPlatformModifiers =
+    /// <summary>iOS platform specific. Sets a value that controls whether elements in the picker are continuously updated while scrolling or updated once after scrolling has completed.</summary>
+    /// <param name="mode">The new property value to assign.</param>
+    [<Extension>]
+    static member inline updateMode(this: WidgetBuilder<'msg, #IPicker>, mode: iOSSpecific.UpdateMode) =
+        this.AddScalar(Picker.UpdateMode.WithValue(mode))

--- a/src/Fabulous.MauiControls/Views/Controls/TimePicker.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/TimePicker.fs
@@ -4,7 +4,7 @@ open System.Runtime.CompilerServices
 open Fabulous
 open Microsoft.Maui
 open Microsoft.Maui.Controls
-// open Microsoft.Maui.PlatformConfiguration
+open Microsoft.Maui.Controls.PlatformConfiguration
 
 type ITimePicker =
     inherit Fabulous.Maui.IView
@@ -39,18 +39,18 @@ module TimePicker =
 // let TextTransform =
 //     Attributes.defineBindableEnum<TextTransform> TimePicker.TextTransformProperty
 
-// let UpdateMode =
-//     Attributes.defineEnum<iOSSpecific.UpdateMode>
-//         "TimePicker_UpdateMode"
-//         (fun _ newValueOpt node ->
-//             let timePicker = node.Target :?> TimePicker
-//
-//             let value =
-//                 match newValueOpt with
-//                 | ValueNone -> iOSSpecific.UpdateMode.Immediately
-//                 | ValueSome v -> v
-//
-//             iOSSpecific.TimePicker.SetUpdateMode(timePicker, value))
+    let UpdateMode =
+        Attributes.defineEnum<iOSSpecific.UpdateMode>
+            "TimePicker_UpdateMode"
+            (fun _ newValueOpt node ->
+                let timePicker = node.Target :?> TimePicker
+
+                let value =
+                    match newValueOpt with
+                    | ValueNone -> iOSSpecific.UpdateMode.Immediately
+                    | ValueSome v -> v
+
+                iOSSpecific.TimePicker.SetUpdateMode(timePicker, value))
 
 [<AutoOpen>]
 module TimePickerBuilders =
@@ -116,10 +116,10 @@ type TimePickerModifiers =
     static member inline reference(this: WidgetBuilder<'msg, ITimePicker>, value: ViewRef<TimePicker>) =
         this.AddScalar(ViewRefAttributes.ViewRef.WithValue(value.Unbox))
 
-// [<Extension>]
-// type TimePickerPlatformModifiers =
-//     /// <summary>iOS platform specific. Sets a value that controls whether elements in the time picker are continuously updated while scrolling or updated once after scrolling has completed.</summary>
-//     /// <param name="mode">The new property value to assign.</param>
-//     [<Extension>]
-//     static member inline updateMode(this: WidgetBuilder<'msg, #ITimePicker>, mode: iOSSpecific.UpdateMode) =
-//         this.AddScalar(TimePicker.UpdateMode.WithValue(mode))
+[<Extension>]
+type TimePickerPlatformModifiers =
+    /// <summary>iOS platform specific. Sets a value that controls whether elements in the time picker are continuously updated while scrolling or updated once after scrolling has completed.</summary>
+    /// <param name="mode">The new property value to assign.</param>
+    [<Extension>]
+    static member inline updateMode(this: WidgetBuilder<'msg, #ITimePicker>, mode: iOSSpecific.UpdateMode) =
+        this.AddScalar(TimePicker.UpdateMode.WithValue(mode))

--- a/src/Fabulous.MauiControls/Views/Controls/TimePicker.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/TimePicker.fs
@@ -36,7 +36,7 @@ module TimePicker =
     let TextColor =
         Attributes.defineBindableAppThemeColor TimePicker.TextColorProperty
 
-// let TextTransform =
+    // let TextTransform =
 //     Attributes.defineBindableEnum<TextTransform> TimePicker.TextTransformProperty
 
     let UpdateMode =

--- a/src/Fabulous.MauiControls/Views/Controls/WebView.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/WebView.fs
@@ -6,7 +6,7 @@ open System.Runtime.CompilerServices
 open Fabulous
 open Microsoft.Maui
 open Microsoft.Maui.Controls
-// open Microsoft.Maui.PlatformConfiguration
+open Microsoft.Maui.Controls.PlatformConfiguration
 
 type IWebView =
     inherit Fabulous.Maui.IView
@@ -35,34 +35,34 @@ module WebView =
     let Navigated =
         Attributes.defineEvent<WebNavigatedEventArgs> "WebView_Navigated" (fun target -> (target :?> WebView).Navigated)
 
-// let ReloadRequested =
-//     Attributes.defineEventNoArg "WebView_ReloadRequested" (fun target -> (target :?> WebView).ReloadRequested)
+    // let ReloadRequested =
+    //     Attributes.defineEventNoArg "WebView_ReloadRequested" (fun target -> (target :?> WebView).ReloadRequested)
 
-// let EnableZoomControls =
-//     Attributes.defineBool
-//         "WebView_EnableZoomControls"
-//         (fun _ newValueOpt node ->
-//             let webview = node.Target :?> WebView
-//
-//             let value =
-//                 match newValueOpt with
-//                 | ValueNone -> false
-//                 | ValueSome v -> v
-//
-//             AndroidSpecific.WebView.SetEnableZoomControls(webview, value))
+    let EnableZoomControls =
+        Attributes.defineBool
+            "WebView_EnableZoomControls"
+            (fun _ newValueOpt node ->
+                let webview = node.Target :?> WebView
 
-// let DisplayZoomControls =
-//     Attributes.defineBool
-//         "WebView_DisplayZoomControls"
-//         (fun _ newValueOpt node ->
-//             let webview = node.Target :?> WebView
-//
-//             let value =
-//                 match newValueOpt with
-//                 | ValueNone -> false
-//                 | ValueSome v -> v
-//
-//             AndroidSpecific.WebView.SetDisplayZoomControls(webview, value))
+                let value =
+                    match newValueOpt with
+                    | ValueNone -> false
+                    | ValueSome v -> v
+
+                AndroidSpecific.WebView.SetEnableZoomControls(webview, value))
+
+    let DisplayZoomControls =
+        Attributes.defineBool
+            "WebView_DisplayZoomControls"
+            (fun _ newValueOpt node ->
+                let webview = node.Target :?> WebView
+
+                let value =
+                    match newValueOpt with
+                    | ValueNone -> false
+                    | ValueSome v -> v
+
+                AndroidSpecific.WebView.SetDisplayZoomControls(webview, value))
 
 [<AutoOpen>]
 module WebViewBuilders =
@@ -127,12 +127,12 @@ type WebViewModifiers() =
     static member inline reference(this: WidgetBuilder<'msg, IWebView>, value: ViewRef<WebView>) =
         this.AddScalar(ViewRefAttributes.ViewRef.WithValue(value.Unbox))
 
-// [<Extension>]
-// type WebViewPlatformModifiers =
-//     [<Extension>]
-//     static member inline enableZoomControls(this: WidgetBuilder<'msg, #IWebView>, value: bool) =
-//         this.AddScalar(WebView.EnableZoomControls.WithValue(value))
-//
-//     [<Extension>]
-//     static member displayZoomControls(this: WidgetBuilder<'msg, #IWebView>, value: bool) =
-//         this.AddScalar(WebView.DisplayZoomControls.WithValue(value))
+[<Extension>]
+type WebViewPlatformModifiers =
+    [<Extension>]
+    static member inline enableZoomControls(this: WidgetBuilder<'msg, #IWebView>, value: bool) =
+        this.AddScalar(WebView.EnableZoomControls.WithValue(value))
+
+    [<Extension>]
+    static member displayZoomControls(this: WidgetBuilder<'msg, #IWebView>, value: bool) =
+        this.AddScalar(WebView.DisplayZoomControls.WithValue(value))

--- a/src/Fabulous.MauiControls/Views/Layouts/AbsoluteLayout.fs
+++ b/src/Fabulous.MauiControls/Views/Layouts/AbsoluteLayout.fs
@@ -25,7 +25,10 @@ module AbsoluteLayout =
 module AbsoluteLayoutBuilders =
     type Fabulous.Maui.View with
         static member inline AbsoluteLayout<'msg>() =
-            CollectionBuilder<'msg, IAbsoluteLayout, Fabulous.Maui.IView>(AbsoluteLayout.WidgetKey, LayoutOfView.Children)
+            CollectionBuilder<'msg, IAbsoluteLayout, Fabulous.Maui.IView>(
+                AbsoluteLayout.WidgetKey,
+                LayoutOfView.Children
+            )
 
 [<Extension>]
 type AbsoluteLayoutModifiers =

--- a/src/Fabulous.MauiControls/Views/Layouts/AbsoluteLayout.fs
+++ b/src/Fabulous.MauiControls/Views/Layouts/AbsoluteLayout.fs
@@ -25,7 +25,7 @@ module AbsoluteLayout =
 module AbsoluteLayoutBuilders =
     type Fabulous.Maui.View with
         static member inline AbsoluteLayout<'msg>() =
-            CollectionBuilder<'msg, IAbsoluteLayout, IView>(AbsoluteLayout.WidgetKey, LayoutOfView.Children)
+            CollectionBuilder<'msg, IAbsoluteLayout, Fabulous.Maui.IView>(AbsoluteLayout.WidgetKey, LayoutOfView.Children)
 
 [<Extension>]
 type AbsoluteLayoutModifiers =
@@ -44,7 +44,7 @@ type AbsoluteLayoutAttachedModifiers =
     [<Extension>]
     static member inline layoutBounds
         (
-            this: WidgetBuilder<'msg, #IView>,
+            this: WidgetBuilder<'msg, #Fabulous.Maui.IView>,
             x: float,
             y: float,
             width: float,
@@ -55,5 +55,5 @@ type AbsoluteLayoutAttachedModifiers =
     /// <summary>Determines how the values in the list are interpreted to create the bounding rectangle.</summary>
     /// <param name= "value">AbsoluteLayoutFlags enumeration value: All, None, HeightProportional, WidthProportional, SizeProportional, XProportional, YProportional, or PositionProportional.</param>
     [<Extension>]
-    static member inline layoutFlags(this: WidgetBuilder<'msg, #IView>, value: AbsoluteLayoutFlags) =
+    static member inline layoutFlags(this: WidgetBuilder<'msg, #Fabulous.Maui.IView>, value: AbsoluteLayoutFlags) =
         this.AddScalar(AbsoluteLayout.LayoutFlags.WithValue(value))

--- a/src/Fabulous.MauiControls/Views/Layouts/ContentView.fs
+++ b/src/Fabulous.MauiControls/Views/Layouts/ContentView.fs
@@ -17,7 +17,9 @@ module ContentView =
 [<AutoOpen>]
 module ContentViewBuilders =
     type Fabulous.Maui.View with
-        static member inline ContentView<'msg, 'marker when 'marker :> Fabulous.Maui.IView>(content: WidgetBuilder<'msg, 'marker>) =
+        static member inline ContentView<'msg, 'marker when 'marker :> Fabulous.Maui.IView>
+            (content: WidgetBuilder<'msg, 'marker>)
+            =
             WidgetHelpers.buildWidgets<'msg, IContentView>
                 ContentView.WidgetKey
                 [| ContentView.Content.WithValue(content.Compile()) |]

--- a/src/Fabulous.MauiControls/Views/Layouts/ContentView.fs
+++ b/src/Fabulous.MauiControls/Views/Layouts/ContentView.fs
@@ -17,7 +17,7 @@ module ContentView =
 [<AutoOpen>]
 module ContentViewBuilders =
     type Fabulous.Maui.View with
-        static member inline ContentView<'msg, 'marker when 'marker :> IView>(content: WidgetBuilder<'msg, 'marker>) =
+        static member inline ContentView<'msg, 'marker when 'marker :> Fabulous.Maui.IView>(content: WidgetBuilder<'msg, 'marker>) =
             WidgetHelpers.buildWidgets<'msg, IContentView>
                 ContentView.WidgetKey
                 [| ContentView.Content.WithValue(content.Compile()) |]

--- a/src/Fabulous.MauiControls/Views/Layouts/Frame.fs
+++ b/src/Fabulous.MauiControls/Views/Layouts/Frame.fs
@@ -23,7 +23,7 @@ module Frame =
 [<AutoOpen>]
 module FrameBuilders =
     type Fabulous.Maui.View with
-        static member inline Frame<'msg, 'marker when 'marker :> IView>(content: WidgetBuilder<'msg, 'marker>) =
+        static member inline Frame<'msg, 'marker when 'marker :> Fabulous.Maui.IView>(content: WidgetBuilder<'msg, 'marker>) =
             WidgetHelpers.buildWidgets<'msg, IFrame>
                 Frame.WidgetKey
                 [| ContentView.Content.WithValue(content.Compile()) |]

--- a/src/Fabulous.MauiControls/Views/Layouts/Frame.fs
+++ b/src/Fabulous.MauiControls/Views/Layouts/Frame.fs
@@ -23,7 +23,9 @@ module Frame =
 [<AutoOpen>]
 module FrameBuilders =
     type Fabulous.Maui.View with
-        static member inline Frame<'msg, 'marker when 'marker :> Fabulous.Maui.IView>(content: WidgetBuilder<'msg, 'marker>) =
+        static member inline Frame<'msg, 'marker when 'marker :> Fabulous.Maui.IView>
+            (content: WidgetBuilder<'msg, 'marker>)
+            =
             WidgetHelpers.buildWidgets<'msg, IFrame>
                 Frame.WidgetKey
                 [| ContentView.Content.WithValue(content.Compile()) |]

--- a/src/Fabulous.MauiControls/Views/Pages/NavigationPage.fs
+++ b/src/Fabulous.MauiControls/Views/Pages/NavigationPage.fs
@@ -8,7 +8,7 @@ open System.Runtime.CompilerServices
 open Fabulous
 open Microsoft.Maui
 open Microsoft.Maui.Controls
-//open Microsoft.Maui.PlatformConfiguration
+open Microsoft.Maui.Controls.PlatformConfiguration
 
 type INavigationPage =
     inherit Fabulous.Maui.IPage
@@ -197,44 +197,44 @@ module NavigationPage =
     let TitleView =
         Attributes.defineBindableWidget NavigationPage.TitleViewProperty
 
-// let HideNavigationBarSeparator =
-//     Attributes.defineBool
-//         "NavigationPage_HideNavigationBarSeparator"
-//         (fun _ newValueOpt node ->
-//             let page = node.Target :?> NavigationPage
-//
-//             let value =
-//                 match newValueOpt with
-//                 | ValueNone -> false
-//                 | ValueSome v -> v
-//
-//             iOSSpecific.NavigationPage.SetHideNavigationBarSeparator(page, value))
+    let HideNavigationBarSeparator =
+        Attributes.defineBool
+            "NavigationPage_HideNavigationBarSeparator"
+            (fun _ newValueOpt node ->
+                let page = node.Target :?> NavigationPage
 
-// let IsNavigationBarTranslucent =
-//     Attributes.defineBool
-//         "NavigationPage_IsNavigationBarTranslucent"
-//         (fun _ newValueOpt node ->
-//             let page = node.Target :?> NavigationPage
-//
-//             let value =
-//                 match newValueOpt with
-//                 | ValueNone -> false
-//                 | ValueSome v -> v
-//
-//             iOSSpecific.NavigationPage.SetIsNavigationBarTranslucent(page, value))
+                let value =
+                    match newValueOpt with
+                    | ValueNone -> false
+                    | ValueSome v -> v
 
-// let PrefersLargeTitles =
-//     Attributes.defineBool
-//         "NavigationPage_PrefersLargeTitles"
-//         (fun _ newValueOpt node ->
-//             let page = node.Target :?> NavigationPage
-//
-//             let value =
-//                 match newValueOpt with
-//                 | ValueNone -> false
-//                 | ValueSome v -> v
-//
-//             iOSSpecific.NavigationPage.SetPrefersLargeTitles(page, value))
+                iOSSpecific.NavigationPage.SetHideNavigationBarSeparator(page, value))
+
+    let IsNavigationBarTranslucent =
+        Attributes.defineBool
+            "NavigationPage_IsNavigationBarTranslucent"
+            (fun _ newValueOpt node ->
+                let page = node.Target :?> NavigationPage
+
+                let value =
+                    match newValueOpt with
+                    | ValueNone -> false
+                    | ValueSome v -> v
+
+                iOSSpecific.NavigationPage.SetIsNavigationBarTranslucent(page, value))
+
+    let PrefersLargeTitles =
+        Attributes.defineBool
+            "NavigationPage_PrefersLargeTitles"
+            (fun _ newValueOpt node ->
+                let page = node.Target :?> NavigationPage
+
+                let value =
+                    match newValueOpt with
+                    | ValueNone -> false
+                    | ValueSome v -> v
+
+                iOSSpecific.NavigationPage.SetPrefersLargeTitles(page, value))
 
 [<AutoOpen>]
 module NavigationPageBuilders =
@@ -383,7 +383,7 @@ type NavigationPageAttachedModifiers =
     /// <summary>Sets the value for TitleView</summary>
     /// <param name= "content">View to use as a title for the navigation page.</param>
     [<Extension>]
-    static member inline titleView<'msg, 'marker, 'contentMarker when 'marker :> IPage and 'contentMarker :> IView>
+    static member inline titleView<'msg, 'marker, 'contentMarker when 'marker :> Fabulous.Maui.IPage and 'contentMarker :> Fabulous.Maui.IView>
         (
             this: WidgetBuilder<'msg, 'marker>,
             content: WidgetBuilder<'msg, 'contentMarker>
@@ -395,18 +395,18 @@ type NavigationPageAttachedModifiers =
     static member inline reference(this: WidgetBuilder<'msg, INavigationPage>, value: ViewRef<NavigationPage>) =
         this.AddScalar(ViewRefAttributes.ViewRef.WithValue(value.Unbox))
 
-// [<Extension>]
-// type NavigationPagePlatformModifiers =
-//     /// <summary>iOS platform specific. Sets a value that hides the navigation bar separator.</summary>
-//     /// <param name="value">true to hide the separator. Otherwise, false.</param>
-//     [<Extension>]
-//     static member inline hideNavigationBarSeparator(this: WidgetBuilder<'msg, #INavigationPage>, value: bool) =
-//         this.AddScalar(NavigationPage.HideNavigationBarSeparator.WithValue(value))
-//
-//     [<Extension>]
-//     static member inline isNavigationBarTranslucent(this: WidgetBuilder<'msg, #INavigationPage>, value: bool) =
-//         this.AddScalar(NavigationPage.IsNavigationBarTranslucent.WithValue(value))
-//
-//     [<Extension>]
-//     static member inline prefersLargeTitles(this: WidgetBuilder<'msg, #INavigationPage>, value: bool) =
-//         this.AddScalar(NavigationPage.PrefersLargeTitles.WithValue(value))
+[<Extension>]
+type NavigationPagePlatformModifiers =
+    /// <summary>iOS platform specific. Sets a value that hides the navigation bar separator.</summary>
+    /// <param name="value">true to hide the separator. Otherwise, false.</param>
+    [<Extension>]
+    static member inline hideNavigationBarSeparator(this: WidgetBuilder<'msg, #INavigationPage>, value: bool) =
+        this.AddScalar(NavigationPage.HideNavigationBarSeparator.WithValue(value))
+
+    [<Extension>]
+    static member inline isNavigationBarTranslucent(this: WidgetBuilder<'msg, #INavigationPage>, value: bool) =
+        this.AddScalar(NavigationPage.IsNavigationBarTranslucent.WithValue(value))
+
+    [<Extension>]
+    static member inline prefersLargeTitles(this: WidgetBuilder<'msg, #INavigationPage>, value: bool) =
+        this.AddScalar(NavigationPage.PrefersLargeTitles.WithValue(value))

--- a/src/Fabulous.MauiControls/Views/Pages/TabbedPage.fs
+++ b/src/Fabulous.MauiControls/Views/Pages/TabbedPage.fs
@@ -3,7 +3,7 @@ namespace Fabulous.Maui
 open System.Runtime.CompilerServices
 open Fabulous
 open Microsoft.Maui.Controls
-//open Microsoft.Maui.PlatformConfiguration
+open Microsoft.Maui.Controls.PlatformConfiguration
 
 type ITabbedPage =
     inherit Fabulous.Maui.IMultiPageOfPage
@@ -23,18 +23,18 @@ module TabbedPage =
     let UnselectedTabColor =
         Attributes.defineBindableAppThemeColor TabbedPage.UnselectedTabColorProperty
 
-// let ToolbarPlacement =
-//     Attributes.defineSimpleScalarWithEquality<AndroidSpecific.ToolbarPlacement>
-//         "TabbedPage_ToolbarPlacement"
-//         (fun _ newValueOpt node ->
-//             let tabbedPage = node.Target :?> TabbedPage
-//
-//             let value =
-//                 match newValueOpt with
-//                 | ValueNone -> AndroidSpecific.ToolbarPlacement.Default
-//                 | ValueSome v -> v
-//
-//             AndroidSpecific.TabbedPage.SetToolbarPlacement(tabbedPage, value))
+    let ToolbarPlacement =
+        Attributes.defineSimpleScalarWithEquality<AndroidSpecific.ToolbarPlacement>
+            "TabbedPage_ToolbarPlacement"
+            (fun _ newValueOpt node ->
+                let tabbedPage = node.Target :?> TabbedPage
+
+                let value =
+                    match newValueOpt with
+                    | ValueNone -> AndroidSpecific.ToolbarPlacement.Default
+                    | ValueSome v -> v
+
+                AndroidSpecific.TabbedPage.SetToolbarPlacement(tabbedPage, value))
 
 [<AutoOpen>]
 module TabbedPageBuilders =
@@ -82,12 +82,12 @@ type TabbedPageModifiers =
     static member inline reference(this: WidgetBuilder<'msg, ITabbedPage>, value: ViewRef<TabbedPage>) =
         this.AddScalar(ViewRefAttributes.ViewRef.WithValue(value.Unbox))
 
-//open Microsoft.Maui.PlatformConfiguration.AndroidSpecific
+open Microsoft.Maui.Controls.PlatformConfiguration.AndroidSpecific
 
-// [<Extension>]
-// type TabbedPagePlatformModifiers =
-//     /// <summary>Android platform specific. Sets the toolbar placement.</summary>
-//     /// <param name= "value">The new toolbar placement value.</param>
-//     [<Extension>]
-//     static member inline toolbarPlacement(this: WidgetBuilder<'msg, #ITabbedPage>, value: ToolbarPlacement) =
-//         this.AddScalar(TabbedPage.ToolbarPlacement.WithValue(value))
+[<Extension>]
+type TabbedPagePlatformModifiers =
+    /// <summary>Android platform specific. Sets the toolbar placement.</summary>
+    /// <param name= "value">The new toolbar placement value.</param>
+    [<Extension>]
+    static member inline toolbarPlacement(this: WidgetBuilder<'msg, #ITabbedPage>, value: ToolbarPlacement) =
+        this.AddScalar(TabbedPage.ToolbarPlacement.WithValue(value))

--- a/src/Fabulous.MauiControls/Views/Pages/_Page.fs
+++ b/src/Fabulous.MauiControls/Views/Pages/_Page.fs
@@ -6,7 +6,7 @@ open System.Runtime.CompilerServices
 open Fabulous
 open Microsoft.Maui
 open Microsoft.Maui.Controls
-//open Microsoft.Maui.PlatformConfiguration
+open Microsoft.Maui.Controls.PlatformConfiguration
 
 type IPage =
     inherit Fabulous.Maui.IVisualElement
@@ -41,18 +41,18 @@ module Page =
     let LayoutChanged =
         Attributes.defineEventNoArg "Page_LayoutChanged" (fun target -> (target :?> Page).LayoutChanged)
 
-// let UseSafeArea =
-//     Attributes.defineSimpleScalarWithEquality<bool>
-//         "Page_UseSafeArea"
-//         (fun _ newValueOpt node ->
-//             let page = node.Target :?> Page
-//
-//             let value =
-//                 match newValueOpt with
-//                 | ValueNone -> false
-//                 | ValueSome v -> v
-//
-//             iOSSpecific.Page.SetUseSafeArea(page, value))
+    let UseSafeArea =
+        Attributes.defineSimpleScalarWithEquality<bool>
+            "Page_UseSafeArea"
+            (fun _ newValueOpt node ->
+                let page = node.Target :?> Page
+
+                let value =
+                    match newValueOpt with
+                    | ValueNone -> false
+                    | ValueSome v -> v
+
+                iOSSpecific.Page.SetUseSafeArea(page, value))
 
 [<Extension>]
 type PageModifiers =
@@ -206,10 +206,10 @@ type PageModifiers =
         ) =
         PageModifiers.padding(this, Thickness(left, top, right, bottom))
 
-// [<Extension>]
-// type PagePlatformModifiers =
-//
-//     /// <summary>iOS platform specific. Sets a value that controls whether padding values are overridden with the safe area insets.</summary>
-//     [<Extension>]
-//     static member inline ignoreSafeArea(this: WidgetBuilder<'msg, #IPage>) =
-//         this.AddScalar(Page.UseSafeArea.WithValue(false))
+[<Extension>]
+type PagePlatformModifiers =
+
+    /// <summary>iOS platform specific. Sets a value that controls whether padding values are overridden with the safe area insets.</summary>
+    [<Extension>]
+    static member inline ignoreSafeArea(this: WidgetBuilder<'msg, #IPage>) =
+        this.AddScalar(Page.UseSafeArea.WithValue(false))


### PR DESCRIPTION
There is some name collisions between the control interfaces which end up applying the wrong generic constraints
eg. `Fabulous.Maui.ILabel` vs `Microsoft.Maui.ILabel`

This PR fixes the ones I noticed