### PR TITLE
Maui Entry changes

### DIFF
--- a/src/Fabulous.MauiControls/Views/Controls/BoxView.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/BoxView.fs
@@ -2,7 +2,6 @@ namespace Fabulous.Maui
 
 open System.Runtime.CompilerServices
 open Fabulous
-open Microsoft.Maui
 open Microsoft.Maui.Controls
 
 type IBoxView =

--- a/src/Fabulous.MauiControls/Views/Controls/Entry.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Entry.fs
@@ -149,12 +149,6 @@ type EntryModifiers =
     static member inline reference(this: WidgetBuilder<'msg, IEntry>, value: ViewRef<Entry>) =
         this.AddScalar(ViewRefAttributes.ViewRef.WithValue(value.Unbox))
 
-    /// <summary>Defines whether the text will reflect scaling preferences set in the operating system.</summary>
-    /// <param name="value">The default value of this property is true.</param>
-    [<Extension>]
-    static member inline fontAutoScalingEnabled(this: WidgetBuilder<'msg, #IEntry>, value: bool) =
-        this.AddScalar(Entry.FontAutoScalingEnabled.WithValue(value))
-
 [<Extension>]
 type EntryPlatformModifiers =
     /// <summary>iOS platform specific. Sets the cursor color.</summary>

--- a/src/Fabulous.MauiControls/Views/Controls/Entry.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Entry.fs
@@ -45,6 +45,9 @@ module Entry =
     let VerticalTextAlignment =
         Attributes.defineBindableEnum<TextAlignment> Entry.VerticalTextAlignmentProperty
 
+    let FontAutoScalingEnabled =
+        Attributes.defineBindableBool Entry.FontAutoScalingEnabledProperty
+
     let Completed =
         Attributes.defineEventNoArg "Entry_Completed" (fun target -> (target :?> Entry).Completed)
 
@@ -88,9 +91,9 @@ type EntryModifiers =
         (
             this: WidgetBuilder<'msg, #IEntry>,
             ?size: float,
-            ?namedSize: NamedSize,
             ?attributes: FontAttributes,
-            ?fontFamily: string
+            ?fontFamily: string,
+            ?fontAutoScalingEnabled: bool
         ) =
 
         let mutable res = this
@@ -99,10 +102,6 @@ type EntryModifiers =
         | None -> ()
         | Some v -> res <- res.AddScalar(Entry.FontSize.WithValue(v))
 
-        match namedSize with
-        | None -> ()
-        | Some v -> res <- res.AddScalar(Entry.FontSize.WithValue(Device.GetNamedSize(v, typeof<Entry>)))
-
         match attributes with
         | None -> ()
         | Some v -> res <- res.AddScalar(Entry.FontAttributes.WithValue(v))
@@ -110,6 +109,10 @@ type EntryModifiers =
         match fontFamily with
         | None -> ()
         | Some v -> res <- res.AddScalar(Entry.FontFamily.WithValue(v))
+
+        match fontAutoScalingEnabled with
+        | None -> ()
+        | Some v -> res <- res.AddScalar(Entry.FontAutoScalingEnabled.WithValue(v))
 
         res
 
@@ -146,10 +149,16 @@ type EntryModifiers =
     static member inline reference(this: WidgetBuilder<'msg, IEntry>, value: ViewRef<Entry>) =
         this.AddScalar(ViewRefAttributes.ViewRef.WithValue(value.Unbox))
 
-// [<Extension>]
-// type EntryPlatformModifiers =
-//     /// <summary>iOS platform specific. Sets the cursor color.</summary>
-//     /// <param name="value">The new cursor color.</param>
-//     [<Extension>]
-//     static member inline cursorColor(this: WidgetBuilder<'msg, #IEntry>, value: FabColor) =
-//         this.AddScalar(Entry.CursorColor.WithValue(value))
+    /// <summary>Defines whether the text will reflect scaling preferences set in the operating system.</summary>
+    /// <param name="value">The default value of this property is true.</param>
+    [<Extension>]
+    static member inline fontAutoScalingEnabled(this: WidgetBuilder<'msg, #IEntry>, value: bool) =
+        this.AddScalar(Entry.FontAutoScalingEnabled.WithValue(value))
+
+[<Extension>]
+type EntryPlatformModifiers =
+    /// <summary>iOS platform specific. Sets the cursor color.</summary>
+    /// <param name="value">The new cursor color.</param>
+    [<Extension>]
+    static member inline cursorColor(this: WidgetBuilder<'msg, #IEntry>, value: FabColor) =
+        this.AddScalar(Entry.CursorColor.WithValue(value))


### PR DESCRIPTION
- Adds the new FontAutoScalingEnabledProperty See https://github.com/dotnet/maui/pull/1774
- Removes NamedSize from the font modifier as it is deprecated and will be deleted in NET 7 . See https://github.com/dotnet/maui/pull/5088