### PR TITLE
Enable ViewAdapter to attach to an existing view

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,13 @@
 name: Build
 on:
    push:
-     branches: [ 'v2.1' ]
+     branches: [ 'v2.2' ]
      paths-ignore: [ 'docs/**' ]
 
 permissions: write-all
 
 env:
-  VERSION: 2.1.0
+  VERSION: 2.2.0
 
 jobs:
   xf:

--- a/src/Fabulous.MauiControls/Widgets.fs
+++ b/src/Fabulous.MauiControls/Widgets.fs
@@ -44,7 +44,28 @@ module Widgets =
                       additionalSetup view node
 
                       Reconciler.update treeContext.CanReuseView ValueNone widget node
-                      struct (node :> IViewNode, box view) }
+                      struct (node :> IViewNode, box view)
+              AttachView =
+                  fun (widget, treeContext, parentNode, view) ->
+                      treeContext.Logger.Debug("Attaching view for {0}", typeof<'T>.Name)
+
+                      let view = unbox<'T> view
+                      let weakReference = WeakReference(view)
+
+                      let parentNode =
+                          match parentNode with
+                          | ValueNone -> None
+                          | ValueSome node -> Some node
+
+                      let node =
+                          ViewNode(parentNode, treeContext, weakReference)
+
+                      ViewNode.set node view
+
+                      additionalSetup view node
+
+                      Reconciler.update treeContext.CanReuseView ValueNone widget node
+                      node :> IViewNode }
 
         WidgetDefinitionStore.set key definition
         key

--- a/src/Fabulous.Tests/APISketchTests/TestUI.Widgets.fs
+++ b/src/Fabulous.Tests/APISketchTests/TestUI.Widgets.fs
@@ -49,8 +49,7 @@ module TestUI_Widgets =
 
                           Reconciler.update context.CanReuseView oldWidget widget viewNode
                           struct (viewNode :> IViewNode, box view)
-                  AttachView =
-                      fun (_widget, _context, _parentNode, _view) -> failwith "not implemented" }
+                  AttachView = fun (_widget, _context, _parentNode, _view) -> failwith "not implemented" }
 
             WidgetDefinitionStore.set key definition
             key

--- a/src/Fabulous.Tests/APISketchTests/TestUI.Widgets.fs
+++ b/src/Fabulous.Tests/APISketchTests/TestUI.Widgets.fs
@@ -48,7 +48,9 @@ module TestUI_Widgets =
                           let oldWidget: Widget voption = ValueNone
 
                           Reconciler.update context.CanReuseView oldWidget widget viewNode
-                          struct (viewNode :> IViewNode, box view) }
+                          struct (viewNode :> IViewNode, box view)
+                  AttachView =
+                      fun (_widget, _context, _parentNode, _view) -> failwith "not implemented" }
 
             WidgetDefinitionStore.set key definition
             key

--- a/src/Fabulous.XamarinForms/Widgets.fs
+++ b/src/Fabulous.XamarinForms/Widgets.fs
@@ -44,7 +44,28 @@ module Widgets =
                       additionalSetup view node
 
                       Reconciler.update treeContext.CanReuseView ValueNone widget node
-                      struct (node :> IViewNode, box view) }
+                      struct (node :> IViewNode, box view)
+              AttachView =
+                  fun (widget, treeContext, parentNode, view) ->
+                      treeContext.Logger.Debug("Attaching view for {0}", typeof<'T>.Name)
+
+                      let view = unbox<'T> view
+                      let weakReference = WeakReference(view)
+
+                      let parentNode =
+                          match parentNode with
+                          | ValueNone -> None
+                          | ValueSome node -> Some node
+
+                      let node =
+                          ViewNode(parentNode, treeContext, weakReference)
+
+                      ViewNode.set node view
+
+                      additionalSetup view node
+
+                      Reconciler.update treeContext.CanReuseView ValueNone widget node
+                      node :> IViewNode }
 
         WidgetDefinitionStore.set key definition
         key

--- a/src/Fabulous/Memo.fs
+++ b/src/Fabulous/Memo.fs
@@ -87,6 +87,7 @@ module Memo =
                   // store widget that was used to produce this node
                   // to pass it to reconciler later on
                   node.MemoizedWidget <- Some memoizedWidget
-                  struct (node, view) }
+                  struct (node, view)
+          AttachView = fun (_widget, _context, _parentNode, _view) -> failwith "Memo widget cannot be attached" }
 
     WidgetDefinitionStore.set MemoWidgetKey widgetDefinition

--- a/src/Fabulous/Runners.fs
+++ b/src/Fabulous/Runners.fs
@@ -34,6 +34,8 @@ type IViewAdapter =
     inherit IDisposable
     /// Instantiates a new view using the current state associated with this ViewAdapter
     abstract CreateView: unit -> obj
+    /// Attaches to the existing view and updates it with the current state associated with this ViewAdapter
+    abstract Attach: obj -> unit
 
 module RunnerStore =
     let private _runners = Dictionary<StateKey, IRunner>()
@@ -186,6 +188,24 @@ module ViewAdapters =
             _root <- root
             _root
 
+        member _.Attach(root) =
+            let state = unbox(StateStore.get stateKey)
+            let widget = (view state).Compile()
+            _widget <- widget
+
+            let treeContext =
+                { CanReuseView = canReuseView
+                  GetViewNode = getViewNode
+                  Logger = logger
+                  Dispatch = this.Dispatch }
+
+            let definition = WidgetDefinitionStore.get widget.Key
+
+            let _node =
+                definition.AttachView(widget, treeContext, ValueNone, root)
+
+            _root <- root
+
         /// Listens for StateStore changes and updates the view if necessary
         member _.OnStateChanged(args) =
             try
@@ -217,6 +237,7 @@ module ViewAdapters =
         interface IViewAdapter with
             member x.Dispose() = x.Dispose()
             member x.CreateView() = x.CreateView()
+            member x.Attach(root) = x.Attach(root)
 
     /// Create a new ViewAdapter for the component
     let create<'arg, 'model, 'msg, 'marker>

--- a/src/Fabulous/WidgetDefinitions.fs
+++ b/src/Fabulous/WidgetDefinitions.fs
@@ -9,7 +9,8 @@ type WidgetDefinition =
     { Key: WidgetKey
       Name: string
       TargetType: Type
-      CreateView: Widget * ViewTreeContext * IViewNode voption -> struct (IViewNode * obj) }
+      CreateView: Widget * ViewTreeContext * IViewNode voption -> struct (IViewNode * obj)
+      AttachView: Widget * ViewTreeContext * IViewNode voption * obj -> IViewNode }
 
 module WidgetDefinitionStore =
     let private _widgets = ResizeArray<WidgetDefinition>()


### PR DESCRIPTION
AvaloniaUI has a specific startup workflow where first the app is created empty; then on initialized the styles are loaded; and finally on FrameworkInitializationCompleted the whole UI tree is loaded.

Today, ViewAdapter will create the App instance with the whole UI tree already loaded.
To enable Fabulous.Avalonia, I added a `Attach` method to ViewAdapter so it can attach and start the diffing process with an existing view.