### PR TITLE
Bypass View.map conversion if msg is already of type 'newMsg

### DIFF
--- a/src/Fabulous.Tests/APISketchTests/TestUI.Attributes.fs
+++ b/src/Fabulous.Tests/APISketchTests/TestUI.Attributes.fs
@@ -61,6 +61,32 @@ module TestUI_Attributes =
 
             { Key = key; Name = name }
 
+        let defineTappable2 name : ScalarAttributeDefinition<obj, obj> =
+            let key =
+                ScalarAttributeDefinition.CreateAttributeData<obj, obj>(
+                    (fun x -> x),
+                    ScalarAttributeComparers.noCompare,
+                    (fun _ newValueOpt node ->
+
+                        let btn = node.Target :?> IButton
+
+                        match node.TryGetHandler<int>(name) with
+                        | ValueNone -> ()
+                        | ValueSome handlerId -> btn.RemoveTap2Listener handlerId
+
+                        match newValueOpt with
+                        | ValueNone -> node.SetHandler(name, ValueNone)
+
+                        | ValueSome msg ->
+                            let handler () = Dispatcher.dispatch node msg
+
+                            let handlerId = btn.AddTap2Listener handler
+                            node.SetHandler<int>(name, ValueSome handlerId))
+                )
+                |> AttributeDefinitionStore.registerScalar
+
+            { Key = key; Name = name }
+
         let defineContainerTappable name : ScalarAttributeDefinition<obj, obj> =
             let key =
                 ScalarAttributeDefinition.CreateAttributeData<obj, obj>(
@@ -116,6 +142,7 @@ module TestUI_Attributes =
         module Button =
             let Pressed = definePressable "Button_Pressed"
             let Tap = defineTappable "Button_Tap"
+            let Tap2 = defineTappable2 "Button_Tap2"
 
 
         module Automation =

--- a/src/Fabulous.Tests/APISketchTests/TestUI.Attributes.fs
+++ b/src/Fabulous.Tests/APISketchTests/TestUI.Attributes.fs
@@ -35,6 +35,58 @@ module TestUI_Attributes =
 
             { Key = key; Name = name }
 
+        let defineTappable name : ScalarAttributeDefinition<obj, obj> =
+            let key =
+                ScalarAttributeDefinition.CreateAttributeData<obj, obj>(
+                    (fun x -> x),
+                    ScalarAttributeComparers.noCompare,
+                    (fun _ newValueOpt node ->
+
+                        let btn = node.Target :?> IButton
+
+                        match node.TryGetHandler<int>(name) with
+                        | ValueNone -> ()
+                        | ValueSome handlerId -> btn.RemoveTapListener handlerId
+
+                        match newValueOpt with
+                        | ValueNone -> node.SetHandler(name, ValueNone)
+
+                        | ValueSome msg ->
+                            let handler () = Dispatcher.dispatch node msg
+
+                            let handlerId = btn.AddTapListener handler
+                            node.SetHandler<int>(name, ValueSome handlerId))
+                )
+                |> AttributeDefinitionStore.registerScalar
+
+            { Key = key; Name = name }
+
+        let defineContainerTappable name : ScalarAttributeDefinition<obj, obj> =
+            let key =
+                ScalarAttributeDefinition.CreateAttributeData<obj, obj>(
+                    (fun x -> x),
+                    ScalarAttributeComparers.noCompare,
+                    (fun _ newValueOpt node ->
+
+                        let btn = node.Target :?> IContainer
+
+                        match node.TryGetHandler<int>(name) with
+                        | ValueNone -> ()
+                        | ValueSome handlerId -> btn.RemoveTapListener handlerId
+
+                        match newValueOpt with
+                        | ValueNone -> node.SetHandler(name, ValueNone)
+
+                        | ValueSome msg ->
+                            let handler () = Dispatcher.dispatch node msg
+
+                            let handlerId = btn.AddTapListener handler
+                            node.SetHandler<int>(name, ValueSome handlerId))
+                )
+                |> AttributeDefinitionStore.registerScalar
+
+            { Key = key; Name = name }
+
 
 
 
@@ -59,8 +111,11 @@ module TestUI_Attributes =
                     "Container_Children"
                     (fun target -> (target :?> IContainer).Children :> System.Collections.Generic.IList<_>)
 
+            let Tap = defineContainerTappable "Container_Tap"
+
         module Button =
             let Pressed = definePressable "Button_Pressed"
+            let Tap = defineTappable "Button_Tap"
 
 
         module Automation =

--- a/src/Fabulous.Tests/APISketchTests/TestUI.Platform.fs
+++ b/src/Fabulous.Tests/APISketchTests/TestUI.Platform.fs
@@ -27,6 +27,8 @@ module Platform =
         abstract RemovePressListener: int -> unit
         abstract AddTapListener: ButtonHandler -> int
         abstract RemoveTapListener: int -> unit
+        abstract AddTap2Listener: ButtonHandler -> int
+        abstract RemoveTap2Listener: int -> unit
 
     type LabelChangeList =
         | TextSet of string
@@ -82,8 +84,10 @@ module Platform =
         inherit TestViewElement()
         let mutable pressCounter: int = 1
         let mutable tapCounter: int = 1
+        let mutable tap2Counter: int = 1
         let pressHandlers = Dictionary<int, ButtonHandler>()
         let tapHandlers = Dictionary<int, ButtonHandler>()
+        let tap2Handlers = Dictionary<int, ButtonHandler>()
 
         member _.Press() =
             for handler in Array.ofSeq(pressHandlers.Values) do
@@ -91,6 +95,10 @@ module Platform =
 
         member _.Tap() =
             for handler in Array.ofSeq(tapHandlers.Values) do
+                handler()
+
+        member _.Tap2() =
+            for handler in Array.ofSeq(tap2Handlers.Values) do
                 handler()
 
         interface IText with
@@ -111,6 +119,13 @@ module Platform =
                 tapCounter - 1
 
             member this.RemoveTapListener(id) = tapHandlers.Remove(id) |> ignore
+
+            member this.AddTap2Listener(handler) =
+                tap2Handlers.Add(tap2Counter, handler)
+                tap2Counter <- tap2Counter + 1
+                tap2Counter - 1
+
+            member this.RemoveTap2Listener(id) = tap2Handlers.Remove(id) |> ignore
 
 
     type TestNumericBag() =

--- a/src/Fabulous.Tests/APISketchTests/TestUI.Widgets.fs
+++ b/src/Fabulous.Tests/APISketchTests/TestUI.Widgets.fs
@@ -118,7 +118,16 @@ module TestUI_Widgets =
 
 
         [<Extension>]
-        static member inline tap2<'msg, 'marker when 'marker :> TestStackMarker>
+        static member inline tap2<'msg, 'marker when 'marker :> TestButtonMarker>
+            (
+                this: WidgetBuilder<'msg, 'marker>,
+                value: 'msg
+            ) =
+            this.AddScalar(Attributes.Button.Tap2.WithValue(value))
+
+
+        [<Extension>]
+        static member inline tapContainer<'msg, 'marker when 'marker :> TestStackMarker>
             (
                 this: WidgetBuilder<'msg, 'marker>,
                 value: 'msg

--- a/src/Fabulous.Tests/APISketchTests/TestUI.Widgets.fs
+++ b/src/Fabulous.Tests/APISketchTests/TestUI.Widgets.fs
@@ -107,6 +107,24 @@ module TestUI_Widgets =
             ) =
             this.AddScalar(Attributes.Text.Record.WithValue(value))
 
+
+        [<Extension>]
+        static member inline tap<'msg, 'marker when 'marker :> TestButtonMarker>
+            (
+                this: WidgetBuilder<'msg, 'marker>,
+                value: 'msg
+            ) =
+            this.AddScalar(Attributes.Button.Tap.WithValue(value))
+
+
+        [<Extension>]
+        static member inline tap2<'msg, 'marker when 'marker :> TestStackMarker>
+            (
+                this: WidgetBuilder<'msg, 'marker>,
+                value: 'msg
+            ) =
+            this.AddScalar(Attributes.Container.Tap.WithValue(value))
+
     ///----------------
     ///----------------
 

--- a/src/Fabulous/View.fs
+++ b/src/Fabulous/View.fs
@@ -32,6 +32,7 @@ module View =
         let replaceWith (oldAttr: ScalarAttribute) =
             let fnWithBoxing (msg: obj) =
                 let oldFn = unbox<obj -> obj> oldAttr.Value
+
                 if msg.GetType() = typeof<'newMsg> then
                     box msg
                 else
@@ -45,7 +46,7 @@ module View =
                     box msg
                 else
                     unbox<'oldMsg> msg |> fn |> box
-            
+
             MapMsg.MapMsg.WithValue(mappedFn)
 
         let builder =

--- a/src/Fabulous/View.fs
+++ b/src/Fabulous/View.fs
@@ -13,7 +13,7 @@ module ViewHelpers =
 
 module View =
     /// Avoid recomputing the whole subtree when the key doesn't change
-    let lazy'<'msg, 'key, 'marker when 'key: equality>
+    let inline lazy'<'msg, 'key, 'marker when 'key: equality>
         (fn: 'key -> WidgetBuilder<'msg, 'marker>)
         (key: 'key)
         : WidgetBuilder<'msg, Memo.Memoized<'marker>> =
@@ -28,7 +28,7 @@ module View =
         WidgetBuilder<'msg, Memo.Memoized<'marker>>(Memo.MemoWidgetKey, Memo.MemoAttribute.WithValue(memo))
 
     /// Map the widget's message type to the parent's message type to allow for view composition
-    let map (fn: 'oldMsg -> 'newMsg) (x: WidgetBuilder<'oldMsg, 'marker>) : WidgetBuilder<'newMsg, 'marker> =
+    let inline map (fn: 'oldMsg -> 'newMsg) (x: WidgetBuilder<'oldMsg, 'marker>) : WidgetBuilder<'newMsg, 'marker> =
         let replaceWith (oldAttr: ScalarAttribute) =
             let fnWithBoxing (msg: obj) =
                 let oldFn = unbox<obj -> obj> oldAttr.Value

--- a/src/Fabulous/View.fs
+++ b/src/Fabulous/View.fs
@@ -28,12 +28,12 @@ module View =
         WidgetBuilder<'msg, Memo.Memoized<'marker>>(Memo.MemoWidgetKey, Memo.MemoAttribute.WithValue(memo))
 
     /// Map the widget's message type to the parent's message type to allow for view composition
-    let inline map (fn: 'oldMsg -> 'newMsg) (x: WidgetBuilder<'oldMsg, 'marker>) : WidgetBuilder<'newMsg, 'marker> =
+    let map (fn: 'oldMsg -> 'newMsg) (x: WidgetBuilder<'oldMsg, 'marker>) : WidgetBuilder<'newMsg, 'marker> =
         let replaceWith (oldAttr: ScalarAttribute) =
             let fnWithBoxing (msg: obj) =
                 let oldFn = unbox<obj -> obj> oldAttr.Value
 
-                if msg.GetType() = typeof<'newMsg> then
+                if typeof<'newMsg>.IsAssignableFrom (msg.GetType()) then
                     box msg
                 else
                     oldFn msg |> unbox<'oldMsg> |> fn |> box
@@ -42,7 +42,7 @@ module View =
 
         let defaultWith () =
             let mappedFn (msg: obj) =
-                if msg.GetType() = typeof<'newMsg> then
+                if typeof<'newMsg>.IsAssignableFrom (msg.GetType()) then
                     box msg
                 else
                     unbox<'oldMsg> msg |> fn |> box

--- a/src/Fabulous/View.fs
+++ b/src/Fabulous/View.fs
@@ -13,7 +13,7 @@ module ViewHelpers =
 
 module View =
     /// Avoid recomputing the whole subtree when the key doesn't change
-    let inline lazy'<'msg, 'key, 'marker when 'key: equality>
+    let lazy'<'msg, 'key, 'marker when 'key: equality>
         (fn: 'key -> WidgetBuilder<'msg, 'marker>)
         (key: 'key)
         : WidgetBuilder<'msg, Memo.Memoized<'marker>> =


### PR DESCRIPTION
When combining a child view with a parent view, we can use `View.map` to convert the child's messages to the parent Msg type. This approach even lets us define additional modifiers to that child view at the parent's level.

```fs
type ParentMsg =
    | ChildMsg of Child.Msg
    | MoreMsg

(View.map ChildMsg childView)
    .backgroundColor(Color.Red)
    .onTapped(MoreMsg)
```

This is completely legal in Fabulous as the types are the ones expected by the F# Type Checker.

But there is an issue. When calling `View.map` on the child view, Fabulous assigns a conversion function (from `Child.Msg` to `ParentMsg`) to the child control itself. This conversion will then get applied to all messages dispatched by the child, including the ones we defined after, at the parent's level.

This leads to an invalid cast exception at runtime.
```
InvalidCastException: ParentMsg.MoreMsg is not of type Child.Msg
```

This PR aims to provide a workaround to this bug by checking the dispatched msg type before trying to convert it.
If the msg type already matches the final type, we do nothing.
